### PR TITLE
feat(reserve-cp): 경기 예매 컴포넌트 개발

### DIFF
--- a/goorm-gongbang/app/api/onboarding/preferences/route.ts
+++ b/goorm-gongbang/app/api/onboarding/preferences/route.ts
@@ -43,8 +43,8 @@ type Preference = {
   obstructionSensitivity?: ObstructionSensitivity;
 
   priceMode?: PriceMode;
-  priceMin?: number;
-  priceMax?: number;
+  priceMin?: number | null;
+  priceMax?: number | null;
 };
 
 type RequestBody = {

--- a/goorm-gongbang/app/api/onboarding/preferences/route.ts
+++ b/goorm-gongbang/app/api/onboarding/preferences/route.ts
@@ -1,0 +1,358 @@
+// app/api/onboarding/preferences/route.ts
+import { NextResponse } from "next/server";
+
+/** =========================
+ * Types (Spec-aligned)
+ ========================= */
+
+type PriceMode = "ANY" | "RANGE";
+
+type Viewpoint =
+  | "CENTER"
+  | "INFIELD_1B"
+  | "INFIELD_3B"
+  | "OUTFIELD_L"
+  | "OUTFIELD_C"
+  | "OUTFIELD_R";
+
+type SeatHeight = "LOW" | "MID" | "HIGH" | "ANY";
+type Section = "CENTER_SIDE" | "MIDDLE" | "CORNER" | "ANY";
+
+type SeatPositionPref = "AISLE" | "MIDDLE" | "ANY";
+type EnvironmentPref = "SHADE" | "SUN_OK" | "ANY";
+type MoodPref = "CHEERFUL" | "QUIET" | "ANY";
+type ObstructionSensitivity =
+  | "NET_SENSITIVE"
+  | "RAIL_PILLAR_SENSITIVE"
+  | "NORMAL"
+  | "ANY";
+
+type MarketingConsent = {
+  marketingAgreed: boolean;
+};
+
+type Preference = {
+  priority: 1 | 2 | 3;
+  viewpoint: Viewpoint;
+  seatHeight: SeatHeight;
+  section: Section;
+
+  seatPositionPref?: SeatPositionPref;
+  environmentPref?: EnvironmentPref;
+  moodPref?: MoodPref;
+  obstructionSensitivity?: ObstructionSensitivity;
+
+  priceMode?: PriceMode;
+  priceMin?: number;
+  priceMax?: number;
+};
+
+type RequestBody = {
+  marketingConsent: MarketingConsent;
+  preferences: Preference[];
+};
+
+/** =========================
+ * Mock "DB" (in-memory)
+ * key: accessToken string
+ ========================= */
+declare global {
+  // eslint-disable-next-line no-var
+  var __ONBOARDING_PREF_MOCK__: Map<
+    string,
+    {
+      onboardingStatus: boolean;
+      onboardingCompletedAt: string;
+      marketingAgreed: boolean;
+      marketingAgreedAt: string | null;
+      body: RequestBody;
+    }
+  > | undefined;
+}
+
+function getStore() {
+  if (!global.__ONBOARDING_PREF_MOCK__) {
+    global.__ONBOARDING_PREF_MOCK__ = new Map();
+  }
+  return global.__ONBOARDING_PREF_MOCK__;
+}
+
+/** =========================
+ * Helpers
+ ========================= */
+
+function nowKSTISOString() {
+  // KST: UTC+09:00
+  const d = new Date(Date.now() + 9 * 60 * 60 * 1000);
+  // ISO without "Z", add +09:00
+  const iso = d.toISOString().replace("Z", "+09:00");
+  return iso;
+}
+
+function jsonError(status: number, message: string, code = "BAD_REQUEST") {
+  return NextResponse.json({ code, message, data: null }, { status });
+}
+
+function getBearerToken(req: Request) {
+  const auth = req.headers.get("authorization") || req.headers.get("Authorization");
+  if (!auth) return null;
+  const m = auth.match(/^Bearer\s+(.+)$/i);
+  if (!m) return null;
+  return m[1].trim();
+}
+
+function isInt(n: unknown): n is number {
+  return typeof n === "number" && Number.isInteger(n);
+}
+
+function isNonNegativeInt(n: unknown): n is number {
+  return isInt(n) && n >= 0;
+}
+
+const VIEWPOINTS: readonly Viewpoint[] = [
+  "CENTER",
+  "INFIELD_1B",
+  "INFIELD_3B",
+  "OUTFIELD_L",
+  "OUTFIELD_C",
+  "OUTFIELD_R",
+] as const;
+
+const SEAT_HEIGHTS: readonly SeatHeight[] = ["LOW", "MID", "HIGH", "ANY"] as const;
+const SECTIONS: readonly Section[] = ["CENTER_SIDE", "MIDDLE", "CORNER", "ANY"] as const;
+
+const SEAT_POS: readonly SeatPositionPref[] = ["AISLE", "MIDDLE", "ANY"] as const;
+const ENVS: readonly EnvironmentPref[] = ["SHADE", "SUN_OK", "ANY"] as const;
+const MOODS: readonly MoodPref[] = ["CHEERFUL", "QUIET", "ANY"] as const;
+const OBSTRUCTIONS: readonly ObstructionSensitivity[] = [
+  "NET_SENSITIVE",
+  "RAIL_PILLAR_SENSITIVE",
+  "NORMAL",
+  "ANY",
+] as const;
+
+const PRICE_MODES: readonly PriceMode[] = ["ANY", "RANGE"] as const;
+
+function assertEnum<T extends readonly string[]>(
+  value: unknown,
+  allowed: T,
+  fieldName: string
+): value is T[number] {
+  if (typeof value !== "string" || !allowed.includes(value)) return false;
+  return true;
+}
+
+function normalizeDefaults(p: Preference): Required<Preference> {
+  return {
+    priority: p.priority,
+    viewpoint: p.viewpoint,
+    seatHeight: p.seatHeight,
+    section: p.section,
+
+    seatPositionPref: p.seatPositionPref ?? "ANY",
+    environmentPref: p.environmentPref ?? "ANY",
+    moodPref: p.moodPref ?? "ANY",
+    obstructionSensitivity: p.obstructionSensitivity ?? "NORMAL",
+    priceMode: p.priceMode ?? "ANY",
+
+    priceMin: p.priceMin ?? (null as any),
+    priceMax: p.priceMax ?? (null as any),
+  };
+}
+
+/** =========================
+ * Route
+ ========================= */
+
+export async function POST(req: Request) {
+  // 401: 인증 실패
+  const token = getBearerToken(req);
+  if (!token) {
+    return jsonError(401, "Authorization Bearer 토큰이 필요합니다.", "UNAUTHORIZED");
+  }
+
+  // (mock) 403: DEACTIVE는 실제 계정상태가 없으니 데모용 규칙 하나 둠
+  // 토큰이 "deactive"를 포함하면 DEACTIVE 취급
+  if (token.toLowerCase().includes("deactive")) {
+    return jsonError(403, "계정 상태가 DEACTIVE 입니다.", "FORBIDDEN");
+  }
+
+  let body: RequestBody;
+  try {
+    body = (await req.json()) as RequestBody;
+  } catch {
+    return jsonError(400, "JSON 파싱에 실패했습니다.");
+  }
+
+  // validation: marketingConsent.marketingAgreed 필수
+  if (
+    !body ||
+    typeof body !== "object" ||
+    !body.marketingConsent ||
+    typeof body.marketingConsent !== "object" ||
+    typeof body.marketingConsent.marketingAgreed !== "boolean"
+  ) {
+    return jsonError(400, "marketingConsent.marketingAgreed(boolean)는 필수입니다.");
+  }
+
+  // validation: preferences 길이 3 고정
+  if (!Array.isArray(body.preferences) || body.preferences.length !== 3) {
+    return jsonError(400, "preferences는 길이 3인 배열이어야 합니다.");
+  }
+
+  // 409: 이미 온보딩 완료인데 재호출(정책: 최초 저장 엄격)
+  const store = getStore();
+  if (store.has(token)) {
+    return jsonError(409, "이미 온보딩이 완료된 사용자입니다.", "CONFLICT");
+  }
+
+  // priority 중복 + 1,2,3 모두 있어야 함
+  const prioritys = body.preferences.map((p) => p?.priority);
+  const prioritySet = new Set(prioritys);
+  const mustprioritys = new Set([1, 2, 3]);
+
+  if (prioritySet.size !== 3 || prioritys.some((r) => r !== 1 && r !== 2 && r !== 3)) {
+    return jsonError(400, "priority는 1,2,3이 각각 한 번씩 있어야 합니다.");
+  }
+  for (const r of mustprioritys) {
+    if (!prioritySet.has(r)) return jsonError(400, "priority는 1,2,3이 모두 포함되어야 합니다.");
+  }
+
+  // 각 preference 필수: viewpoint, seatHeight, section
+  // + viewpoint 중복 불가
+  const viewpointSet = new Set<string>();
+
+  for (const [idx, raw] of body.preferences.entries()) {
+    if (!raw || typeof raw !== "object") {
+      return jsonError(400, `preferences[${idx}] 형식이 올바르지 않습니다.`);
+    }
+
+    // required fields
+    if (!assertEnum(raw.viewpoint, VIEWPOINTS, "viewpoint")) {
+      return jsonError(400, `preferences[${idx}].viewpoint 허용값이 아닙니다.`);
+    }
+    if (!assertEnum(raw.seatHeight, SEAT_HEIGHTS, "seatHeight")) {
+      return jsonError(400, `preferences[${idx}].seatHeight 허용값이 아닙니다.`);
+    }
+    if (!assertEnum(raw.section, SECTIONS, "section")) {
+      return jsonError(400, `preferences[${idx}].section 허용값이 아닙니다.`);
+    }
+
+    // optional enums if present
+    if (
+      raw.seatPositionPref !== undefined &&
+      !assertEnum(raw.seatPositionPref, SEAT_POS, "seatPositionPref")
+    ) {
+      return jsonError(400, `preferences[${idx}].seatPositionPref 허용값이 아닙니다.`);
+    }
+    if (
+      raw.environmentPref !== undefined &&
+      !assertEnum(raw.environmentPref, ENVS, "environmentPref")
+    ) {
+      return jsonError(400, `preferences[${idx}].environmentPref 허용값이 아닙니다.`);
+    }
+    if (raw.moodPref !== undefined && !assertEnum(raw.moodPref, MOODS, "moodPref")) {
+      return jsonError(400, `preferences[${idx}].moodPref 허용값이 아닙니다.`);
+    }
+    if (
+      raw.obstructionSensitivity !== undefined &&
+      !assertEnum(raw.obstructionSensitivity, OBSTRUCTIONS, "obstructionSensitivity")
+    ) {
+      return jsonError(400, `preferences[${idx}].obstructionSensitivity 허용값이 아닙니다.`);
+    }
+    if (raw.priceMode !== undefined && !assertEnum(raw.priceMode, PRICE_MODES, "priceMode")) {
+      return jsonError(400, `preferences[${idx}].priceMode 허용값이 아닙니다.`);
+    }
+
+    // viewpoint uniqueness (user_id, viewpoint) unique
+    if (viewpointSet.has(raw.viewpoint)) {
+      return jsonError(400, "동일 viewpoint로 여러 순위를 등록할 수 없습니다.");
+    }
+    viewpointSet.add(raw.viewpoint);
+
+    // price validation
+    const priceMode: PriceMode = raw.priceMode ?? "ANY";
+    const hasMin = raw.priceMin !== undefined && raw.priceMin !== null;
+    const hasMax = raw.priceMax !== undefined && raw.priceMax !== null;
+
+    if (priceMode === "ANY") {
+      // ignore min/max (null 저장)
+      continue;
+    }
+
+    // RANGE
+    if (!hasMin || !hasMax) {
+      return jsonError(400, "priceMode가 RANGE이면 priceMin, priceMax는 둘 다 필수입니다.");
+    }
+    if (!isNonNegativeInt(raw.priceMin)) {
+      return jsonError(400, "priceMin은 0 이상의 정수여야 합니다.");
+    }
+    if (!isNonNegativeInt(raw.priceMax)) {
+      return jsonError(400, "priceMax는 0 이상의 정수여야 합니다.");
+    }
+    if (raw.priceMax < raw.priceMin) {
+      return jsonError(400, "priceMax는 priceMin 이상이어야 합니다.");
+    }
+  }
+
+  // 서버 기본값 자동 설정(ANY/NORMAL) + priceMode ANY면 null로 저장(모사)
+  const normalized: RequestBody = {
+    marketingConsent: { marketingAgreed: body.marketingConsent.marketingAgreed },
+    preferences: body.preferences
+      .map((p) => normalizeDefaults(p))
+      .map((p) => {
+        if (p.priceMode === "ANY") {
+          return {
+            ...p,
+            priceMin: null as any,
+            priceMax: null as any,
+          };
+        }
+        return p;
+      }),
+  };
+
+  // save mock + onboarding complete
+  const now = nowKSTISOString();
+  const marketingAgreed = normalized.marketingConsent.marketingAgreed;
+
+  store.set(token, {
+    onboardingStatus: true,
+    onboardingCompletedAt: now,
+    marketingAgreed,
+    marketingAgreedAt: marketingAgreed ? now : null,
+    body: normalized,
+  });
+
+  return NextResponse.json(
+    {
+      code: "OK",
+      message: "온보딩 저장 및 완료 처리 성공",
+      data: {
+        onboardingStatus: true,
+        onboardingCompletedAt: now,
+        marketingAgreed,
+        marketingAgreedAt: marketingAgreed ? now : null,
+      },
+    },
+    { status: 201 }
+  );
+}
+
+/**
+ * (선택) 디버깅용: 현재 저장된 mock 상태 조회
+ * GET /api/onboarding/preferences
+ * - Authorization 토큰 기준으로 저장된 body 반환
+ */
+export async function GET(req: Request) {
+  const token = getBearerToken(req);
+  if (!token) {
+    return jsonError(401, "Authorization Bearer 토큰이 필요합니다.", "UNAUTHORIZED");
+  }
+  const store = getStore();
+  const data = store.get(token);
+  if (!data) {
+    return jsonError(404, "저장된 온보딩 선호도가 없습니다.", "NOT_FOUND");
+  }
+  return NextResponse.json({ code: "OK", message: "조회 성공", data }, { status: 200 });
+}

--- a/goorm-gongbang/app/design/components/page.tsx
+++ b/goorm-gongbang/app/design/components/page.tsx
@@ -1,8 +1,11 @@
+"use client";
+import * as React from "react";
+import { useState } from "react";
 import { PrimaryButton } from "@/components/common/PrimaryButton";
 import { SecondaryButton } from "@/components/common/SecondaryButton";
 import { TertiaryButton } from "@/components/common/TertiaryButton";
 import { PrimaryButtonWithIcon, SecondaryButtonWithIcon, TertiaryButtonWithIcon } from "@/components/common/ButtonWithIcon";
-import { Plus } from "lucide-react";
+import { Plus, MapPin } from "lucide-react";
 import { DestructiveButton } from "@/components/common/ButtonDestructive";
 import { KakaoButton } from "@/components/login/KakaoButton";
 import { GoogleButton } from "@/components/login/GoogleButton";
@@ -10,6 +13,15 @@ import { ButtonSpinner } from "@/components/common/ButtonLoading";
 import { Toggle } from "@/components/common/Toggle";
 import { ChipButton } from "@/components/common/ChipButton";
 import { UiCheckbox } from "@/components/common/UiCheckbox";
+import { RankChipButton } from "@/components/common/RankChipButton";
+import { TicketingNavigator } from "@/components/common/TicketingNavigator";
+import { ChipBlackButton } from "@/components/common/ChipBlackButton";
+import { ButtonReload } from "@/components/common/ButtonReload";
+import { SeatPreferenceRecommendCard } from "@/components/common/SeatPreferenceRecommendCard"
+import { ChipDropButton } from "@/components/common/ChipDropButton"
+import { DropDown } from "@/components/common/DropDown"
+import { Header } from "@/components/layout/Header"
+import { SeatRecommendSummaryCard } from "@/components/common/SeatRecommendSummaryCard"
 
 function ToneRow({
   title,
@@ -49,6 +61,10 @@ function Section({
 }
 
 export default function Components() {
+  const [enabled, setEnabled] = useState(true);
+  const [people, setPeople] = useState(2);
+  const [loggedIn, setLoggedIn] = React.useState(false);
+
   return (
     <div className="mx-auto max-w-5xl space-y-8 p-6">
       <div className="space-y-1">
@@ -462,6 +478,125 @@ export default function Components() {
           <UiCheckbox />
         </ToneRow>
       </Section>
+
+      {/* Rank Chip Button */}
+      <Section title="Rank Chip Button">
+        <ToneRow title="Rank Chip Button">
+          <RankChipButton rank={1} />
+          <RankChipButton rank={2} />
+          <RankChipButton rank={3} />
+          <RankChipButton rank={4} />
+          <RankChipButton rank={5} />
+        </ToneRow>
+      </Section>
+
+      {/* Ticket Navigator */}
+      <Section title="Ticket Navigator">
+        <ToneRow title="Ticket Navigator">
+          <TicketingNavigator active="seat" /> <br />
+          <TicketingNavigator active="order" /> <br />
+          <TicketingNavigator active="pay" />
+        </ToneRow>
+      </Section>
+
+      {/* Chip Black Button */}
+      <Section title="Chip Black Button">
+        <ToneRow title="Chip Black Button">
+          <ChipBlackButton variant="outlineStrong">Button</ChipBlackButton>
+          <ChipBlackButton variant="outline">Button</ChipBlackButton>
+          <ChipBlackButton variant="filled">Button</ChipBlackButton>
+          <ChipBlackButton variant="dark">Button</ChipBlackButton>
+        </ToneRow>
+      </Section>
+
+      {/* Reload Button */}
+      <Section title="Reload Button">
+        <ToneRow title="Reload Button">
+          <ButtonReload state="default" />
+          <ButtonReload state="hover" />
+          <ButtonReload state="pressed" />
+        </ToneRow>
+      </Section>
+
+      {/* DropButton */}
+      <Section title="DropButton">
+        <ToneRow title="DropButton">
+          <DropDown value={people} onChange={setPeople} max={5} />
+        </ToneRow>
+      </Section>
+
+      {/* SeatPreferenceRecommendCard */}
+      <Section title="SeatPreferenceRecommendCard">
+        <ToneRow title="SeatPreferenceRecommendCard">
+          <SeatPreferenceRecommendCard
+            enabled={enabled}
+            onChange={setEnabled}
+          />
+        </ToneRow>
+      </Section>
+
+      {/* ChipDropButton */}
+      <Section title="ChipDropButton">
+        <ToneRow title="ChipDropButton">
+
+          <ChipDropButton label="버튼" variant="neutral" uiState="default" />
+          <ChipDropButton label="버튼" variant="neutral" uiState="default" leftIcon={<MapPin />} />
+
+          <ChipDropButton label="버튼" variant="primary" uiState="default" />
+          <ChipDropButton label="버튼" variant="primary" uiState="default" leftIcon={<MapPin />} />
+
+          <ChipDropButton label="버튼" variant="neutral" uiState="hover" />
+          <ChipDropButton label="버튼" variant="neutral" uiState="hover" leftIcon={<MapPin />} />
+
+          <ChipDropButton label="버튼" uiState="disabled" />
+          <ChipDropButton label="버튼" uiState="disabled" leftIcon={<MapPin />} />
+
+        </ToneRow>
+      </Section>
+
+      <Section title="Header">
+        <ToneRow title="Header">
+          <Header />
+          <Header
+            loggedIn={loggedIn}
+            onLoginClick={() => setLoggedIn(true)}
+            onMyInfoClick={() => console.log("내 정보")}
+            onMyTicketClick={() => console.log("내 티켓")}
+          />
+        </ToneRow>
+      </Section>
+
+      <Section title="SeatRecommendSummaryCard">
+        <ToneRow title="SeatRecommendSummaryCard">
+          <SeatRecommendSummaryCard
+            variant="default"
+            totalPriceText="총 0원"
+            seats={[
+              { left: "000석 000블럭 00열 00번, 00번", right: "0원/매" },
+              { left: "000석 000블럭 00열 00번", right: "0원/매" },
+            ]}
+            tags={["# 1루 내야", "# 하단", "# 통로", "# 응원단 바로 앞"]}
+          />
+
+          <SeatRecommendSummaryCard
+            variant="hover"
+            totalPriceText="총 0원"
+            seats={[{ left: "000석 000블럭 00열 00번", right: "0원/매" }]}
+            tags={["# 1루 내야", "# 하단", "# 통로", "# 응원단 바로 앞"]}
+          />
+
+          <SeatRecommendSummaryCard
+            variant="focused"
+            totalPriceText="총 0원"
+            seats={[
+              { left: "000석 000블럭 00열 00번, 00번", right: "0원/매" },
+              { left: "000석 000블럭 00열 00번", right: "0원/매" },
+            ]}
+            tags={["# 1루 내야", "# 하단", "# 통로", "# 응원단 바로 앞"]}
+          />
+        </ToneRow>
+      </Section>
+
     </div>
   );
 }

--- a/goorm-gongbang/app/globals.css
+++ b/goorm-gongbang/app/globals.css
@@ -49,6 +49,27 @@
   --radius-4xl: calc(var(--radius) + 16px);
 }
 
+/* ===========================
+   Scroll Design
+=========================== */
+.thin-scrollbar {
+   scrollbar-width: thin;
+   scrollbar-color: rgba(0,0,0,0.25) transparent;
+}
+
+.thin-scrollbar::-webkit-scrollbar {
+   width: 6px;
+}
+
+.thin-scrollbar::-webkit-scrollbar-track {
+   background: transparent;
+}
+
+.thin-scrollbar::-webkit-scrollbar-thumb {
+   background-color: rgba(0,0,0,0.25);
+   border-radius: 9999px;
+}
+
 :root {
   --font-pretendard: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue",
   Arial, "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", sans-serif;
@@ -127,6 +148,7 @@
   --foundation-neutral-white: #FFFFFF;
   --background-interactive-neutral-disabled: #E5E5E5;
   --text-interactive-neutral-disabled: #999999;
+  --light-background: #FFFFFF;
 
   /* ===========================
      Foundation / (Red)
@@ -263,12 +285,12 @@
   =========================== */
   --text-normal-n240: #3D3D3D;
   --light-foreground: #000000;
-
+  
   --background-grey: #FAFAFA;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
+  --card-foreground: oklch(44.563% 0.07914 20.682);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
   --primary: oklch(0.205 0 0);

--- a/goorm-gongbang/app/onboarding/option/page.tsx
+++ b/goorm-gongbang/app/onboarding/option/page.tsx
@@ -53,63 +53,61 @@ function toggleSingle<T>(prev: T | null, next: T): T | null {
     return prev === next ? null : next;
 }
 
+/* 서버 enum 매핑 */
+const SEAT_POSITION_MAP: Record<ViewTypePreference, SeatPositionPref> = {
+    "통로 선호": "AISLE",
+    "중앙 선호": "MIDDLE",
+    "무관": "ANY",
+};
+
+const ENV_MAP: Record<EnvPreference, EnvironmentPref> = {
+    "그늘 선호": "SHADE",
+    "햇빛 무관": "SUN_OK",
+    "무관": "ANY",
+};
+
+const MOOD_MAP: Record<MoodPreference, MoodPref> = {
+    "열정적인 응원": "CHEERFUL",
+    "조용한 관람": "QUIET",
+    "무관": "ANY",
+};
+
+const OBSTRUCTION_MAP: Record<DistPreference, ObstructionSensitivity> = {
+    "안전망 민감": "NET_SENSITIVE",
+    "난간·기둥 민감": "RAIL_PILLAR_SENSITIVE",
+    "보통": "NORMAL",
+    "둔감": "ANY",
+};
+
+function priceToPayload(p: PricePreference | null): { priceMode: PriceMode; priceMin?: number; priceMax?: number | null } {
+    if (!p || p === "무관") return { priceMode: "ANY" };
+
+    switch (p) {
+        case "~ 13,000원":
+            return { priceMode: "RANGE", priceMin: 0, priceMax: 13000 };
+        case "14,000원 ~ 17,000원":
+            return { priceMode: "RANGE", priceMin: 14000, priceMax: 17000 };
+        case "18,000원 ~ 29,000원":
+            return { priceMode: "RANGE", priceMin: 18000, priceMax: 29000 };
+        case "30,000원 ~ ":
+            return { priceMode: "RANGE", priceMin: 30000, priceMax: null };
+        default:
+            return { priceMode: "ANY" };
+    }
+}
+
+/* priceMode=AMY면 min/max 제거 */
+function normalizePricePatch(patch: { priceMode: PriceMode; priceMin?: number; priceMax?: number | null }) {
+    if (patch.priceMode === "ANY") {
+        return { priceMode: "ANY" as const, priceMin: null, priceMax: null };
+    }
+    return patch;
+}
 export default function SeatStyleOnboardingOptionPage() {
-    /* 서버 enum 매핑 */
-    const SEAT_POSITION_MAP: Record<ViewTypePreference, SeatPositionPref> = {
-        "통로 선호": "AISLE",
-        "중앙 선호": "MIDDLE",
-        "무관": "ANY",
-    };
-
-    const ENV_MAP: Record<EnvPreference, EnvironmentPref> = {
-        "그늘 선호": "SHADE",
-        "햇빛 무관": "SUN_OK",
-        "무관": "ANY",
-    };
-
-    const MOOD_MAP: Record<MoodPreference, MoodPref> = {
-        "열정적인 응원": "CHEERFUL",
-        "조용한 관람": "QUIET",
-        "무관": "ANY",
-    };
-
-    const OBSTRUCTION_MAP: Record<DistPreference, ObstructionSensitivity> = {
-        "안전망 민감": "NET_SENSITIVE",
-        "난간·기둥 민감": "RAIL_PILLAR_SENSITIVE",
-        "보통": "NORMAL",
-        "둔감": "ANY",
-    };
-
-    function priceToPayload(p: PricePreference | null): { priceMode: PriceMode; priceMin?: number; priceMax?: number | null } {
-        if (!p || p === "무관") return { priceMode: "ANY" };
-
-        switch (p) {
-            case "~ 13,000원":
-                return { priceMode: "RANGE", priceMin: 0, priceMax: 13000 };
-            case "14,000원 ~ 17,000원":
-                return { priceMode: "RANGE", priceMin: 14000, priceMax: 17000 };
-            case "18,000원 ~ 29,000원":
-                return { priceMode: "RANGE", priceMin: 18000, priceMax: 29000 };
-            case "30,000원 ~ ":
-                return { priceMode: "RANGE", priceMin: 30000, priceMax: null };
-            default:
-                return { priceMode: "ANY" };
-        }
-    }
-
-    /* priceMode=AMY면 min/max 제거 */
-    function normalizePricePatch(patch: { priceMode: PriceMode; priceMin?: number; priceMax?: number | null }) {
-        if (patch.priceMode === "ANY") {
-            return { priceMode: "ANY" as const, priceMin: null, priceMax: null };
-        }
-        return patch;
-    }
-
     const accessToken = useAuthStore((s) => s.accessToken); // auth
 
     const preferences = useOnboardingPrefStore((s) => s.preferences); // 필수 페이지 priority 1~3
     const marketingAgreed = useOnboardingPrefStore((s) => s.marketingAgreed); // 필수 페이지 마케팅 동의 체크 여부
-    const updatePreference = useOnboardingPrefStore((s) => s.updatePreference);
     const reset = useOnboardingPrefStore((s) => s.reset);
 
     const router = useRouter();

--- a/goorm-gongbang/app/onboarding/option/page.tsx
+++ b/goorm-gongbang/app/onboarding/option/page.tsx
@@ -137,32 +137,9 @@ export default function SeatStyleOnboardingOptionPage() {
     /* 이전 버튼 클릭 */
     const handlePrev = () => router.back();
 
-    /* Zustand 데이터 patch 적용 */
-    const applyOptionPatchToAllPrioritys = () => {
-        const seatPositionPref: SeatPositionPref = viewType ? SEAT_POSITION_MAP[viewType] : "ANY";
-        const environmentPref: EnvironmentPref = env ? ENV_MAP[env] : "ANY";
-        const moodPref: MoodPref = mood ? MOOD_MAP[mood] : "ANY";
-        const obstructionSensitivity: ObstructionSensitivity = dist ? OBSTRUCTION_MAP[dist] : "NORMAL";
-        const pricePatch = normalizePricePatch(priceToPayload(price));
-
-        const patch: Partial<Preference> = {
-            seatPositionPref,
-            environmentPref,
-            moodPref,
-            obstructionSensitivity,
-            ...pricePatch,
-        };
-
-        updatePreference(1, patch);
-        updatePreference(2, patch);
-        updatePreference(3, patch);
-    };
-
     /* 시작하기 버튼 클릭 */
     const handleNext = async () => {
         if (!canSubmit) return;
-
-        applyOptionPatchToAllPrioritys(); // patch 적용
 
         const seatPositionPref: SeatPositionPref = viewType ? SEAT_POSITION_MAP[viewType] : "ANY";
         const environmentPref: EnvironmentPref = env ? ENV_MAP[env] : "ANY";

--- a/goorm-gongbang/app/onboarding/option/page.tsx
+++ b/goorm-gongbang/app/onboarding/option/page.tsx
@@ -1,10 +1,23 @@
 "use client";
-import { useState } from "react";
+
+import { useState, useMemo, useEffect } from "react";
 import { ChipButton } from "@/components/common/ChipButton";
-import { useRouter} from "next/navigation";
+import { useRouter } from "next/navigation";
 import { TertiaryButton } from "@/components/common/TertiaryButton";
 import { PrimaryButton } from "@/components/common/PrimaryButton";
 import { SecondaryButton } from "@/components/common/SecondaryButton";
+import { InfoTooltip } from "@/components/common/InfoTooltip";
+
+import { useAuthStore } from "@/stores/authStore";
+import {
+    useOnboardingPrefStore,
+    type Preference,
+    type SeatPositionPref,
+    type EnvironmentPref,
+    type MoodPref,
+    type ObstructionSensitivity,
+    type PriceMode,
+} from "@/stores/onboardingPrefStore";
 
 type ViewTypePreference = "통로 선호" | "중앙 선호" | "무관";
 type EnvPreference = "그늘 선호" | "햇빛 무관" | "무관";
@@ -41,30 +54,191 @@ function toggleSingle<T>(prev: T | null, next: T): T | null {
 }
 
 export default function SeatStyleOnboardingOptionPage() {
-    const router = useRouter();
+    /* 서버 enum 매핑 */
+    const SEAT_POSITION_MAP: Record<ViewTypePreference, SeatPositionPref> = {
+        "통로 선호": "AISLE",
+        "중앙 선호": "MIDDLE",
+        "무관": "ANY",
+    };
 
+    const ENV_MAP: Record<EnvPreference, EnvironmentPref> = {
+        "그늘 선호": "SHADE",
+        "햇빛 무관": "SUN_OK",
+        "무관": "ANY",
+    };
+
+    const MOOD_MAP: Record<MoodPreference, MoodPref> = {
+        "열정적인 응원": "CHEERFUL",
+        "조용한 관람": "QUIET",
+        "무관": "ANY",
+    };
+
+    const OBSTRUCTION_MAP: Record<DistPreference, ObstructionSensitivity> = {
+        "안전망 민감": "NET_SENSITIVE",
+        "난간·기둥 민감": "RAIL_PILLAR_SENSITIVE",
+        "보통": "NORMAL",
+        "둔감": "ANY",
+    };
+
+    function priceToPayload(p: PricePreference | null): { priceMode: PriceMode; priceMin?: number; priceMax?: number | null } {
+        if (!p || p === "무관") return { priceMode: "ANY" };
+
+        switch (p) {
+            case "~ 13,000원":
+                return { priceMode: "RANGE", priceMin: 0, priceMax: 13000 };
+            case "14,000원 ~ 17,000원":
+                return { priceMode: "RANGE", priceMin: 14000, priceMax: 17000 };
+            case "18,000원 ~ 29,000원":
+                return { priceMode: "RANGE", priceMin: 18000, priceMax: 29000 };
+            case "30,000원 ~ ":
+                return { priceMode: "RANGE", priceMin: 30000, priceMax: null };
+            default:
+                return { priceMode: "ANY" };
+        }
+    }
+
+    /* priceMode=AMY면 min/max 제거 */
+    function normalizePricePatch(patch: { priceMode: PriceMode; priceMin?: number; priceMax?: number | null }) {
+        if (patch.priceMode === "ANY") {
+            return { priceMode: "ANY" as const, priceMin: null, priceMax: null };
+        }
+        return patch;
+    }
+
+    const accessToken = useAuthStore((s) => s.accessToken); // auth
+
+    const preferences = useOnboardingPrefStore((s) => s.preferences); // 필수 페이지 priority 1~3
+    const marketingAgreed = useOnboardingPrefStore((s) => s.marketingAgreed); // 필수 페이지 마케팅 동의 체크 여부
+    const updatePreference = useOnboardingPrefStore((s) => s.updatePreference);
+    const reset = useOnboardingPrefStore((s) => s.reset);
+
+    const router = useRouter();
     const [viewType, setViewType] = useState<ViewTypePreference | null>(null);
     const [env, setEnv] = useState<EnvPreference | null>(null);
     const [mood, setMood] = useState<MoodPreference | null>(null);
     const [dist, setDist] = useState<DistPreference | null>(null);
     const [price, setPrice] = useState<PricePreference | null>(null);
+    const [isFinishing, setIsFinishing] = useState(false);
+
+    /* 옵션 페이지 바로 진입 방지 */
+    useEffect(() => {
+        if (isFinishing) return; // 완료 흐름에서 가드 무시
+        if (!preferences || preferences.length !== 3) {
+            router.replace("/onboarding");
+        }
+    }, [preferences, router, isFinishing]);
+
+    /* api 요청 조건 (accesstoken, preferences data) */
+    const canSubmit = useMemo(() => {
+        return Boolean(accessToken) && Array.isArray(preferences) && preferences.length === 3;
+    }, [accessToken, preferences]);
+
 
     /* 이전 버튼 클릭 */
-    const handlePrev = () => {
-        console.log("handlePrev click");
-        //router.push("/");
-    }
+    const handlePrev = () => router.back();
 
-    /* 시작하기 버튼 클릭 */
-    const handleNext = () => {
-        console.log("handlenext click");
-        //router.push("/");
+    /* Zustand 데이터 patch 적용 */
+    const applyOptionPatchToAllPrioritys = () => {
+        const seatPositionPref: SeatPositionPref = viewType ? SEAT_POSITION_MAP[viewType] : "ANY";
+        const environmentPref: EnvironmentPref = env ? ENV_MAP[env] : "ANY";
+        const moodPref: MoodPref = mood ? MOOD_MAP[mood] : "ANY";
+        const obstructionSensitivity: ObstructionSensitivity = dist ? OBSTRUCTION_MAP[dist] : "NORMAL";
+        const pricePatch = normalizePricePatch(priceToPayload(price));
+
+        const patch: Partial<Preference> = {
+            seatPositionPref,
+            environmentPref,
+            moodPref,
+            obstructionSensitivity,
+            ...pricePatch,
+        };
+
+        updatePreference(1, patch);
+        updatePreference(2, patch);
+        updatePreference(3, patch);
     };
 
+    /* 시작하기 버튼 클릭 */
+    const handleNext = async () => {
+        if (!canSubmit) return;
+
+        applyOptionPatchToAllPrioritys(); // patch 적용
+
+        const seatPositionPref: SeatPositionPref = viewType ? SEAT_POSITION_MAP[viewType] : "ANY";
+        const environmentPref: EnvironmentPref = env ? ENV_MAP[env] : "ANY";
+        const moodPref: MoodPref = mood ? MOOD_MAP[mood] : "ANY";
+        const obstructionSensitivity: ObstructionSensitivity = dist ? OBSTRUCTION_MAP[dist] : "NORMAL";
+        const pricePatch = normalizePricePatch(priceToPayload(price));
+
+        const finalPreferences: Preference[] = preferences
+            .slice()
+            .sort((a, b) => a.priority - b.priority)
+            .map((p) => ({
+                ...p,
+                seatPositionPref,
+                environmentPref,
+                moodPref,
+                obstructionSensitivity,
+                ...pricePatch,
+            }));
+
+        const body = {
+            marketingConsent: { marketingAgreed: Boolean(marketingAgreed) },
+            preferences: finalPreferences,
+        };
+
+        console.log("body: ", body);
+
+        /* ===========================
+            API REQUEST
+        =========================== */
+        try {
+            const res = await fetch("/api/onboarding/preferences", { // 이부분 실제 api url로 수정 /onboarding/preferences ★
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${accessToken}`,
+                },
+                credentials: "include",
+                body: JSON.stringify(body),
+            })
+
+            /* 명세: 401 / 403 / 409 */
+            if (res.status === 401) { // 인증 실패
+                router.replace("/auth/login");
+                return;
+            }
+
+            if (res.status === 403) { // 계정 상태 DEACTIVE
+                router.replace("/auth/login");
+                return;
+            }
+
+            if (res.status === 409) { // 이미 온보딩 완료
+                router.replace("/");
+                return;
+            }
+
+            if (!res.ok) {
+                const err = await res.json().catch(() => null);
+                console.error("❌ onboarding/preferences failed:", res.status, err);
+                return;
+            }
+            const json = await res.json().catch(() => null);
+            console.log("✅ onboarding/preferences success:", json);
+
+            setIsFinishing(true);
+            router.replace("/"); // 홈 으로 이동
+            setTimeout(() => reset(), 0); // 완료 후 초기화
+
+        } catch (e) { console.error("⚠️ onboarding/preferences error:", e); }
+
+    }
+
+
     /* 건너뛰기 버튼 클릭 */
-    const handleSkip = () => {
-        console.log("handleskip click");
-        //router.push("/");
+    const handleSkip = async () => {
+        await handleNext();
     }
 
     return (
@@ -205,10 +379,21 @@ export default function SeatStyleOnboardingOptionPage() {
                                 {/* Section 5 */}
                                 <section className="self-stretch flex flex-col items-start gap-4">
                                     <div className="self-stretch flex flex-col items-start gap-1.5">
-                                        <div className="self-stretch inline-flex items-start gap-2">
+                                        <div className="self-stretch inline-flex items-center gap-1">
                                             <div className="text-base sm:text-lg font-semibold leading-6 text-black">
                                                 좌석 가격은 어떤 가격대를 원하시나요?
                                             </div>
+                                            <InfoTooltip
+                                                ariaLabel="가격 안내"
+                                                content={
+                                                    <ul className="list-disc pl-4 text-sm leading-5 text-[var(--light-foreground,#111)] space-y-1">
+                                                        <li>~ 13,000원: 외야석 중심</li>
+                                                        <li>14,000원 ~ 17,000원: 내야 저가 / 외야 상단</li>
+                                                        <li>18,000원 ~ 29,000원: 내야 일반석</li>
+                                                        <li>30,000원 ~ : 테이블석 / 프리미엄</li>
+                                                    </ul>
+                                                }
+                                            />
                                         </div>
                                         <div className="self-stretch inline-flex items-center gap-2">
                                             <div className="flex-1 text-sm font-medium leading-5 text-black">

--- a/goorm-gongbang/app/onboarding/page.tsx
+++ b/goorm-gongbang/app/onboarding/page.tsx
@@ -102,32 +102,32 @@ function getPriority<T>(arr: T[], value: T) {
   return idx === -1 ? null : idx + 1; // 1, 2, 3
 }
 
+/* 서버 enum 매핑 */
+const VIEWPOINT_MAP: Record<ViewPreference, Viewpoint> = {
+  "중앙": "CENTER",
+  "1루 내야": "INFIELD_1B",
+  "3루 내야": "INFIELD_3B",
+  "외야(좌)": "OUTFIELD_L",
+  "외야(중)": "OUTFIELD_C",
+  "외야(우)": "OUTFIELD_R",
+};
+
+const SEAT_HEIGHT_MAP: Record<HeightPreference, SeatHeight> = {
+  "하단": "LOW",
+  "중단": "MID",
+  "상단": "HIGH",
+  "무관": "ANY",
+};
+
+const SECTION_MAP: Record<ZonePreference, Section> = {
+  "중앙쪽": "MIDDLE",
+  "중간": "CENTER_SIDE",
+  "코너(파울라인)": "CORNER",
+  "무관": "ANY",
+};
+
+
 export default function SeatStyleOnboardingPage() {
-  /* 서버 enum 매핑 */
-  const VIEWPOINT_MAP: Record<ViewPreference, Viewpoint> = {
-    "중앙": "CENTER",
-    "1루 내야": "INFIELD_1B",
-    "3루 내야": "INFIELD_3B",
-    "외야(좌)": "OUTFIELD_L",
-    "외야(중)": "OUTFIELD_C",
-    "외야(우)": "OUTFIELD_R",
-  };
-
-  const SEAT_HEIGHT_MAP: Record<HeightPreference, SeatHeight> = {
-    "하단": "LOW",
-    "중단": "MID",
-    "상단": "HIGH",
-    "무관": "ANY",
-  };
-
-  const SECTION_MAP: Record<ZonePreference, Section> = {
-    "중앙쪽": "MIDDLE",
-    "중간": "CENTER_SIDE",
-    "코너(파울라인)": "CORNER",
-    "무관": "ANY",
-  };
-
-
   const router = useRouter();
   const pathname = usePathname();
   const sp = useSearchParams();
@@ -391,7 +391,7 @@ export default function SeatStyleOnboardingPage() {
 
             {/* Bottom CTA */}
             <div className="self-stretch flex flex-col items-end gap-2 pt-6">
-              <PrimaryButton 
+              <PrimaryButton
                 uiSize="lg"
                 tone="base"
                 onClick={handleNext}

--- a/goorm-gongbang/app/onboarding/page.tsx
+++ b/goorm-gongbang/app/onboarding/page.tsx
@@ -18,8 +18,8 @@ const viewOptions: ViewPreference[] = ["중앙", "1루 내야", "3루 내야", "
 const heightOptions: HeightPreference[] = ["하단", "중단", "상단", "무관"];
 const zoneOptions: ZonePreference[] = ["중앙쪽", "중간", "코너(파울라인)", "무관"];
 
-/* Rank Badge */
-function RankBadge({ n }: { n: number }) {
+/* priority Badge */
+function PriorityBadge({ n }: { n: number }) {
   return (
     <div className="px-1.5 bg-[var(--foundation-primary-700)] rounded-[100px] inline-flex flex-col justify-center items-center overflow-hidden">
       <div className="text-[var(--foundation-primary-10)] text-xs font-normal font-['Pretendard'] leading-4">
@@ -30,19 +30,19 @@ function RankBadge({ n }: { n: number }) {
 }
 
 /* Chip  */
-function Chip({ label, rank, onClick }: {
+function Chip({ label, priority, onClick }: {
   label: string; // 글자 데이터
-  rank: number | null;
+  priority: number | null;
   onClick: () => void;
 }) {
   return (
     <ChipButton
       uiSize="lg"
-      tone={rank ? "strong" : "soft"}
+      tone={priority ? "strong" : "soft"}
       onClick={onClick}
-      aria-pressed={Boolean(rank)}
-      leftIcon={rank ? <RankBadge n={rank} /> : undefined}
-      className={rank ? "gap-2" : ""}
+      aria-pressed={Boolean(priority)}
+      leftIcon={priority ? <PriorityBadge n={priority} /> : undefined}
+      className={priority ? "gap-2" : ""}
     >
       {label}
     </ChipButton>
@@ -97,7 +97,7 @@ function toggleUpToThree<T>(prev: T[], value: T) {
   return [...prev, value];
 }
 
-function getRank<T>(arr: T[], value: T) {
+function getPriority<T>(arr: T[], value: T) {
   const idx = arr.indexOf(value);
   return idx === -1 ? null : idx + 1; // 1, 2, 3
 }
@@ -225,7 +225,7 @@ export default function SeatStyleOnboardingPage() {
     if (!canGoNext) return;
 
     const basePrefs: PreferenceBase[] = [0, 1, 2].map((i) => ({
-      rank: (i + 1) as 1 | 2 | 3,
+      priority: (i + 1) as 1 | 2 | 3,
       viewpoint: VIEWPOINT_MAP[view[i]],
       seatHeight: SEAT_HEIGHT_MAP[height[i]],
       section: SECTION_MAP[zone[i]],
@@ -309,7 +309,7 @@ export default function SeatStyleOnboardingPage() {
 
                   <div className="self-stretch inline-flex items-center gap-1.5 flex-wrap">
                     {viewOptions.map((opt) => (
-                      <Chip key={opt} label={opt} rank={getRank(view, opt)} onClick={() => setView((prev) => toggleUpToThree(prev, opt))} />
+                      <Chip key={opt} label={opt} priority={getPriority(view, opt)} onClick={() => setView((prev) => toggleUpToThree(prev, opt))} />
                     ))}
                   </div>
                 </section>
@@ -337,7 +337,7 @@ export default function SeatStyleOnboardingPage() {
 
                   <div className="self-stretch inline-flex items-center gap-1.5 flex-wrap">
                     {heightOptions.map((opt) => (
-                      <Chip key={opt} label={opt} rank={getRank(height, opt)} onClick={() => setHeight((prev) => toggleUpToThree(prev, opt))} />
+                      <Chip key={opt} label={opt} priority={getPriority(height, opt)} onClick={() => setHeight((prev) => toggleUpToThree(prev, opt))} />
                     ))}
                   </div>
                 </section>
@@ -365,7 +365,7 @@ export default function SeatStyleOnboardingPage() {
 
                   <div className="self-stretch inline-flex items-center gap-1.5 flex-wrap">
                     {zoneOptions.map((opt) => (
-                      <Chip key={opt} label={opt} rank={getRank(zone, opt)} onClick={() => setZone((prev) => toggleUpToThree(prev, opt))} />
+                      <Chip key={opt} label={opt} priority={getPriority(zone, opt)} onClick={() => setZone((prev) => toggleUpToThree(prev, opt))} />
                     ))}
                   </div>
                 </section>

--- a/goorm-gongbang/components/common/ButtonReload.tsx
+++ b/goorm-gongbang/components/common/ButtonReload.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { RotateCw, type LucideProps } from "lucide-react";
+
+type IconCircleState = "default" | "hover" | "pressed";
+
+type ButtonReloadProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  state?: IconCircleState;
+  icon?: React.ReactNode;
+  iconProps?: LucideProps;
+};
+
+const bgByState: Record<IconCircleState, string> = {
+  default: "bg-[var(--foundation-neutral-white)]",
+  hover: "bg-[var(--foundation-neutral-960)]",
+  pressed: "bg-[var(--foundation-neutral-940)]",
+};
+
+export function ButtonReload({
+  state = "default",
+  icon,
+  iconProps,
+  className,
+  type = "button",
+  ...props
+}: ButtonReloadProps) {
+  return (
+    <button
+      type={type}
+      className={cn(
+        "w-9 h-9 rounded-[100px] inline-flex justify-center items-center",
+        "outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-800)]",
+        bgByState[state],
+        className
+      )}
+      {...props}
+    >
+      <span className="w-4 h-4 inline-flex items-center justify-center">
+        {icon ?? (
+          <RotateCw
+            size={16}
+            strokeWidth={2}
+            className={cn("text-[var(--text-normal-n240)]", iconProps?.className)}
+            {...iconProps}
+          />
+        )}
+      </span>
+    </button>
+  );
+}

--- a/goorm-gongbang/components/common/ChipBlackButton.tsx
+++ b/goorm-gongbang/components/common/ChipBlackButton.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type ChipBlackVariant = "outlineStrong" | "outline" | "filled" | "dark";
+
+type ChipBlackButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: ChipBlackVariant;
+};
+
+const base =
+  "h-9 rounded-[100px] inline-flex justify-center items-center px-3 py-1.5 select-none";
+const baseText =
+  "text-center justify-center text-xs leading-5 font-['Pretendard']";
+
+const variants: Record<
+  ChipBlackVariant,
+  { wrap: string; text: string }
+> = {
+  // 1) bg white + outline neutral-800 + text normal
+  outlineStrong: {
+    wrap:
+      "bg-[var(--foundation-neutral-white)] outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-800)]",
+    text: "text-[var(--foundation-neutral-240)] font-normal",
+  },
+
+  // 2) bg white + outline neutral-640 + text normal
+  outline: {
+    wrap:
+      "bg-[var(--foundation-neutral-white)] outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-640)]",
+    text: "text-[var(--foundation-neutral-240)] font-normal",
+  },
+
+  // 3) bg neutral-60 + outline neutral-60 + text white (medium, leading-4)
+  filled: {
+    wrap:
+      "bg-[var(--foundation-neutral-60)] outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-60)]",
+    text: "text-[var(--foundation-neutral-white)] font-medium leading-4",
+  },
+
+  // 4) bg neutral-960 + text neutral-760 (no outline)
+  dark: {
+    wrap: "bg-[var(--foundation-neutral-960)]",
+    text: "text-[var(--foundation-neutral-760)] font-normal",
+  },
+};
+
+export function ChipBlackButton({
+  variant = "outlineStrong",
+  className,
+  children = "Button",
+  type = "button",
+  ...props
+}: ChipBlackButtonProps) {
+  const v = variants[variant];
+
+  return (
+    <button
+      type={type}
+      className={cn(base, v.wrap, className)}
+      {...props}
+    >
+      <span className={cn(baseText, v.text)}>{children}</span>
+    </button>
+  );
+}

--- a/goorm-gongbang/components/common/ChipDropButton.tsx
+++ b/goorm-gongbang/components/common/ChipDropButton.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { TriangleDownIcon } from "@radix-ui/react-icons";
+
+type Variant = "neutral" | "primary";
+type UIState = "default" | "hover" | "disabled";
+
+type Props = {
+    label: string;
+    variant?: Variant;
+    uiState?: UIState;
+    leftIcon?: React.ReactNode;
+    showChevron?: boolean;
+    onClick?: () => void;
+    className?: string;
+};
+
+function getContainerStyles(variant: Variant, uiState: UIState) {
+    // 기본값들
+    const base =
+        "min-w-20 px-4 py-2 rounded-lg outline outline-1 outline-offset-[-1px] inline-flex justify-center items-center";
+
+    // 배경/아웃라인 토큰은 네가 준 그대로 매핑
+    if (uiState === "disabled") {
+        return cn(
+            base,
+            "bg-[var(--foundation-neutral-white)]",
+            "outline-[var(--foundation-neutral-900)]"
+        );
+    }
+
+    if (uiState === "hover") {
+        return cn(
+            base,
+            "bg-[var(--foundation-neutral-960)]",
+            "outline-[var(--foundation-neutral-760)]"
+        );
+    }
+
+    // default
+    if (variant === "primary") {
+        return cn(base, "bg-[var(--foundation-primary-10)]", "outline-[var(--foundation-primary-500)]");
+    }
+    return cn(base, "bg-[var(--foundation-neutral-white)]", "outline-[var(--foundation-neutral-800)]");
+}
+
+function getLabelStyles(variant: Variant, uiState: UIState) {
+    const base = "text-center justify-center text-sm font-normal font-['Pretendard'] leading-5";
+
+    if (uiState === "disabled") {
+        return cn(base, "text-[var(--foundation-neutral-720)]");
+    }
+
+    if (variant === "primary") {
+        return cn(base, "text-[var(--foundation-primary-700)]");
+    }
+
+    return cn(base, "text-[var(--foundation-neutral-240)]");
+}
+
+/* 왼쪽 아이콘 자리 */
+function LeftIconSlot({
+    children,
+    uiState,
+}: {
+    children: React.ReactNode;
+    uiState: UIState;
+}) {
+    const iconColor =
+        uiState === "disabled"
+            ? "text-[var(--foundation-neutral-900)]"
+            : "text-[var(--foundation-primary-500)]";
+
+    return (
+        <div className="w-6 h-6 pr-1 flex justify-start items-center gap-2.5">
+            <div className="flex-1 self-stretch relative overflow-hidden">
+                {children ? (
+                    <div className={cn("absolute inset-0 flex items-center justify-center", iconColor)}>
+                        {children}
+                    </div>
+                ) : null}
+            </div>
+        </div>
+    );
+}
+
+export function ChipDropButton({
+    label,
+    variant = "neutral",
+    uiState = "default",
+    leftIcon,
+    showChevron = true,
+    onClick,
+    className,
+}: Props) {
+    const disabled = uiState === "disabled";
+
+    return (
+        <button
+            type="button"
+            disabled={disabled}
+            onClick={disabled ? undefined : onClick}
+            className={cn(getContainerStyles(variant, uiState), className)}
+        >
+            {/* Left icon (optional) */}
+            {leftIcon ? <LeftIconSlot uiState={uiState}>{leftIcon}</LeftIconSlot> : null}
+
+            {/* Label */}
+            <div className="flex justify-center items-center gap-2.5">
+                <div className={getLabelStyles(variant, uiState)}>{label}</div>
+            </div>
+
+            {/* TriangleDownIcon */}
+            {showChevron ? (
+                <div className="pl-2 flex justify-start items-center gap-2.5">
+                    <TriangleDownIcon
+                        className={cn(
+                            "h-4 w-4",
+                            uiState === "disabled"
+                                ? "text-[var(--foundation-neutral-900)]"
+                                : "text-[var(--foundation-primary-400)]"
+                        )}
+                    />
+                </div>
+            ) : null}
+        </button>
+    );
+}

--- a/goorm-gongbang/components/common/DropDown.tsx
+++ b/goorm-gongbang/components/common/DropDown.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { ChevronDown } from "lucide-react";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+type Props = {
+    value: number;
+    onChange: (next: number) => void;
+
+    /** 1~max 까지 옵션 생성 */
+    max?: number;
+
+    /** Trigger 스타일 커스텀 */
+    className?: string;
+
+    /** Dropdown content 클래스 추가 */
+    contentClassName?: string;
+
+    /** 비활성화 */
+    disabled?: boolean;
+
+    /** aria-label */
+    ariaLabel?: string;
+};
+
+export function DropDown({
+    value,
+    onChange,
+    max = 10,
+    className,
+    contentClassName,
+    disabled = false,
+    ariaLabel = "값 선택",
+}: Props) {
+    const options = React.useMemo(() => {
+        const m = Math.max(1, Math.floor(max));
+        return Array.from({ length: m }, (_, i) => i + 1);
+    }, [max]);
+
+    const safeValue = React.useMemo(() => {
+        const m = Math.max(1, Math.floor(max));
+        return Math.min(Math.max(1, Math.floor(value)), m);
+    }, [value, max]);
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild disabled={disabled}>
+                <button
+                    type="button"
+                    aria-label={ariaLabel}
+                    className={cn(
+                        "w-20 h-10 px-2 bg-[var(--foundation-neutral-white)] rounded-md",
+                        "outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-880)]",
+                        "inline-flex justify-end items-center gap-4",
+                        disabled && "opacity-60 cursor-not-allowed",
+                        className
+                    )}
+                >
+                    <span className="flex-1 p-2 flex justify-end items-center gap-4">
+                        <span className="text-right justify-center text-[var(--foundation-neutral-200)] text-base font-medium font-['Pretendard'] leading-6">
+                            {safeValue}
+                        </span>
+
+                        <ChevronDown className="h-4 w-4 text-[var(--light-foreground)]" aria-hidden="true" />
+                    </span>
+                </button>
+            </DropdownMenuTrigger>
+
+            <DropdownMenuContent
+                align="end"
+                className={cn(
+                    "w-20 p-0 bg-[var(--foundation-neutral-white)] rounded-md",
+                    "outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-880)]",
+                    "max-h-56 overflow-y-auto",
+                    "thin-scrollbar",
+                    contentClassName
+                )}
+            >
+                <div className="self-stretch h-px my-1 border border-[var(--foundation-neutral-880)]" />
+
+                {options.map((n) => {
+                    const selected = n === safeValue;
+                    return (
+                        <DropdownMenuItem
+                            key={n}
+                            onSelect={() => onChange(n)}
+                            className={cn(
+                                "p-2 flex justify-end items-center gap-4",
+                                "text-Text-normal(N240) text-base font-medium font-['Pretendard'] leading-6",
+                                selected && "bg-[var(--foundation-neutral-920)]",
+                                "focus:bg-[var(--foundation-neutral-920)]"
+                            )}
+                        >
+                            <span className="w-full text-right">{n}</span>
+                        </DropdownMenuItem>
+                    );
+                })}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}

--- a/goorm-gongbang/components/common/InfoTooltip.tsx
+++ b/goorm-gongbang/components/common/InfoTooltip.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Info } from "lucide-react";
+
+type InfoTooltipProps = {
+    /** 툴팁 안에 들어갈 내용 */
+    content: React.ReactNode;
+    /** 버튼 접근성 라벨 */
+    ariaLabel?: string;
+    /** 툴팁 가로폭 */
+    widthClassName?: string;
+    /** 툴팁 세로폭 */
+    heightClassName?: string;
+    /** 아이콘 색상 */
+    iconClassName?: string;
+    /** 아이콘 클릭 시 색상 */
+    activeIconClassName?: string;
+    /** (옵션) 바깥에서 열기/닫기 제어하고 싶을 때 */
+    defaultOpen?: boolean;
+};
+
+export function InfoTooltip({
+    content,
+    ariaLabel = "안내",
+    widthClassName = "w-[299px]",
+    heightClassName = "h-[120px]",
+    iconClassName = "text-[var(--foundation-neutral-600,#999999)]",
+    activeIconClassName = "text-[var(--foundation-primary-500,#00C292)]",
+    defaultOpen = false,
+}: InfoTooltipProps) {
+    const [open, setOpen] = useState(defaultOpen);
+    const wrapRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        const onDown = (e: MouseEvent) => {
+            if (!wrapRef.current) return;
+            if (!wrapRef.current.contains(e.target as Node)) setOpen(false);
+        };
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") setOpen(false);
+        };
+
+        document.addEventListener("mousedown", onDown);
+        document.addEventListener("keydown", onKey);
+        return () => {
+            document.removeEventListener("mousedown", onDown);
+            document.removeEventListener("keydown", onKey);
+        };
+    }, []);
+
+    return (
+        <div ref={wrapRef} className="relative inline-flex items-center">
+            <button
+                type="button"
+                aria-label={ariaLabel}
+                aria-haspopup="dialog"
+                aria-expanded={open}
+                onClick={() => setOpen((v) => !v)}
+                className="inline-flex h-6 w-6 items-center justify-center rounded-md hover:bg-black/5"
+            >
+                <Info 
+                    className={[
+                        "h-4 w-4 transition",
+                        open ? activeIconClassName : iconClassName,
+                    ].join(" ")}
+                />
+            </button>
+
+            {open && (
+                <div
+                    role="dialog"
+                    aria-label={`${ariaLabel} 툴팁`}
+                    className={`
+                        absolute left-full ml-2 top-1/2 -translate-y-1/2 z-50
+                        ${widthClassName}
+                        ${heightClassName}
+                        rounded-lg bg-[var(--light-background,#fff)]
+                        shadow-[0px_1px_3px_0px_rgba(0,0,0,0.05)]
+                        outline outline-1 outline-offset-[-1px] outline-[var(--light-border,#E6E6E6)]
+                        p-4
+                    `}
+                >
+                    {/* 화살표(왼쪽 방향) */}
+                    <div
+                        className="
+                            absolute -left-2 top-1/2 -translate-y-1/2
+                            h-0 w-0
+                            border-y-8 border-y-transparent
+                            border-r-8 border-r-[var(--light-border,#E6E6E6)]
+                        "
+                    />
+                    <div
+                        className="
+                            absolute -left-[7px] top-1/2 -translate-y-1/2
+                            h-0 w-0
+                            border-y-[7px] border-y-transparent
+                            border-r-[7px] border-r-[var(--light-background,#fff)]
+                        "
+                    />
+                    <div className="w-full h-full text-left break-words">
+                        {content}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/goorm-gongbang/components/common/InfoTooltip.tsx
+++ b/goorm-gongbang/components/common/InfoTooltip.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { Info } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 type InfoTooltipProps = {
     /** 툴팁 안에 들어갈 내용 */
@@ -60,10 +61,10 @@ export function InfoTooltip({
                 className="inline-flex h-6 w-6 items-center justify-center rounded-md hover:bg-black/5"
             >
                 <Info 
-                    className={[
+                    className={cn(
                         "h-4 w-4 transition",
-                        open ? activeIconClassName : iconClassName,
-                    ].join(" ")}
+                        open ? activeIconClassName : iconClassName
+                    )}
                 />
             </button>
 

--- a/goorm-gongbang/components/common/RankChipButton.tsx
+++ b/goorm-gongbang/components/common/RankChipButton.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type Rank = 1 | 2 | 3 | 4 | 5;
+
+type RankChipProps = React.HTMLAttributes<HTMLDivElement> & {
+  rank: Rank;
+  label?: string; // 기본: `${rank}순위`
+};
+
+const rankStyles: Record<
+  Rank,
+  { bg: string; outline: string; text: string }
+> = {
+  1: {
+    bg: "bg-[var(--foundation-secondary-400)]",
+    outline: "outline-[var(--foundation-secondary-300)]",
+    text: "text-[var(--foundation-neutral-white)]",
+  },
+  2: {
+    bg: "bg-[var(--foundation-primary-500)]",
+    outline: "outline-[var(--foundation-primary-400)]",
+    text: "text-[var(--foundation-neutral-white)]",
+  },
+  3: {
+    bg: "bg-[var(--foundation-yellow-500)]",
+    outline: "outline-[var(--foundation-yellow-400)]",
+    text: "text-[var(--foundation-neutral-white)]",
+  },
+  4: {
+    bg: "bg-[var(--foundation-orange-500)]",
+    outline: "outline-[var(--foundation-orange-400)]",
+    text: "text-[var(--foundation-neutral-white)]",
+  },
+  5: {
+    bg: "bg-[var(--foundation-red-500)]",
+    outline: "outline-[var(--foundation-red-400)]",
+    text: "text-[var(--foundation-neutral-white)]",
+  },
+};
+
+export function RankChipButton({
+  rank,
+  label,
+  className,
+  ...props
+}: RankChipProps) {
+  const s = rankStyles[rank];
+  const text = label ?? `${rank}순위`;
+
+  return (
+    <div
+      className={cn(
+        "h-6 rounded-[100px] p-2 inline-flex items-center justify-center",
+        "outline outline-1 outline-offset-[-1px]",
+        s.bg,
+        s.outline,
+        className
+      )}
+      {...props}
+    >
+      <div
+        className={cn(
+          "text-center text-xs font-semibold leading-5",
+          "font-['Pretendard']",
+          s.text
+        )}
+      >
+        {text}
+      </div>
+    </div>
+  );
+}

--- a/goorm-gongbang/components/common/SeatPreferenceRecommendCard.tsx
+++ b/goorm-gongbang/components/common/SeatPreferenceRecommendCard.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { Toggle } from "@/components/common/Toggle";
+import { DropDown } from "@/components/common/DropDown"
+
+type Props = {
+  enabled: boolean;
+  onChange: (next: boolean) => void;
+  className?: string;
+};
+
+export function SeatPreferenceRecommendCard({
+  enabled,
+  onChange,
+  className,
+}: Props) {
+
+  const [people, setPeople] = useState(2);
+
+  return (
+    <div
+      className={cn(
+        "w-96 px-6 py-4 bg-[var(--foundation-neutral-white)] rounded-2xl",
+        "outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-880)]",
+        "inline-flex flex-col justify-start items-start gap-2",
+        className
+      )}
+    >
+      {/* Header */}
+      <div className="self-stretch h-8 inline-flex justify-between items-center">
+        <div className="flex justify-center items-center gap-2">
+          <div className="justify-center text-[var(--foundation-neutral-black)] text-base font-semibold font-['Pretendard'] leading-6">
+            사용자 선호 좌석 추천
+          </div>
+        </div>
+
+        <Toggle checked={enabled} onCheckedChange={onChange} />
+      </div>
+
+      {/* 토글 ON일 때만 아래 영역 표시 */}
+      {enabled && (
+        <>
+          {/* Divider */}
+          <div className="self-stretch h-0 outline outline-1 outline-offset-[-0.50px] outline-[var(--foundation-neutral-840)]" />
+
+          {/* People count row */}
+          <div className="self-stretch inline-flex justify-between items-center">
+            <div className="flex justify-center items-center gap-2">
+              <div className="justify-center text-[var(--foundation-neutral-240)] text-base font-semibold font-['Pretendard'] leading-6">
+                인원 수
+              </div>
+            </div>
+
+            <DropDown value={people} onChange={setPeople} max={10} />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/goorm-gongbang/components/common/SeatRecommendSummaryCard.tsx
+++ b/goorm-gongbang/components/common/SeatRecommendSummaryCard.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type Variant = "default" | "hover" | "focused";
+
+type SeatLine = {
+    left: string;   // "000석 000블럭 00열 00번, 00번"
+    right: string;  // "0원/매"
+};
+
+type Props = {
+    variant?: Variant;
+
+    orderLabel?: string;        // "1순위"
+    totalPriceText: string;     // "총 0원"
+
+    seats: SeatLine[];          // 1~N 줄
+    tags: string[];             // "# 1루 내야" 등
+
+    className?: string;
+};
+
+function getCardStyles(variant: Variant) {
+    const base =
+        "w-96 p-6 rounded-lg shadow-[0px_1px_3px_0px_rgba(0,0,0,0.05)] outline outline-1 outline-offset-[-1px] inline-flex flex-col justify-start items-start gap-3 overflow-hidden";
+
+    if (variant === "hover") {
+        return cn(base, "bg-[var(--foundation-neutral-980)]", "outline-[var(--foundation-neutral-760)]");
+    }
+
+    if (variant === "focused") {
+        return cn(
+            base,
+            "bg-gradient-to-b from-[var(--foundation-primary-10)] to-white",
+            "outline-[var(--foundation-primary-500)]"
+        );
+    }
+
+    // default
+    return cn(base, "bg-[var(--foundation-neutral-white)]", "outline-[var(--foundation-neutral-880)]");
+}
+
+function OrderBadge({ label }: { label: string }) {
+    return (
+        <div
+            data-order={label}
+            className="h-6 p-2 bg-[var(--foundation-secondary-400)] rounded-[100px] outline outline-1 outline-offset-[-1px] outline-[var(--foundation-secondary-300)] flex justify-center items-center"
+        >
+            <div className="text-center justify-center text-[var(--foundation-neutral-white)] text-xs font-semibold font-['Pretendard'] leading-5">
+                {label}
+            </div>
+        </div>
+    );
+}
+
+function TagChip({ text }: { text: string }) {
+    return (
+        <div
+            data-icon="off"
+            data-size="Small"
+            data-state="Selected"
+            className="h-6 min-w-14 p-2 bg-[var(--foundation-primary-10)] rounded-[100px] outline outline-1 outline-offset-[-1px] outline-[var(--foundation-primary-500)] flex justify-center items-center"
+        >
+            <div className="flex-1 text-center justify-center text-[var(--foundation-primary-700)] text-xs font-normal font-['Pretendard'] leading-5">
+                {text}
+            </div>
+        </div>
+    );
+}
+
+export function SeatRecommendSummaryCard({
+    variant = "default",
+    orderLabel = "1순위",
+    totalPriceText,
+    seats,
+    tags,
+    className,
+}: Props) {
+    return (
+        <div className={cn(getCardStyles(variant), className)}>
+            {/* Top area */}
+            <div className="self-stretch flex flex-col justify-start items-start gap-0.5">
+                <div className="self-stretch inline-flex justify-start items-center gap-2">
+                    <OrderBadge label={orderLabel} />
+                    <div className="flex-1 justify-center text-[var(--foundation-neutral-160)] text-xl font-bold font-['Pretendard'] leading-7">
+                        {totalPriceText}
+                    </div>
+                </div>
+
+                {seats.map((line, idx) => (
+                    <div key={idx} className="self-stretch inline-flex justify-start items-start">
+                        <div className="justify-center text-[var(--foundation-neutral-240)] text-sm font-semibold font-['Pretendard'] leading-5">
+                            {line.left}
+                        </div>
+                        <div className="flex-1 text-right justify-center text-[var(--foundation-neutral-240)] text-sm font-medium font-['Pretendard'] leading-5">
+                            {line.right}
+                        </div>
+                    </div>
+                ))}
+            </div>
+
+            {/* Tags */}
+            <div className="w-80 inline-flex justify-end items-start gap-2 flex-wrap content-start">
+                {tags.map((t, i) => (
+                    <TagChip key={`${t}-${i}`} text={t} />
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/goorm-gongbang/components/common/TicketingNavigator.tsx
+++ b/goorm-gongbang/components/common/TicketingNavigator.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type StepKey = "seat" | "order" | "pay";
+
+type TicketingNavigatorProps = {
+  active: StepKey;
+  className?: string;
+};
+
+const steps: { key: StepKey; label: string }[] = [
+  { key: "seat", label: "좌석 선택" },
+  { key: "order", label: "주문서" },
+  { key: "pay", label: "결제하기" },
+];
+
+const baseText =
+  "text-center justify-center text-sm leading-5 font-['Pretendard']";
+const strongText = "text-[var(--foundation-neutral-160)] font-semibold";
+const infoText = "text-[var(--foundation-neutral-600)] font-normal";
+
+export function TicketingNavigator({ active, className }: TicketingNavigatorProps) {
+  return (
+    <div className={cn("inline-flex justify-start items-center gap-2", className)}>
+      {steps.map((s, idx) => {
+        const isActive = s.key === active;
+
+        return (
+          <React.Fragment key={s.key}>
+            <div className="flex justify-center items-center gap-2">
+              <div className={cn(baseText, isActive ? strongText : infoText)}>
+                {s.label}
+              </div>
+            </div>
+
+            {idx !== steps.length - 1 && (
+              <div className={cn(baseText, infoText)}>&gt;</div>
+            )}
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+}

--- a/goorm-gongbang/components/common/Toggle.tsx
+++ b/goorm-gongbang/components/common/Toggle.tsx
@@ -1,17 +1,21 @@
-import { Switch } from "@/components/ui/switch"
+"use client";
 
-export function Toggle() {
+import * as React from "react";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+
+type ToggleProps = React.ComponentProps<typeof Switch>;
+
+export function Toggle({ className, ...props }: ToggleProps) {
   return (
-    <div className="flex items-center space-x-2">
-      <Switch
-        id="switch-size-default"
-        size="default"
-        className="
-          data-[state=checked]:bg-[var(--foundation-primary-400)]
-          data-[state=unchecked]:bg-[var(--foundation-neutral-680)]
-        "
-      />
-    </div>
-  )
+    <Switch
+      {...props}
+      className={cn(
+        "w-9 h-5 rounded-[300px] overflow-hidden p-0",
+        "data-[state=checked]:bg-[var(--foundation-primary-400)]",
+        "data-[state=unchecked]:bg-[var(--foundation-neutral-680)]",
+        className
+      )}
+    />
+  );
 }
-

--- a/goorm-gongbang/components/layout/Header.tsx
+++ b/goorm-gongbang/components/layout/Header.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { User, Ticket } from "lucide-react";
+
+type Props = {
+  className?: string;
+
+  /** 초기 로그인 상태(옵션). 외부에서 제어하고 싶으면 아래 controlled props 사용 추천 */
+  defaultLoggedIn?: boolean;
+
+  /** controlled로 쓰고 싶을 때 */
+  loggedIn?: boolean;
+  onLoginClick?: () => void;
+  onMyInfoClick?: () => void;
+  onMyTicketClick?: () => void;
+};
+
+export function Header({
+  className,
+  defaultLoggedIn = false,
+  loggedIn,
+  onLoginClick,
+  onMyInfoClick,
+  onMyTicketClick,
+}: Props) {
+  // uncontrolled fallback
+  const [internalLoggedIn, setInternalLoggedIn] = React.useState(defaultLoggedIn);
+  const isLoggedIn = loggedIn ?? internalLoggedIn;
+
+  const handleLogin = () => {
+    onLoginClick?.();
+    if (loggedIn === undefined) setInternalLoggedIn(true);
+  };
+
+  return (
+    <div
+      className={cn(
+        "w-full self-stretch h-12 px-8 bg-[var(--foundation-neutral-980)] inline-flex justify-between items-center",
+        className
+      )}
+    >
+      {/* Logo */}
+      <div className="self-stretch flex justify-start items-center">
+        <div className="justify-start text-gray-900 text-lg font-bold font-['Pretendard'] leading-9">
+          Pyo
+        </div>
+        <div className="justify-start text-emerald-500 text-lg font-bold font-['Pretendard'] leading-9">
+          Go
+        </div>
+      </div>
+
+      {/* Right area */}
+      {!isLoggedIn ? (
+        // 로그인 버튼 상태
+        <button
+          type="button"
+          onClick={handleLogin}
+          className={cn(
+            "h-6 min-w-14 p-2 bg-[var(--foundation-primary-500)] rounded-md",
+            "flex justify-center items-center"
+          )}
+        >
+          <span className="flex-1 text-center justify-center text-[var(--foundation-neutral-white)] text-xs font-medium font-['Pretendard'] leading-5 cursor-pointer">
+            로그인
+          </span>
+        </button>
+      ) : (
+        // 로그인 후 메뉴 상태
+        <div className="flex justify-start items-center gap-8">
+          <button
+            type="button"
+            onClick={onMyInfoClick}
+            className="w-20 h-6 flex justify-start items-center gap-2"
+          >
+            <User className="w-5 h-5 text-gray-700" aria-hidden="true" />
+            <div className="flex-1 flex justify-center items-center gap-2">
+              <div className="justify-start text-gray-700 text-sm font-medium font-['Pretendard'] leading-6">
+                내 정보
+              </div>
+            </div>
+          </button>
+
+          <button
+            type="button"
+            onClick={onMyTicketClick}
+            className="h-6 flex justify-start items-center gap-2"
+          >
+            <Ticket className="w-5 h-5 text-gray-700" aria-hidden="true" />
+            <div className="flex justify-center items-center gap-2">
+              <div className="justify-start text-gray-700 text-sm font-medium font-['Pretendard'] leading-6">
+                내 티켓
+              </div>
+            </div>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/goorm-gongbang/components/ui/dropdown-menu.tsx
+++ b/goorm-gongbang/components/ui/dropdown-menu.tsx
@@ -1,0 +1,257 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  )
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/goorm-gongbang/package-lock.json
+++ b/goorm-gongbang/package-lock.json
@@ -39,6 +39,7 @@
         "pino": "^10.3.0",
         "pino-http": "^11.0.0",
         "prom-client": "^15.1.3",
+        "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "sonner": "^2.0.7",
@@ -455,6 +456,44 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
+      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
+      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.4",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.7.tgz",
+      "integrity": "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.14.3",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
@@ -786,6 +825,111 @@
       "license": "MIT",
       "dependencies": {
         "fast-glob": "3.3.1"
+      }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.4.tgz",
+      "integrity": "sha512-T8atLKuvk13XQUdVLCv1ZzMPgLPW0+DWWbHSQXs0/3TjPrKNxTmUIhOEaoEyl3Z82k8h/gEtqyuoZGv6+Ugawg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.4.tgz",
+      "integrity": "sha512-AKC/qVjUGUQDSPI6gESTx0xOnOPQ5gttogNS3o6bA83yiaSZJek0Am5yXy82F1KcZCx3DdOwdGPZpQCluonuxg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.4.tgz",
+      "integrity": "sha512-POQ65+pnYOkZNdngWfMEt7r53bzWiKkVNbjpmCt1Zb3V6lxJNXSsjwRuTQ8P/kguxDC8LRkqaL3vvsFrce4dMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.4.tgz",
+      "integrity": "sha512-3Wm0zGYVCs6qDFAiSSDL+Z+r46EdtCv/2l+UlIdMbAq9hPJBvGu/rZOeuvCaIUjbArkmXac8HnTyQPJFzFWA0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.4.tgz",
+      "integrity": "sha512-lWAYAezFinaJiD5Gv8HDidtsZdT3CDaCeqoPoJjeB57OqzvMajpIhlZFce5sCAH6VuX4mdkxCRqecCJFwfm2nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.4.tgz",
+      "integrity": "sha512-fHaIpT7x4gA6VQbdEpYUXRGyge/YbRrkG6DXM60XiBqDM2g2NcrsQaIuj375egnGFkJow4RHacgBOEsHfGbiUw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.4.tgz",
+      "integrity": "sha512-MCrXxrTSE7jPN1NyXJr39E+aNFBrQZtO154LoCz7n99FuKqJDekgxipoodLNWdQP7/DZ5tKMc/efybx1l159hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
@@ -2384,11 +2528,190 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-accessible-icon": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.7.tgz",
+      "integrity": "sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
+      "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collapsible": "1.1.12",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-aspect-ratio": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.7.tgz",
+      "integrity": "sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
+      "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-checkbox": {
       "version": "1.3.3",
@@ -2416,6 +2739,80 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
+      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2450,6 +2847,281 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-context-menu": {
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz",
+      "integrity": "sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-form": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.8.tgz",
+      "integrity": "sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-label": "2.1.7",
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-form/node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.15.tgz",
+      "integrity": "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-icons": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.2.tgz",
@@ -2457,6 +3129,24 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-label": {
@@ -2489,6 +3179,307 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menubar": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.16.tgz",
+      "integrity": "sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.14.tgz",
+      "integrity": "sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-one-time-password-field": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.8.tgz",
+      "integrity": "sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-password-toggle-field": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.3.tgz",
+      "integrity": "sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-is-hydrated": "0.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2570,6 +3561,185 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
+      "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
+      "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-separator": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.8.tgz",
@@ -2600,6 +3770,39 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2663,6 +3866,243 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.15.tgz",
+      "integrity": "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
+      "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-toggle": "1.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toolbar": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.11.tgz",
+      "integrity": "sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-separator": "1.1.7",
+        "@radix-ui/react-toggle-group": "1.1.11"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toolbar/node_modules/@radix-ui/react-separator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-controllable-state": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
@@ -2689,6 +4129,42 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
+      "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.5.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2730,6 +4206,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-size": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
@@ -2747,6 +4241,35 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -3360,6 +4883,18 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
@@ -4034,6 +5569,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -4990,6 +6531,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -6889,6 +8439,147 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
+    "node_modules/radix-ui": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.4.3.tgz",
+      "integrity": "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-accessible-icon": "1.1.7",
+        "@radix-ui/react-accordion": "1.2.12",
+        "@radix-ui/react-alert-dialog": "1.1.15",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-aspect-ratio": "1.1.7",
+        "@radix-ui/react-avatar": "1.1.10",
+        "@radix-ui/react-checkbox": "1.3.3",
+        "@radix-ui/react-collapsible": "1.1.12",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-context-menu": "2.2.16",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-dropdown-menu": "2.1.16",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-form": "0.1.8",
+        "@radix-ui/react-hover-card": "1.1.15",
+        "@radix-ui/react-label": "2.1.7",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-menubar": "1.1.16",
+        "@radix-ui/react-navigation-menu": "1.2.14",
+        "@radix-ui/react-one-time-password-field": "0.1.8",
+        "@radix-ui/react-password-toggle-field": "0.1.3",
+        "@radix-ui/react-popover": "1.1.15",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-progress": "1.1.7",
+        "@radix-ui/react-radio-group": "1.3.8",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-scroll-area": "1.2.10",
+        "@radix-ui/react-select": "2.2.6",
+        "@radix-ui/react-separator": "1.1.7",
+        "@radix-ui/react-slider": "1.3.6",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-switch": "1.2.6",
+        "@radix-ui/react-tabs": "1.1.13",
+        "@radix-ui/react-toast": "1.2.15",
+        "@radix-ui/react-toggle": "1.1.10",
+        "@radix-ui/react-toggle-group": "1.1.11",
+        "@radix-ui/react-toolbar": "1.1.11",
+        "@radix-ui/react-tooltip": "1.2.8",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-escape-keydown": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-separator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react": {
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
@@ -6916,6 +8607,75 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/real-require": {
       "version": "0.2.0",
@@ -8142,6 +9902,58 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -8452,111 +10264,6 @@
         "use-sync-external-store": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.4.tgz",
-      "integrity": "sha512-T8atLKuvk13XQUdVLCv1ZzMPgLPW0+DWWbHSQXs0/3TjPrKNxTmUIhOEaoEyl3Z82k8h/gEtqyuoZGv6+Ugawg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.4.tgz",
-      "integrity": "sha512-AKC/qVjUGUQDSPI6gESTx0xOnOPQ5gttogNS3o6bA83yiaSZJek0Am5yXy82F1KcZCx3DdOwdGPZpQCluonuxg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.4.tgz",
-      "integrity": "sha512-POQ65+pnYOkZNdngWfMEt7r53bzWiKkVNbjpmCt1Zb3V6lxJNXSsjwRuTQ8P/kguxDC8LRkqaL3vvsFrce4dMQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.4.tgz",
-      "integrity": "sha512-3Wm0zGYVCs6qDFAiSSDL+Z+r46EdtCv/2l+UlIdMbAq9hPJBvGu/rZOeuvCaIUjbArkmXac8HnTyQPJFzFWA0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.4.tgz",
-      "integrity": "sha512-lWAYAezFinaJiD5Gv8HDidtsZdT3CDaCeqoPoJjeB57OqzvMajpIhlZFce5sCAH6VuX4mdkxCRqecCJFwfm2nQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.4.tgz",
-      "integrity": "sha512-fHaIpT7x4gA6VQbdEpYUXRGyge/YbRrkG6DXM60XiBqDM2g2NcrsQaIuj375egnGFkJow4RHacgBOEsHfGbiUw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.4.tgz",
-      "integrity": "sha512-MCrXxrTSE7jPN1NyXJr39E+aNFBrQZtO154LoCz7n99FuKqJDekgxipoodLNWdQP7/DZ5tKMc/efybx1l159hw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/goorm-gongbang/package.json
+++ b/goorm-gongbang/package.json
@@ -40,6 +40,7 @@
     "pino": "^10.3.0",
     "pino-http": "^11.0.0",
     "prom-client": "^15.1.3",
+    "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "sonner": "^2.0.7",

--- a/goorm-gongbang/stores/onboardingPrefStore.ts
+++ b/goorm-gongbang/stores/onboardingPrefStore.ts
@@ -11,7 +11,7 @@ export type ObstructionSensitivity = "NET_SENSITIVE" | "RAIL_PILLAR_SENSITIVE" |
 export type PriceMode = "ANY" | "RANGE";
 
 export type Preference = {
-    rank: 1 | 2 | 3;
+    priority: 1 | 2 | 3;
     viewpoint: Viewpoint;
     seatHeight: SeatHeight;
     section: Section;
@@ -22,12 +22,12 @@ export type Preference = {
     obstructionSensitivity: ObstructionSensitivity;
 
     priceMode: PriceMode;
-    priceMin?: number;
-    priceMax?: number;
+    priceMin?: number | null;
+    priceMax?: number | null;
 };
 
 /* 1단계에서 받는 값 */
-export type PreferenceBase = Pick<Preference, "rank" | "viewpoint" | "seatHeight" | "section">;
+export type PreferenceBase = Pick<Preference, "priority" | "viewpoint" | "seatHeight" | "section">;
 
 type OnboardingPrefState = {
     preferences: Preference[];
@@ -35,7 +35,7 @@ type OnboardingPrefState = {
 
     setBasePreferences: (prefs: PreferenceBase[]) => void;
     setMarketingAgreed: (v: boolean) => void;
-    updatePreference: (rank: 1 | 2 | 3, patch: Partial<Preference>) => void;
+    updatePreference: (priority: 1 | 2 | 3, patch: Partial<Preference>) => void;
     reset: () => void;
 };
 
@@ -46,12 +46,12 @@ export const useOnboardingPrefStore = create<OnboardingPrefState>()(
             marketingAgreed: false,
 
             setBasePreferences: (basePrefs) => {
-                // rank 정렬 + 중복 제거/검증
-                const sorted = [...basePrefs].sort((a, b) => a.rank - b.rank);
+                // priority 정렬 + 중복 제거/검증
+                const sorted = [...basePrefs].sort((a, b) => a.priority - b.priority);
 
-                // rank 1~3 모두 있는지 간단 체크(없으면 그냥 저장 안 함)
-                const ranks = new Set(sorted.map((p) => p.rank));
-                if (!(ranks.has(1) && ranks.has(2) && ranks.has(3))) {
+                // priority 1~3 모두 있는지 간단 체크(없으면 그냥 저장 안 함)
+                const prioritys = new Set(sorted.map((p) => p.priority));
+                if (!(prioritys.has(1) && prioritys.has(2) && prioritys.has(3))) {
                     console.warn("[onboardingPrefStore] invalid basePrefs:", basePrefs);
                     return;
                 }
@@ -76,9 +76,9 @@ export const useOnboardingPrefStore = create<OnboardingPrefState>()(
                 console.log("[onboardingPrefStore] after setMarketingAgreed:", get().marketingAgreed);
             },
 
-            updatePreference: (rank, patch) => {
+            updatePreference: (priority, patch) => {
                 const prev = get().preferences;
-                const next = prev.map((p) => (p.rank === rank ? { ...p, ...patch } : p));
+                const next = prev.map((p) => (p.priority === priority ? { ...p, ...patch } : p));
                 set({ preferences: next });
 
                 console.log("[onboardingPrefStore] after updatePreference:", get().preferences);


### PR DESCRIPTION
🔧 작업 내용

경기 예매 컴포넌트 UI/레이아웃 구현

예매 정보 요약 카드(총 금액/좌석 정보/태그) 컴포넌트화

인원 수 선택 드롭다운(shadcn DropdownMenu) 공통 컴포넌트 적용

칩 형태 드롭 버튼(좌측 아이콘/삼각형 아이콘 포함) 공통 컴포넌트 적용

🧩 구현 상세(선택)

Figma 토큰 기반(Foundation/Stroke/Background) 스타일 적용

상태별 스타일 분기 지원: default / hover / focused / disabled

드롭다운 옵션(1~max) 동적 생성 및 value 보정(clamp) 처리

📌 관련 Jira Issue

GBGB-97

🧪 테스트 방법(선택)

예매 페이지 진입 후 인원 수 드롭다운에서 1~max 선택 동작 확인

칩 드롭 버튼 disabled 상태에서 텍스트/아이콘 색상 변경 확인

예매 요약 카드에서 좌석 라인 1개/2개 이상 렌더링 확인

❗ 참고 사항

shadcn DropdownMenu 의존 컴포넌트 필요(dropdown-menu 설치 확인)

Radix Icons 사용 시 @radix-ui/react-icons 설치 필요

Fixes: #24