### PR TITLE
fix(onboarding): 온보딩 선호 좌석 marketingConsent 추가(수정)

### DIFF
--- a/goorm-gongbang/app/onboarding/option/page.tsx
+++ b/goorm-gongbang/app/onboarding/option/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-export default function SeatStyleOnboardingPage() {
+export default function SeatStyleOnboardingOptionPage() {
   
 
   return (

--- a/goorm-gongbang/app/onboarding/option/page.tsx
+++ b/goorm-gongbang/app/onboarding/option/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+export default function SeatStyleOnboardingPage() {
+  
+
+  return (
+    <div>
+        
+    </div>
+  );
+}

--- a/goorm-gongbang/app/onboarding/page.tsx
+++ b/goorm-gongbang/app/onboarding/page.tsx
@@ -141,7 +141,8 @@ export default function SeatStyleOnboardingPage() {
   const [consentRequired, setConsentRequired] = useState(false); // 선호 데이터 체크
   const [consentMarketing, setConsentMarketing] = useState(false); // 마케팅 수신 동의 체크
 
-  const setBasePreferences = useOnboardingPrefStore((s) => s.setBasePreferences); // 온보딩 zustand 저장
+  const setBasePreferences = useOnboardingPrefStore((s) => s.setBasePreferences); // 온보딩 zustand 저장 (정보)
+  const setMarketingAgreed = useOnboardingPrefStore((s) => s.setMarketingAgreed); // 온보딩 zustand 저장 (마케팅)
 
   useEffect(() => {
     if (!bootstrapped) return;
@@ -228,10 +229,10 @@ export default function SeatStyleOnboardingPage() {
       seatHeight: SEAT_HEIGHT_MAP[height[i]],
       section: SECTION_MAP[zone[i]],
     }));
-    console.log({ basePrefs });
 
     /* 1단계 필수 값 저장 */
     setBasePreferences(basePrefs);
+    setMarketingAgreed(consentMarketing);
 
     /* 옵션 페이지로 이동 */
     router.push("/onboarding/option");

--- a/goorm-gongbang/stores/onboardingPrefStore.ts
+++ b/goorm-gongbang/stores/onboardingPrefStore.ts
@@ -31,8 +31,10 @@ export type PreferenceBase = Pick<Preference, "rank" | "viewpoint" | "seatHeight
 
 type OnboardingPrefState = {
     preferences: Preference[];
+    marketingAgreed: boolean;
 
     setBasePreferences: (prefs: PreferenceBase[]) => void;
+    setMarketingAgreed: (v: boolean) => void;
     updatePreference: (rank: 1 | 2 | 3, patch: Partial<Preference>) => void;
     reset: () => void;
 };
@@ -41,6 +43,7 @@ export const useOnboardingPrefStore = create<OnboardingPrefState>()(
     persist(
         (set, get) => ({
             preferences: [],
+            marketingAgreed: false,
 
             setBasePreferences: (basePrefs) => {
                 // rank 정렬 + 중복 제거/검증
@@ -62,20 +65,33 @@ export const useOnboardingPrefStore = create<OnboardingPrefState>()(
                     priceMode: "ANY",
                     // priceMin/priceMax는 priceMode=RANGE일 때만 채워질 예정
                 }));
-
-                console.log("[onboardingPrefStore] setBasePreferences input:", basePrefs);
-                console.log("[onboardingPrefStore] merged preferences:", merged);
-
                 set({ preferences: merged });
+
+                console.log("[onboardingPrefStore] after setBasePreferences:", get().preferences);
+            },
+
+            setMarketingAgreed: (v) => {
+                set({ marketingAgreed: v });
+
+                console.log("[onboardingPrefStore] after setMarketingAgreed:", get().marketingAgreed);
             },
 
             updatePreference: (rank, patch) => {
                 const prev = get().preferences;
                 const next = prev.map((p) => (p.rank === rank ? { ...p, ...patch } : p));
                 set({ preferences: next });
+
+                console.log("[onboardingPrefStore] after updatePreference:", get().preferences);
             },
 
-            reset: () => set({ preferences: [] }),
+            reset: () => {
+                set({ preferences: [], marketingAgreed: false });
+
+                console.log("[onboardingPrefStore] after reset:", {
+                    preferences: get().preferences,
+                    marketingAgreed: get().marketingAgreed,
+                });
+            }
         }),
         {
             name: "onboarding-preferences",


### PR DESCRIPTION
🔧 작업 내용

온보딩 선호 좌석 단계에 marketingConsent(마케팅 수신 동의) 저장 로직 추가

consentMarketing 체크 여부를 marketingAgreed: boolean 형태로 Zustand에 저장하도록 반영

🧩 구현 상세(선택)

onboardingPrefStore에 marketingAgreed state 및 setMarketingAgreed() action 추가

SeatStyleOnboardingPage에서 다음 단계 이동 시 setMarketingAgreed(consentMarketing) 호출하여 동의 여부를 함께 저장

📌 관련 Jira Issue

GBGB-77

🧪 테스트 방법(선택)

/onboarding/seat-style 진입

(필수) 선호 좌석 3개씩 선택 + [필수] 선호 데이터 활용 동의 체크

[선택] 마케팅 수신 동의 체크/해제 각각 테스트

다음 클릭 후, Zustand에 marketingAgreed 값이 체크 여부에 맞게 저장되는지 콘솔로 확인

❗ 참고 사항

Fixes: https://github.com/goorm-gongbang/101-goormgb-frontend/issues/12