### PR TITLE
feat(onboarding): 온보딩 선택 페이지 기능 개발

### DIFF
--- a/goorm-gongbang/app/api/onboarding/preferences/route.ts
+++ b/goorm-gongbang/app/api/onboarding/preferences/route.ts
@@ -1,0 +1,358 @@
+// app/api/onboarding/preferences/route.ts
+import { NextResponse } from "next/server";
+
+/** =========================
+ * Types (Spec-aligned)
+ ========================= */
+
+type PriceMode = "ANY" | "RANGE";
+
+type Viewpoint =
+  | "CENTER"
+  | "INFIELD_1B"
+  | "INFIELD_3B"
+  | "OUTFIELD_L"
+  | "OUTFIELD_C"
+  | "OUTFIELD_R";
+
+type SeatHeight = "LOW" | "MID" | "HIGH" | "ANY";
+type Section = "CENTER_SIDE" | "MIDDLE" | "CORNER" | "ANY";
+
+type SeatPositionPref = "AISLE" | "MIDDLE" | "ANY";
+type EnvironmentPref = "SHADE" | "SUN_OK" | "ANY";
+type MoodPref = "CHEERFUL" | "QUIET" | "ANY";
+type ObstructionSensitivity =
+  | "NET_SENSITIVE"
+  | "RAIL_PILLAR_SENSITIVE"
+  | "NORMAL"
+  | "ANY";
+
+type MarketingConsent = {
+  marketingAgreed: boolean;
+};
+
+type Preference = {
+  priority: 1 | 2 | 3;
+  viewpoint: Viewpoint;
+  seatHeight: SeatHeight;
+  section: Section;
+
+  seatPositionPref?: SeatPositionPref;
+  environmentPref?: EnvironmentPref;
+  moodPref?: MoodPref;
+  obstructionSensitivity?: ObstructionSensitivity;
+
+  priceMode?: PriceMode;
+  priceMin?: number;
+  priceMax?: number;
+};
+
+type RequestBody = {
+  marketingConsent: MarketingConsent;
+  preferences: Preference[];
+};
+
+/** =========================
+ * Mock "DB" (in-memory)
+ * key: accessToken string
+ ========================= */
+declare global {
+  // eslint-disable-next-line no-var
+  var __ONBOARDING_PREF_MOCK__: Map<
+    string,
+    {
+      onboardingStatus: boolean;
+      onboardingCompletedAt: string;
+      marketingAgreed: boolean;
+      marketingAgreedAt: string | null;
+      body: RequestBody;
+    }
+  > | undefined;
+}
+
+function getStore() {
+  if (!global.__ONBOARDING_PREF_MOCK__) {
+    global.__ONBOARDING_PREF_MOCK__ = new Map();
+  }
+  return global.__ONBOARDING_PREF_MOCK__;
+}
+
+/** =========================
+ * Helpers
+ ========================= */
+
+function nowKSTISOString() {
+  // KST: UTC+09:00
+  const d = new Date(Date.now() + 9 * 60 * 60 * 1000);
+  // ISO without "Z", add +09:00
+  const iso = d.toISOString().replace("Z", "+09:00");
+  return iso;
+}
+
+function jsonError(status: number, message: string, code = "BAD_REQUEST") {
+  return NextResponse.json({ code, message, data: null }, { status });
+}
+
+function getBearerToken(req: Request) {
+  const auth = req.headers.get("authorization") || req.headers.get("Authorization");
+  if (!auth) return null;
+  const m = auth.match(/^Bearer\s+(.+)$/i);
+  if (!m) return null;
+  return m[1].trim();
+}
+
+function isInt(n: unknown): n is number {
+  return typeof n === "number" && Number.isInteger(n);
+}
+
+function isNonNegativeInt(n: unknown): n is number {
+  return isInt(n) && n >= 0;
+}
+
+const VIEWPOINTS: readonly Viewpoint[] = [
+  "CENTER",
+  "INFIELD_1B",
+  "INFIELD_3B",
+  "OUTFIELD_L",
+  "OUTFIELD_C",
+  "OUTFIELD_R",
+] as const;
+
+const SEAT_HEIGHTS: readonly SeatHeight[] = ["LOW", "MID", "HIGH", "ANY"] as const;
+const SECTIONS: readonly Section[] = ["CENTER_SIDE", "MIDDLE", "CORNER", "ANY"] as const;
+
+const SEAT_POS: readonly SeatPositionPref[] = ["AISLE", "MIDDLE", "ANY"] as const;
+const ENVS: readonly EnvironmentPref[] = ["SHADE", "SUN_OK", "ANY"] as const;
+const MOODS: readonly MoodPref[] = ["CHEERFUL", "QUIET", "ANY"] as const;
+const OBSTRUCTIONS: readonly ObstructionSensitivity[] = [
+  "NET_SENSITIVE",
+  "RAIL_PILLAR_SENSITIVE",
+  "NORMAL",
+  "ANY",
+] as const;
+
+const PRICE_MODES: readonly PriceMode[] = ["ANY", "RANGE"] as const;
+
+function assertEnum<T extends readonly string[]>(
+  value: unknown,
+  allowed: T,
+  fieldName: string
+): value is T[number] {
+  if (typeof value !== "string" || !allowed.includes(value)) return false;
+  return true;
+}
+
+function normalizeDefaults(p: Preference): Required<Preference> {
+  return {
+    priority: p.priority,
+    viewpoint: p.viewpoint,
+    seatHeight: p.seatHeight,
+    section: p.section,
+
+    seatPositionPref: p.seatPositionPref ?? "ANY",
+    environmentPref: p.environmentPref ?? "ANY",
+    moodPref: p.moodPref ?? "ANY",
+    obstructionSensitivity: p.obstructionSensitivity ?? "NORMAL",
+    priceMode: p.priceMode ?? "ANY",
+
+    priceMin: p.priceMin ?? (null as any),
+    priceMax: p.priceMax ?? (null as any),
+  };
+}
+
+/** =========================
+ * Route
+ ========================= */
+
+export async function POST(req: Request) {
+  // 401: 인증 실패
+  const token = getBearerToken(req);
+  if (!token) {
+    return jsonError(401, "Authorization Bearer 토큰이 필요합니다.", "UNAUTHORIZED");
+  }
+
+  // (mock) 403: DEACTIVE는 실제 계정상태가 없으니 데모용 규칙 하나 둠
+  // 토큰이 "deactive"를 포함하면 DEACTIVE 취급
+  if (token.toLowerCase().includes("deactive")) {
+    return jsonError(403, "계정 상태가 DEACTIVE 입니다.", "FORBIDDEN");
+  }
+
+  let body: RequestBody;
+  try {
+    body = (await req.json()) as RequestBody;
+  } catch {
+    return jsonError(400, "JSON 파싱에 실패했습니다.");
+  }
+
+  // validation: marketingConsent.marketingAgreed 필수
+  if (
+    !body ||
+    typeof body !== "object" ||
+    !body.marketingConsent ||
+    typeof body.marketingConsent !== "object" ||
+    typeof body.marketingConsent.marketingAgreed !== "boolean"
+  ) {
+    return jsonError(400, "marketingConsent.marketingAgreed(boolean)는 필수입니다.");
+  }
+
+  // validation: preferences 길이 3 고정
+  if (!Array.isArray(body.preferences) || body.preferences.length !== 3) {
+    return jsonError(400, "preferences는 길이 3인 배열이어야 합니다.");
+  }
+
+  // 409: 이미 온보딩 완료인데 재호출(정책: 최초 저장 엄격)
+  const store = getStore();
+  if (store.has(token)) {
+    return jsonError(409, "이미 온보딩이 완료된 사용자입니다.", "CONFLICT");
+  }
+
+  // priority 중복 + 1,2,3 모두 있어야 함
+  const prioritys = body.preferences.map((p) => p?.priority);
+  const prioritySet = new Set(prioritys);
+  const mustprioritys = new Set([1, 2, 3]);
+
+  if (prioritySet.size !== 3 || prioritys.some((r) => r !== 1 && r !== 2 && r !== 3)) {
+    return jsonError(400, "priority는 1,2,3이 각각 한 번씩 있어야 합니다.");
+  }
+  for (const r of mustprioritys) {
+    if (!prioritySet.has(r)) return jsonError(400, "priority는 1,2,3이 모두 포함되어야 합니다.");
+  }
+
+  // 각 preference 필수: viewpoint, seatHeight, section
+  // + viewpoint 중복 불가
+  const viewpointSet = new Set<string>();
+
+  for (const [idx, raw] of body.preferences.entries()) {
+    if (!raw || typeof raw !== "object") {
+      return jsonError(400, `preferences[${idx}] 형식이 올바르지 않습니다.`);
+    }
+
+    // required fields
+    if (!assertEnum(raw.viewpoint, VIEWPOINTS, "viewpoint")) {
+      return jsonError(400, `preferences[${idx}].viewpoint 허용값이 아닙니다.`);
+    }
+    if (!assertEnum(raw.seatHeight, SEAT_HEIGHTS, "seatHeight")) {
+      return jsonError(400, `preferences[${idx}].seatHeight 허용값이 아닙니다.`);
+    }
+    if (!assertEnum(raw.section, SECTIONS, "section")) {
+      return jsonError(400, `preferences[${idx}].section 허용값이 아닙니다.`);
+    }
+
+    // optional enums if present
+    if (
+      raw.seatPositionPref !== undefined &&
+      !assertEnum(raw.seatPositionPref, SEAT_POS, "seatPositionPref")
+    ) {
+      return jsonError(400, `preferences[${idx}].seatPositionPref 허용값이 아닙니다.`);
+    }
+    if (
+      raw.environmentPref !== undefined &&
+      !assertEnum(raw.environmentPref, ENVS, "environmentPref")
+    ) {
+      return jsonError(400, `preferences[${idx}].environmentPref 허용값이 아닙니다.`);
+    }
+    if (raw.moodPref !== undefined && !assertEnum(raw.moodPref, MOODS, "moodPref")) {
+      return jsonError(400, `preferences[${idx}].moodPref 허용값이 아닙니다.`);
+    }
+    if (
+      raw.obstructionSensitivity !== undefined &&
+      !assertEnum(raw.obstructionSensitivity, OBSTRUCTIONS, "obstructionSensitivity")
+    ) {
+      return jsonError(400, `preferences[${idx}].obstructionSensitivity 허용값이 아닙니다.`);
+    }
+    if (raw.priceMode !== undefined && !assertEnum(raw.priceMode, PRICE_MODES, "priceMode")) {
+      return jsonError(400, `preferences[${idx}].priceMode 허용값이 아닙니다.`);
+    }
+
+    // viewpoint uniqueness (user_id, viewpoint) unique
+    if (viewpointSet.has(raw.viewpoint)) {
+      return jsonError(400, "동일 viewpoint로 여러 순위를 등록할 수 없습니다.");
+    }
+    viewpointSet.add(raw.viewpoint);
+
+    // price validation
+    const priceMode: PriceMode = raw.priceMode ?? "ANY";
+    const hasMin = raw.priceMin !== undefined && raw.priceMin !== null;
+    const hasMax = raw.priceMax !== undefined && raw.priceMax !== null;
+
+    if (priceMode === "ANY") {
+      // ignore min/max (null 저장)
+      continue;
+    }
+
+    // RANGE
+    if (!hasMin || !hasMax) {
+      return jsonError(400, "priceMode가 RANGE이면 priceMin, priceMax는 둘 다 필수입니다.");
+    }
+    if (!isNonNegativeInt(raw.priceMin)) {
+      return jsonError(400, "priceMin은 0 이상의 정수여야 합니다.");
+    }
+    if (!isNonNegativeInt(raw.priceMax)) {
+      return jsonError(400, "priceMax는 0 이상의 정수여야 합니다.");
+    }
+    if (raw.priceMax < raw.priceMin) {
+      return jsonError(400, "priceMax는 priceMin 이상이어야 합니다.");
+    }
+  }
+
+  // 서버 기본값 자동 설정(ANY/NORMAL) + priceMode ANY면 null로 저장(모사)
+  const normalized: RequestBody = {
+    marketingConsent: { marketingAgreed: body.marketingConsent.marketingAgreed },
+    preferences: body.preferences
+      .map((p) => normalizeDefaults(p))
+      .map((p) => {
+        if (p.priceMode === "ANY") {
+          return {
+            ...p,
+            priceMin: null as any,
+            priceMax: null as any,
+          };
+        }
+        return p;
+      }),
+  };
+
+  // save mock + onboarding complete
+  const now = nowKSTISOString();
+  const marketingAgreed = normalized.marketingConsent.marketingAgreed;
+
+  store.set(token, {
+    onboardingStatus: true,
+    onboardingCompletedAt: now,
+    marketingAgreed,
+    marketingAgreedAt: marketingAgreed ? now : null,
+    body: normalized,
+  });
+
+  return NextResponse.json(
+    {
+      code: "OK",
+      message: "온보딩 저장 및 완료 처리 성공",
+      data: {
+        onboardingStatus: true,
+        onboardingCompletedAt: now,
+        marketingAgreed,
+        marketingAgreedAt: marketingAgreed ? now : null,
+      },
+    },
+    { status: 201 }
+  );
+}
+
+/**
+ * (선택) 디버깅용: 현재 저장된 mock 상태 조회
+ * GET /api/onboarding/preferences
+ * - Authorization 토큰 기준으로 저장된 body 반환
+ */
+export async function GET(req: Request) {
+  const token = getBearerToken(req);
+  if (!token) {
+    return jsonError(401, "Authorization Bearer 토큰이 필요합니다.", "UNAUTHORIZED");
+  }
+  const store = getStore();
+  const data = store.get(token);
+  if (!data) {
+    return jsonError(404, "저장된 온보딩 선호도가 없습니다.", "NOT_FOUND");
+  }
+  return NextResponse.json({ code: "OK", message: "조회 성공", data }, { status: 200 });
+}

--- a/goorm-gongbang/app/onboarding/option/page.tsx
+++ b/goorm-gongbang/app/onboarding/option/page.tsx
@@ -1,10 +1,23 @@
 "use client";
-import { useState } from "react";
+
+import { useState, useMemo, useEffect } from "react";
 import { ChipButton } from "@/components/common/ChipButton";
-import { useRouter} from "next/navigation";
+import { useRouter } from "next/navigation";
 import { TertiaryButton } from "@/components/common/TertiaryButton";
 import { PrimaryButton } from "@/components/common/PrimaryButton";
 import { SecondaryButton } from "@/components/common/SecondaryButton";
+import { InfoTooltip } from "@/components/common/InfoTooltip";
+
+import { useAuthStore } from "@/stores/authStore";
+import {
+    useOnboardingPrefStore,
+    type Preference,
+    type SeatPositionPref,
+    type EnvironmentPref,
+    type MoodPref,
+    type ObstructionSensitivity,
+    type PriceMode,
+} from "@/stores/onboardingPrefStore";
 
 type ViewTypePreference = "통로 선호" | "중앙 선호" | "무관";
 type EnvPreference = "그늘 선호" | "햇빛 무관" | "무관";
@@ -41,30 +54,191 @@ function toggleSingle<T>(prev: T | null, next: T): T | null {
 }
 
 export default function SeatStyleOnboardingOptionPage() {
-    const router = useRouter();
+    /* 서버 enum 매핑 */
+    const SEAT_POSITION_MAP: Record<ViewTypePreference, SeatPositionPref> = {
+        "통로 선호": "AISLE",
+        "중앙 선호": "MIDDLE",
+        "무관": "ANY",
+    };
 
+    const ENV_MAP: Record<EnvPreference, EnvironmentPref> = {
+        "그늘 선호": "SHADE",
+        "햇빛 무관": "SUN_OK",
+        "무관": "ANY",
+    };
+
+    const MOOD_MAP: Record<MoodPreference, MoodPref> = {
+        "열정적인 응원": "CHEERFUL",
+        "조용한 관람": "QUIET",
+        "무관": "ANY",
+    };
+
+    const OBSTRUCTION_MAP: Record<DistPreference, ObstructionSensitivity> = {
+        "안전망 민감": "NET_SENSITIVE",
+        "난간·기둥 민감": "RAIL_PILLAR_SENSITIVE",
+        "보통": "NORMAL",
+        "둔감": "ANY",
+    };
+
+    function priceToPayload(p: PricePreference | null): { priceMode: PriceMode; priceMin?: number; priceMax?: number | null } {
+        if (!p || p === "무관") return { priceMode: "ANY" };
+
+        switch (p) {
+            case "~ 13,000원":
+                return { priceMode: "RANGE", priceMin: 0, priceMax: 13000 };
+            case "14,000원 ~ 17,000원":
+                return { priceMode: "RANGE", priceMin: 14000, priceMax: 17000 };
+            case "18,000원 ~ 29,000원":
+                return { priceMode: "RANGE", priceMin: 18000, priceMax: 29000 };
+            case "30,000원 ~ ":
+                return { priceMode: "RANGE", priceMin: 30000, priceMax: null };
+            default:
+                return { priceMode: "ANY" };
+        }
+    }
+
+    /* priceMode=AMY면 min/max 제거 */
+    function normalizePricePatch(patch: { priceMode: PriceMode; priceMin?: number; priceMax?: number | null }) {
+        if (patch.priceMode === "ANY") {
+            return { priceMode: "ANY" as const, priceMin: null, priceMax: null };
+        }
+        return patch;
+    }
+
+    const accessToken = useAuthStore((s) => s.accessToken); // auth
+
+    const preferences = useOnboardingPrefStore((s) => s.preferences); // 필수 페이지 priority 1~3
+    const marketingAgreed = useOnboardingPrefStore((s) => s.marketingAgreed); // 필수 페이지 마케팅 동의 체크 여부
+    const updatePreference = useOnboardingPrefStore((s) => s.updatePreference);
+    const reset = useOnboardingPrefStore((s) => s.reset);
+
+    const router = useRouter();
     const [viewType, setViewType] = useState<ViewTypePreference | null>(null);
     const [env, setEnv] = useState<EnvPreference | null>(null);
     const [mood, setMood] = useState<MoodPreference | null>(null);
     const [dist, setDist] = useState<DistPreference | null>(null);
     const [price, setPrice] = useState<PricePreference | null>(null);
+    const [isFinishing, setIsFinishing] = useState(false);
+
+    /* 옵션 페이지 바로 진입 방지 */
+    useEffect(() => {
+        if (isFinishing) return; // 완료 흐름에서 가드 무시
+        if (!preferences || preferences.length !== 3) {
+            router.replace("/onboarding");
+        }
+    }, [preferences, router, isFinishing]);
+
+    /* api 요청 조건 (accesstoken, preferences data) */
+    const canSubmit = useMemo(() => {
+        return Boolean(accessToken) && Array.isArray(preferences) && preferences.length === 3;
+    }, [accessToken, preferences]);
+
 
     /* 이전 버튼 클릭 */
-    const handlePrev = () => {
-        console.log("handlePrev click");
-        //router.push("/");
-    }
+    const handlePrev = () => router.back();
 
-    /* 시작하기 버튼 클릭 */
-    const handleNext = () => {
-        console.log("handlenext click");
-        //router.push("/");
+    /* Zustand 데이터 patch 적용 */
+    const applyOptionPatchToAllPrioritys = () => {
+        const seatPositionPref: SeatPositionPref = viewType ? SEAT_POSITION_MAP[viewType] : "ANY";
+        const environmentPref: EnvironmentPref = env ? ENV_MAP[env] : "ANY";
+        const moodPref: MoodPref = mood ? MOOD_MAP[mood] : "ANY";
+        const obstructionSensitivity: ObstructionSensitivity = dist ? OBSTRUCTION_MAP[dist] : "NORMAL";
+        const pricePatch = normalizePricePatch(priceToPayload(price));
+
+        const patch: Partial<Preference> = {
+            seatPositionPref,
+            environmentPref,
+            moodPref,
+            obstructionSensitivity,
+            ...pricePatch,
+        };
+
+        updatePreference(1, patch);
+        updatePreference(2, patch);
+        updatePreference(3, patch);
     };
 
+    /* 시작하기 버튼 클릭 */
+    const handleNext = async () => {
+        if (!canSubmit) return;
+
+        applyOptionPatchToAllPrioritys(); // patch 적용
+
+        const seatPositionPref: SeatPositionPref = viewType ? SEAT_POSITION_MAP[viewType] : "ANY";
+        const environmentPref: EnvironmentPref = env ? ENV_MAP[env] : "ANY";
+        const moodPref: MoodPref = mood ? MOOD_MAP[mood] : "ANY";
+        const obstructionSensitivity: ObstructionSensitivity = dist ? OBSTRUCTION_MAP[dist] : "NORMAL";
+        const pricePatch = normalizePricePatch(priceToPayload(price));
+
+        const finalPreferences: Preference[] = preferences
+            .slice()
+            .sort((a, b) => a.priority - b.priority)
+            .map((p) => ({
+                ...p,
+                seatPositionPref,
+                environmentPref,
+                moodPref,
+                obstructionSensitivity,
+                ...pricePatch,
+            }));
+
+        const body = {
+            marketingConsent: { marketingAgreed: Boolean(marketingAgreed) },
+            preferences: finalPreferences,
+        };
+
+        console.log("body: ", body);
+
+        /* ===========================
+            API REQUEST
+        =========================== */
+        try {
+            const res = await fetch("/api/onboarding/preferences", { // 이부분 실제 api url로 수정 /onboarding/preferences ★
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${accessToken}`,
+                },
+                credentials: "include",
+                body: JSON.stringify(body),
+            })
+
+            /* 명세: 401 / 403 / 409 */
+            if (res.status === 401) { // 인증 실패
+                router.replace("/auth/login");
+                return;
+            }
+
+            if (res.status === 403) { // 계정 상태 DEACTIVE
+                router.replace("/auth/login");
+                return;
+            }
+
+            if (res.status === 409) { // 이미 온보딩 완료
+                router.replace("/");
+                return;
+            }
+
+            if (!res.ok) {
+                const err = await res.json().catch(() => null);
+                console.error("❌ onboarding/preferences failed:", res.status, err);
+                return;
+            }
+            const json = await res.json().catch(() => null);
+            console.log("✅ onboarding/preferences success:", json);
+
+            setIsFinishing(true);
+            router.replace("/"); // 홈 으로 이동
+            setTimeout(() => reset(), 0); // 완료 후 초기화
+
+        } catch (e) { console.error("⚠️ onboarding/preferences error:", e); }
+
+    }
+
+
     /* 건너뛰기 버튼 클릭 */
-    const handleSkip = () => {
-        console.log("handleskip click");
-        //router.push("/");
+    const handleSkip = async () => {
+        await handleNext();
     }
 
     return (
@@ -205,10 +379,21 @@ export default function SeatStyleOnboardingOptionPage() {
                                 {/* Section 5 */}
                                 <section className="self-stretch flex flex-col items-start gap-4">
                                     <div className="self-stretch flex flex-col items-start gap-1.5">
-                                        <div className="self-stretch inline-flex items-start gap-2">
+                                        <div className="self-stretch inline-flex items-center gap-1">
                                             <div className="text-base sm:text-lg font-semibold leading-6 text-black">
                                                 좌석 가격은 어떤 가격대를 원하시나요?
                                             </div>
+                                            <InfoTooltip
+                                                ariaLabel="가격 안내"
+                                                content={
+                                                    <ul className="list-disc pl-4 text-sm leading-5 text-[var(--light-foreground,#111)] space-y-1">
+                                                        <li>~ 13,000원: 외야석 중심</li>
+                                                        <li>14,000원 ~ 17,000원: 내야 저가 / 외야 상단</li>
+                                                        <li>18,000원 ~ 29,000원: 내야 일반석</li>
+                                                        <li>30,000원 ~ : 테이블석 / 프리미엄</li>
+                                                    </ul>
+                                                }
+                                            />
                                         </div>
                                         <div className="self-stretch inline-flex items-center gap-2">
                                             <div className="flex-1 text-sm font-medium leading-5 text-black">

--- a/goorm-gongbang/app/onboarding/page.tsx
+++ b/goorm-gongbang/app/onboarding/page.tsx
@@ -18,8 +18,8 @@ const viewOptions: ViewPreference[] = ["중앙", "1루 내야", "3루 내야", "
 const heightOptions: HeightPreference[] = ["하단", "중단", "상단", "무관"];
 const zoneOptions: ZonePreference[] = ["중앙쪽", "중간", "코너(파울라인)", "무관"];
 
-/* Rank Badge */
-function RankBadge({ n }: { n: number }) {
+/* priority Badge */
+function PriorityBadge({ n }: { n: number }) {
   return (
     <div className="px-1.5 bg-[var(--foundation-primary-700)] rounded-[100px] inline-flex flex-col justify-center items-center overflow-hidden">
       <div className="text-[var(--foundation-primary-10)] text-xs font-normal font-['Pretendard'] leading-4">
@@ -30,19 +30,19 @@ function RankBadge({ n }: { n: number }) {
 }
 
 /* Chip  */
-function Chip({ label, rank, onClick }: {
+function Chip({ label, priority, onClick }: {
   label: string; // 글자 데이터
-  rank: number | null;
+  priority: number | null;
   onClick: () => void;
 }) {
   return (
     <ChipButton
       uiSize="lg"
-      tone={rank ? "strong" : "soft"}
+      tone={priority ? "strong" : "soft"}
       onClick={onClick}
-      aria-pressed={Boolean(rank)}
-      leftIcon={rank ? <RankBadge n={rank} /> : undefined}
-      className={rank ? "gap-2" : ""}
+      aria-pressed={Boolean(priority)}
+      leftIcon={priority ? <PriorityBadge n={priority} /> : undefined}
+      className={priority ? "gap-2" : ""}
     >
       {label}
     </ChipButton>
@@ -97,7 +97,7 @@ function toggleUpToThree<T>(prev: T[], value: T) {
   return [...prev, value];
 }
 
-function getRank<T>(arr: T[], value: T) {
+function getPriority<T>(arr: T[], value: T) {
   const idx = arr.indexOf(value);
   return idx === -1 ? null : idx + 1; // 1, 2, 3
 }
@@ -225,7 +225,7 @@ export default function SeatStyleOnboardingPage() {
     if (!canGoNext) return;
 
     const basePrefs: PreferenceBase[] = [0, 1, 2].map((i) => ({
-      rank: (i + 1) as 1 | 2 | 3,
+      priority: (i + 1) as 1 | 2 | 3,
       viewpoint: VIEWPOINT_MAP[view[i]],
       seatHeight: SEAT_HEIGHT_MAP[height[i]],
       section: SECTION_MAP[zone[i]],
@@ -309,7 +309,7 @@ export default function SeatStyleOnboardingPage() {
 
                   <div className="self-stretch inline-flex items-center gap-1.5 flex-wrap">
                     {viewOptions.map((opt) => (
-                      <Chip key={opt} label={opt} rank={getRank(view, opt)} onClick={() => setView((prev) => toggleUpToThree(prev, opt))} />
+                      <Chip key={opt} label={opt} priority={getPriority(view, opt)} onClick={() => setView((prev) => toggleUpToThree(prev, opt))} />
                     ))}
                   </div>
                 </section>
@@ -337,7 +337,7 @@ export default function SeatStyleOnboardingPage() {
 
                   <div className="self-stretch inline-flex items-center gap-1.5 flex-wrap">
                     {heightOptions.map((opt) => (
-                      <Chip key={opt} label={opt} rank={getRank(height, opt)} onClick={() => setHeight((prev) => toggleUpToThree(prev, opt))} />
+                      <Chip key={opt} label={opt} priority={getPriority(height, opt)} onClick={() => setHeight((prev) => toggleUpToThree(prev, opt))} />
                     ))}
                   </div>
                 </section>
@@ -365,7 +365,7 @@ export default function SeatStyleOnboardingPage() {
 
                   <div className="self-stretch inline-flex items-center gap-1.5 flex-wrap">
                     {zoneOptions.map((opt) => (
-                      <Chip key={opt} label={opt} rank={getRank(zone, opt)} onClick={() => setZone((prev) => toggleUpToThree(prev, opt))} />
+                      <Chip key={opt} label={opt} priority={getPriority(zone, opt)} onClick={() => setZone((prev) => toggleUpToThree(prev, opt))} />
                     ))}
                   </div>
                 </section>

--- a/goorm-gongbang/components/common/InfoTooltip.tsx
+++ b/goorm-gongbang/components/common/InfoTooltip.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Info } from "lucide-react";
+
+type InfoTooltipProps = {
+    /** 툴팁 안에 들어갈 내용 */
+    content: React.ReactNode;
+    /** 버튼 접근성 라벨 */
+    ariaLabel?: string;
+    /** 툴팁 가로폭 */
+    widthClassName?: string;
+    /** 툴팁 세로폭 */
+    heightClassName?: string;
+    /** 아이콘 색상 */
+    iconClassName?: string;
+    /** 아이콘 클릭 시 색상 */
+    activeIconClassName?: string;
+    /** (옵션) 바깥에서 열기/닫기 제어하고 싶을 때 */
+    defaultOpen?: boolean;
+};
+
+export function InfoTooltip({
+    content,
+    ariaLabel = "안내",
+    widthClassName = "w-[299px]",
+    heightClassName = "h-[120px]",
+    iconClassName = "text-[var(--foundation-neutral-600,#999999)]",
+    activeIconClassName = "text-[var(--foundation-primary-500,#00C292)]",
+    defaultOpen = false,
+}: InfoTooltipProps) {
+    const [open, setOpen] = useState(defaultOpen);
+    const wrapRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        const onDown = (e: MouseEvent) => {
+            if (!wrapRef.current) return;
+            if (!wrapRef.current.contains(e.target as Node)) setOpen(false);
+        };
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") setOpen(false);
+        };
+
+        document.addEventListener("mousedown", onDown);
+        document.addEventListener("keydown", onKey);
+        return () => {
+            document.removeEventListener("mousedown", onDown);
+            document.removeEventListener("keydown", onKey);
+        };
+    }, []);
+
+    return (
+        <div ref={wrapRef} className="relative inline-flex items-center">
+            <button
+                type="button"
+                aria-label={ariaLabel}
+                aria-haspopup="dialog"
+                aria-expanded={open}
+                onClick={() => setOpen((v) => !v)}
+                className="inline-flex h-6 w-6 items-center justify-center rounded-md hover:bg-black/5"
+            >
+                <Info 
+                    className={[
+                        "h-4 w-4 transition",
+                        open ? activeIconClassName : iconClassName,
+                    ].join(" ")}
+                />
+            </button>
+
+            {open && (
+                <div
+                    role="dialog"
+                    aria-label={`${ariaLabel} 툴팁`}
+                    className={`
+                        absolute left-full ml-2 top-1/2 -translate-y-1/2 z-50
+                        ${widthClassName}
+                        ${heightClassName}
+                        rounded-lg bg-[var(--light-background,#fff)]
+                        shadow-[0px_1px_3px_0px_rgba(0,0,0,0.05)]
+                        outline outline-1 outline-offset-[-1px] outline-[var(--light-border,#E6E6E6)]
+                        p-4
+                    `}
+                >
+                    {/* 화살표(왼쪽 방향) */}
+                    <div
+                        className="
+                            absolute -left-2 top-1/2 -translate-y-1/2
+                            h-0 w-0
+                            border-y-8 border-y-transparent
+                            border-r-8 border-r-[var(--light-border,#E6E6E6)]
+                        "
+                    />
+                    <div
+                        className="
+                            absolute -left-[7px] top-1/2 -translate-y-1/2
+                            h-0 w-0
+                            border-y-[7px] border-y-transparent
+                            border-r-[7px] border-r-[var(--light-background,#fff)]
+                        "
+                    />
+                    <div className="w-full h-full text-left break-words">
+                        {content}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/goorm-gongbang/stores/onboardingPrefStore.ts
+++ b/goorm-gongbang/stores/onboardingPrefStore.ts
@@ -11,7 +11,7 @@ export type ObstructionSensitivity = "NET_SENSITIVE" | "RAIL_PILLAR_SENSITIVE" |
 export type PriceMode = "ANY" | "RANGE";
 
 export type Preference = {
-    rank: 1 | 2 | 3;
+    priority: 1 | 2 | 3;
     viewpoint: Viewpoint;
     seatHeight: SeatHeight;
     section: Section;
@@ -22,12 +22,12 @@ export type Preference = {
     obstructionSensitivity: ObstructionSensitivity;
 
     priceMode: PriceMode;
-    priceMin?: number;
-    priceMax?: number;
+    priceMin?: number | null;
+    priceMax?: number | null;
 };
 
 /* 1단계에서 받는 값 */
-export type PreferenceBase = Pick<Preference, "rank" | "viewpoint" | "seatHeight" | "section">;
+export type PreferenceBase = Pick<Preference, "priority" | "viewpoint" | "seatHeight" | "section">;
 
 type OnboardingPrefState = {
     preferences: Preference[];
@@ -35,7 +35,7 @@ type OnboardingPrefState = {
 
     setBasePreferences: (prefs: PreferenceBase[]) => void;
     setMarketingAgreed: (v: boolean) => void;
-    updatePreference: (rank: 1 | 2 | 3, patch: Partial<Preference>) => void;
+    updatePreference: (priority: 1 | 2 | 3, patch: Partial<Preference>) => void;
     reset: () => void;
 };
 
@@ -46,12 +46,12 @@ export const useOnboardingPrefStore = create<OnboardingPrefState>()(
             marketingAgreed: false,
 
             setBasePreferences: (basePrefs) => {
-                // rank 정렬 + 중복 제거/검증
-                const sorted = [...basePrefs].sort((a, b) => a.rank - b.rank);
+                // priority 정렬 + 중복 제거/검증
+                const sorted = [...basePrefs].sort((a, b) => a.priority - b.priority);
 
-                // rank 1~3 모두 있는지 간단 체크(없으면 그냥 저장 안 함)
-                const ranks = new Set(sorted.map((p) => p.rank));
-                if (!(ranks.has(1) && ranks.has(2) && ranks.has(3))) {
+                // priority 1~3 모두 있는지 간단 체크(없으면 그냥 저장 안 함)
+                const prioritys = new Set(sorted.map((p) => p.priority));
+                if (!(prioritys.has(1) && prioritys.has(2) && prioritys.has(3))) {
                     console.warn("[onboardingPrefStore] invalid basePrefs:", basePrefs);
                     return;
                 }
@@ -76,9 +76,9 @@ export const useOnboardingPrefStore = create<OnboardingPrefState>()(
                 console.log("[onboardingPrefStore] after setMarketingAgreed:", get().marketingAgreed);
             },
 
-            updatePreference: (rank, patch) => {
+            updatePreference: (priority, patch) => {
                 const prev = get().preferences;
-                const next = prev.map((p) => (p.rank === rank ? { ...p, ...patch } : p));
+                const next = prev.map((p) => (p.priority === priority ? { ...p, ...patch } : p));
                 set({ preferences: next });
 
                 console.log("[onboardingPrefStore] after updatePreference:", get().preferences);


### PR DESCRIPTION
🔧 작업 내용

온보딩 선택 페이지(/onboarding/option) UI/상태 관리 및 제출 플로우(기능) 구현

필수 페이지에서 저장한 Zustand(preferences/marketingAgreed) 를 기반으로 옵션 선택값을 합쳐 온보딩 선호도 API 제출 처리

가격/좌석 옵션 관련 매핑 및 payload 생성 로직 추가

선택 페이지 내 Info 툴팁 컴포넌트 분리 및 노출/닫힘 UX 개선(외부 클릭, ESC)

🧩 구현 상세(선택)

Zustand 데이터 병합

필수 페이지의 rank(구)(1~3) 기반 preferences에 선택 페이지 옵션(seatPositionPref, environmentPref, moodPref, obstructionSensitivity, priceMode/priceMin/priceMax)을 동일하게 patch

priceMax가 null 가능하도록 타입 및 payload 처리

API 요청

POST /api/onboarding/preferences로 { marketingConsent, preferences } 전송

응답 코드별 분기 처리(401/403/409/기타 에러)

내비게이션/가드

선택 페이지 직접 진입 시 필수 데이터 없으면 /onboarding로 이동

완료 플로우에서 reset 타이밍/가드 충돌 방지 처리

툴팁

Info 아이콘 클릭 시 우측 툴팁 노출

open 상태에 따른 아이콘 스타일 변경

툴팁 내용은 ReactNode로 받고, 리스트 형태(li)로도 사용 가능

📌 관련 Jira Issue

GBGB-48

🧪 테스트 방법(선택)

로그인 상태에서 /onboarding 진입

필수 항목(1~3순위) 모두 선택 + 필수 동의 체크 후 “다음” 클릭

/onboarding/option에서 옵션(좌석 타입/환경/분위기/민감도/가격)을 선택 후 “시작하기” 클릭

네트워크 탭에서 POST /api/onboarding/preferences 요청 payload 확인

성공 시 홈 이동 및 온보딩 데이터 초기화 확인

“건너뛰기” 동작 시에도 동일하게 제출/이동되는지 확인(요구사항에 따라 reset 여부 확인)

❗ 참고 사항

priceMax: null 케이스(“30,000원 ~”)는 서버에서 null 허용 전제로 처리됨

선택 페이지의 직접 진입 가드는 필수 데이터(3개 rank(구)) 기준으로 동작

Fixes: #20