### PR TITLE
feat(GBGB-134-home-function): 홈 화면 기능 개발

### DIFF
--- a/goorm-gongbang/app/api/auth/logout/route.ts
+++ b/goorm-gongbang/app/api/auth/logout/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse } from "next/server";
+
+/** =========================
+ * Mock "Redis" (in-memory)
+ * key: refreshToken
+ * value: { accessToken, createdAt }
+ ========================= */
+declare global {
+  // eslint-disable-next-line no-var
+  var __REFRESH_TOKEN_MOCK__: Map<
+    string,
+    { accessToken: string; createdAt: string }
+  > | undefined;
+}
+
+function getStore() {
+  if (!global.__REFRESH_TOKEN_MOCK__) {
+    global.__REFRESH_TOKEN_MOCK__ = new Map();
+  }
+  return global.__REFRESH_TOKEN_MOCK__;
+}
+
+/** =========================
+ * Helpers
+ ========================= */
+function jsonError(status: number, message: string, code = "UNAUTHORIZED") {
+  return NextResponse.json({ code, message, data: null }, { status });
+}
+
+function getBearerToken(req: Request) {
+  const auth = req.headers.get("authorization") || req.headers.get("Authorization");
+  if (!auth) return null;
+  const m = auth.match(/^Bearer\s+(.+)$/i);
+  if (!m) return null;
+  return m[1].trim();
+}
+
+function getCookie(req: Request, name: string) {
+  const cookie = req.headers.get("cookie") || "";
+  const parts = cookie.split(";").map((v) => v.trim());
+  const found = parts.find((p) => p.startsWith(name + "="));
+  if (!found) return null;
+  return decodeURIComponent(found.slice(name.length + 1));
+}
+
+function buildDeleteCookie(name: string) {
+  const isProd = process.env.NODE_ENV === "production";
+  // 명세: 쿠키 삭제(예: Max-Age=0)
+  return [
+    `${name}=`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Lax",
+    // prod에서만 Secure 권장 (http 로컬에서 Secure면 쿠키가 안 박힐 수 있음)
+    isProd ? "Secure" : "",
+    "Max-Age=0",
+  ]
+    .filter(Boolean)
+    .join("; ");
+}
+
+/** =========================
+ * POST /api/auth/logout (MOCK)
+ ========================= */
+export async function POST(req: Request) {
+  // 1) Authorization 체크
+  const accessToken = getBearerToken(req);
+  if (!accessToken) {
+    return jsonError(401, "인증 실패 (Access Token 없음/만료)");
+  }
+
+  // 2) refreshToken 쿠키 읽기 (권장 입력)
+  const refreshToken = getCookie(req, "refreshToken");
+
+  // 3) (mock) Redis에서 refreshToken 폐기
+  if (refreshToken) {
+    const store = getStore();
+    store.delete(refreshToken);
+  }
+
+  // 4) 응답 + 쿠키 삭제
+  const res = NextResponse.json(
+    {
+      code: "OK",
+      message: "로그아웃 완료",
+      data: null,
+    },
+    { status: 200 }
+  );
+
+  res.headers.append("Set-Cookie", buildDeleteCookie("refreshToken"));
+
+  return res;
+}

--- a/goorm-gongbang/app/api/clubs/route.ts
+++ b/goorm-gongbang/app/api/clubs/route.ts
@@ -1,0 +1,121 @@
+// app/api/clubs/route.ts
+import { NextResponse } from "next/server";
+
+type ApiResponse<T> = {
+  code: string;
+  message: string;
+  data: T;
+};
+
+type ApiClub = {
+  clubId: number;
+  koName: string;
+  enName: string;
+  logoImg: string;
+  clubColor: string;
+};
+
+type TeamsPayload = {
+  clubs: ApiClub[];
+};
+
+const MOCK_CLUBS: ApiClub[] = [
+  {
+    clubId: 1,
+    koName: "두산 베어스",
+    enName: "Doosan Bears",
+    logoImg: "/doosan-bears.png",
+    clubColor: "#121130",
+  },
+  {
+    clubId: 2,
+    koName: "삼성 라이온즈",
+    enName: "Samsung Lions",
+    logoImg: "samsung-lions.png",
+    clubColor: "#0472C4",
+  },
+  {
+    clubId: 3,
+    koName: "키움 히어로즈",
+    enName: "Kiwoom Heroes",
+    logoImg: "kiwoom-heroes.png",
+    clubColor: "#6C1126",
+  },
+  {
+    clubId: 4,
+    koName: "한화 이글스",
+    enName: "Hanwha Eagles",
+    logoImg: "hanwha-eagles.png",
+    clubColor: "#E27032",
+  },
+  {
+    clubId: 5,
+    koName: "롯데 자이언츠",
+    enName: "Lotte Giants",
+    logoImg: "lotte-giants.png",
+    clubColor: "#072C5A",
+  },
+  {
+    clubId: 6,
+    koName: "LG 트윈스",
+    enName: "LG Twins",
+    logoImg: "lg-twins.png",
+    clubColor: "#A32C41",
+  },
+  {
+    clubId: 7,
+    koName: "NC 다이노스",
+    enName: "NC Dinos",
+    logoImg: "nc-dinos.png",
+    clubColor: "#1C467D",
+  },
+  {
+    clubId: 8,
+    koName: "SSG 랜더스",
+    enName: "SSG Landers",
+    logoImg: "ssg-landers.png",
+    clubColor: "#BB2F45",
+  },
+  {
+    clubId: 9,
+    koName: "kt 위즈",
+    enName: "kt wiz",
+    logoImg: "kt-wiz.png",
+    clubColor: "#231F20",
+  },
+  {
+    clubId: 10,
+    koName: "KIA 타이거즈",
+    enName: "KIA Tigers",
+    logoImg: "kia-tigers.png",
+    clubColor: "#A32425",
+  },
+];
+
+function ok<T>(data: T, message = "구단 목록 조회 성공") {
+  const body: ApiResponse<T> = { code: "OK", message, data };
+  return NextResponse.json(body, { status: 200 });
+}
+
+function unauthorized(message = "인증이 필요합니다.") {
+  const body: ApiResponse<null> = { code: "UNAUTHORIZED", message, data: null };
+  return NextResponse.json(body, { status: 401 });
+}
+
+export async function GET(req: Request) {
+  // ✅ Authorization: Bearer <accessToken> 체크 (명세 준수)
+  const auth = req.headers.get("authorization") ?? "";
+  const m = auth.match(/^Bearer\s+(.+)$/i);
+  const token = m?.[1]?.trim();
+
+  if (!token) {
+    return unauthorized("Authorization Bearer 토큰이 필요합니다.");
+  }
+
+  // ✅ 토큰 검증은 '임시 mock'이므로 여기서는 통과 처리
+  // 실제로 검증하고 싶으면 아래처럼 환경변수로 간단 체크 가능:
+  // const expected = process.env.MOCK_ACCESS_TOKEN;
+  // if (expected && token !== expected) return unauthorized("토큰이 유효하지 않습니다.");
+
+  return ok<TeamsPayload>({ clubs: MOCK_CLUBS });
+}

--- a/goorm-gongbang/app/api/matches/route.ts
+++ b/goorm-gongbang/app/api/matches/route.ts
@@ -1,0 +1,194 @@
+import { NextResponse } from "next/server";
+
+/* ===========================
+   RESPONSE SHAPE
+=========================== */
+type ApiResponse<T> = { code: string; message: string; data: T };
+
+type ApiClub = {
+  clubId: number;
+  koName: string;
+  enName: string;
+  logoImg: string;
+};
+
+type Stadium = {
+  stadiumId: number;
+  koName: string;
+  enName: string;
+};
+
+type SaleStatus = "ON_SALE" | "UPCOMING" | "SOLD_OUT" | "ENDED";
+
+type ApiMatch = {
+  matchId: number;
+  matchAt: string; // "YYYY-MM-DDTHH:mm:ss"
+  saleStatus: SaleStatus;
+  salesOpenAt: string; // 경기 7일전 오전 11시 (ISO-8601, timezone 없이)
+  homeClub: ApiClub;
+  awayClub: ApiClub;
+  stadium: Stadium;
+};
+
+type MatchesPayload = {
+  date: string; // YYYY-MM-DD
+  matchCount: number;
+  matches: ApiMatch[];
+};
+
+/* ===========================
+   HELPERS
+=========================== */
+function requireBearer(req: Request) {
+  const auth = req.headers.get("authorization") ?? "";
+  const m = auth.match(/^Bearer\s+(.+)$/i);
+  return m?.[1]?.trim() ?? null;
+}
+
+function json<T>(status: number, body: ApiResponse<T>) {
+  return NextResponse.json(body, { status });
+}
+
+function isValidYmd(s: string) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return false;
+  const [y, m, d] = s.split("-").map(Number);
+  const dt = new Date(y, m - 1, d);
+  return dt.getFullYear() === y && dt.getMonth() === m - 1 && dt.getDate() === d;
+}
+
+function toYmdLocal(d: Date) {
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function isPastDate(ymd: string) {
+  const [y, m, d] = ymd.split("-").map(Number);
+  const reqDay = new Date(y, m - 1, d);
+  reqDay.setHours(0, 0, 0, 0);
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  return reqDay < today;
+}
+
+// 경기 7일 전 오전 11시 -> "YYYY-MM-DDT11:00:00"
+function calcSalesOpenAt(matchAtIsoLocal: string) {
+  // matchAtIsoLocal: "YYYY-MM-DDTHH:mm:ss"
+  const [datePart] = matchAtIsoLocal.split("T");
+  const [y, m, d] = datePart.split("-").map(Number);
+
+  const dt = new Date(y, m - 1, d);
+  dt.setDate(dt.getDate() - 7);
+  dt.setHours(11, 0, 0, 0);
+
+  const yyyy = dt.getFullYear();
+  const mm = String(dt.getMonth() + 1).padStart(2, "0");
+  const dd = String(dt.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}T11:00:00`;
+}
+
+/* ===========================
+   MOCK DATA
+=========================== */
+function makeMockMatches(date: string): ApiMatch[] {
+  const matchAt = `${date}T18:30:00`;
+  const salesOpenAt = calcSalesOpenAt(matchAt);
+
+  return [
+    {
+      matchId: 10,
+      matchAt,
+      saleStatus: "ON_SALE",
+      salesOpenAt,
+      homeClub: { clubId: 1, koName: "LG 트윈스", enName: "LG Twins", logoImg: "lg-twins.png" },
+      awayClub: { clubId: 2, koName: "두산 베어스", enName: "Doosan Bears", logoImg: "doosan-bears.png" },
+      stadium: { stadiumId: 3, koName: "잠실야구장", enName: "Jamsil Baseball Stadium" },
+    },
+    {
+      matchId: 11,
+      matchAt,
+      saleStatus: "ON_SALE",
+      salesOpenAt,
+      homeClub: { clubId: 1, koName: "LG 트윈스", enName: "LG Twins", logoImg: "lg-twins.png" },
+      awayClub: { clubId: 2, koName: "두산 베어스", enName: "Doosan Bears", logoImg: "doosan-bears.png" },
+      stadium: { stadiumId: 3, koName: "잠실야구장", enName: "Jamsil Baseball Stadium" },
+    },
+    {
+      matchId: 12,
+      matchAt,
+      saleStatus: "UPCOMING",
+      salesOpenAt,
+      homeClub: { clubId: 4, koName: "한화 이글스", enName: "Hanwha Eagles", logoImg: "hanwha-eagles.png" },
+      awayClub: { clubId: 5, koName: "롯데 자이언츠", enName: "Lotte Giants", logoImg: "lotte-giants.png" },
+      stadium: { stadiumId: 5, koName: "한화생명 이글스파크", enName: "Hanwha Life Eagles Park" },
+    },
+    {
+      matchId: 13,
+      matchAt,
+      saleStatus: "SOLD_OUT",
+      salesOpenAt,
+      homeClub: { clubId: 8, koName: "SSG 랜더스", enName: "SSG Landers", logoImg: "ssg-landers.png" },
+      awayClub: { clubId: 9, koName: "kt 위즈", enName: "kt wiz", logoImg: "kt-wiz.png" },
+      stadium: { stadiumId: 8, koName: "인천SSG랜더스필드", enName: "Incheon SSG Landers Field" },
+    },
+    {
+      matchId: 14,
+      matchAt,
+      saleStatus: "ENDED",
+      salesOpenAt,
+      homeClub: { clubId: 8, koName: "SSG 랜더스", enName: "SSG Landers", logoImg: "ssg-landers.png" },
+      awayClub: { clubId: 9, koName: "kt 위즈", enName: "kt wiz", logoImg: "kt-wiz.png" },
+      stadium: { stadiumId: 8, koName: "인천SSG랜더스필드", enName: "Incheon SSG Landers Field" },
+    },
+  ];
+}
+
+/* ===========================
+   ROUTE
+=========================== */
+export async function GET(req: Request) {
+  const token = requireBearer(req);
+  if (!token) {
+    return json<null>(401, {
+      code: "UNAUTHORIZED",
+      message: "Authorization: Bearer <accessToken> 헤더가 필요합니다.",
+      data: null,
+    });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const dateParam = searchParams.get("date");
+
+  const date = dateParam ?? toYmdLocal(new Date());
+
+  if (!isValidYmd(date)) {
+    return json<null>(400, {
+      code: "INVALID_DATE_FORMAT",
+      message: "날짜 형식이 올바르지 않습니다. YYYY-MM-DD 형식으로 입력해주세요.",
+      data: null,
+    });
+  }
+
+  if (isPastDate(date)) {
+    return json<null>(400, {
+      code: "PAST_DATE_NOT_ALLOWED",
+      message: "오늘 이전 날짜는 조회할 수 없습니다.",
+      data: null,
+    });
+  }
+
+  const matches = makeMockMatches(date);
+
+  return json<MatchesPayload>(200, {
+    code: "OK",
+    message: "경기 목록 조회 성공",
+    data: {
+      date,
+      matchCount: matches.length,
+      matches,
+    },
+  });
+}

--- a/goorm-gongbang/app/auth/callback/kakao/page.tsx
+++ b/goorm-gongbang/app/auth/callback/kakao/page.tsx
@@ -86,6 +86,4 @@ export default function KakaoCallbackPage() {
       toast.success(json.message ?? "로그인 성공");
     })();
   }, [sp, router, setAccessToken, setUser]);
-
-  return <div className="p-6">로그인 중...</div>;
 }

--- a/goorm-gongbang/app/clubs/[clubId]/page.tsx
+++ b/goorm-gongbang/app/clubs/[clubId]/page.tsx
@@ -1,0 +1,10 @@
+export default async function ClubDetailPage({ params }: { params: Promise<{ clubId: string }> }) {
+  const { clubId } = await params;
+  
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-semibold">Match Detail</h1>
+      <p>clubId: {clubId}</p>
+    </div>
+  );
+}

--- a/goorm-gongbang/app/clubs/[clubId]/page.tsx
+++ b/goorm-gongbang/app/clubs/[clubId]/page.tsx
@@ -1,6 +1,10 @@
-export default async function ClubDetailPage({ params }: { params: Promise<{ clubId: string }> }) {
-  const { clubId } = await params;
-  
+"use client";
+
+import * as React from "react";
+
+export default function ClubDetailPage({ params }: { params: Promise<{ clubId: string }> }) {
+  const { clubId } = React.use(params);
+
   return (
     <div className="p-6">
       <h1 className="text-xl font-semibold">Match Detail</h1>

--- a/goorm-gongbang/app/design/components/page.tsx
+++ b/goorm-gongbang/app/design/components/page.tsx
@@ -568,8 +568,6 @@ export default function Components() {
         <ToneRow title="Header">
           <Header />
           <Header
-            loggedIn={loggedIn}
-            onLoginClick={() => setLoggedIn(true)}
             onMyInfoClick={() => console.log("내 정보")}
             onMyTicketClick={() => console.log("내 티켓")}
           />
@@ -609,10 +607,10 @@ export default function Components() {
 
       <Section title="IconPreview">
         <ToneRow title="IconPreview">
-          <IconPreview index={0} size="xl" />
-          <IconPreview index={1} size="lg" />
-          <IconPreview index={2} size="md" />
-          <IconPreview index={3} size="sm" />
+          <IconPreview logoImg="https://i.postimg.cc/nhNmb3Nn/logo1.png" size="xl" />
+          <IconPreview logoImg="https://i.postimg.cc/nhNmb3Nn/logo1.png" size="lg" />
+          <IconPreview logoImg="https://i.postimg.cc/nhNmb3Nn/logo1.png" size="md" />
+          <IconPreview logoImg="https://i.postimg.cc/nhNmb3Nn/logo1.png" size="sm" />
         </ToneRow>
       </Section>
 
@@ -628,13 +626,13 @@ export default function Components() {
               ko: "SSG 랜더스",
               en: "SSG LANDERS",
               dataLogo: "SSG",
-              logo: <IconPreview index={0} size="md" />,
+              logo: <IconPreview logoImg="https://i.postimg.cc/nhNmb3Nn/logo1.png" size="md" />,
             }}
             home={{
               ko: "기아 타이거즈",
               en: "KIA TIGERS",
               dataLogo: "기아",
-              logo: <IconPreview index={1} size="md" />,
+              logo: <IconPreview logoImg="https://i.postimg.cc/nhNmb3Nn/logo1.png" size="md" />,
             }}
           />
 
@@ -650,13 +648,13 @@ export default function Components() {
               ko: "SSG 랜더스",
               en: "SSG LANDERS",
               dataLogo: "SSG",
-              logo: <IconPreview index={2} size="md" />,
+              logo: <IconPreview logoImg="https://i.postimg.cc/nhNmb3Nn/logo1.png" size="md" />,
             }}
             home={{
               ko: "기아 타이거즈",
               en: "KIA TIGERS",
               dataLogo: "기아",
-              logo: <IconPreview index={3} size="md" />,
+              logo: <IconPreview logoImg="https://i.postimg.cc/nhNmb3Nn/logo1.png" size="md" />,
             }}
           />
 
@@ -671,13 +669,13 @@ export default function Components() {
               ko: "SSG 랜더스",
               en: "SSG LANDERS",
               dataLogo: "SSG",
-              logo: <IconPreview index={4} size="md" />,
+              logo: <IconPreview logoImg="https://i.postimg.cc/nhNmb3Nn/logo1.png" size="md" />,
             }}
             home={{
               ko: "기아 타이거즈",
               en: "KIA TIGERS",
               dataLogo: "기아",
-              logo: <IconPreview index={5} size="md" />,
+              logo: <IconPreview logoImg="https://i.postimg.cc/nhNmb3Nn/logo1.png" size="md" />,
             }}
             overlayTopText="Coming Soon"
             overlayMainText="3월 21일 16:00 오픈"
@@ -696,13 +694,13 @@ export default function Components() {
               ko: "SSG 랜더스",
               en: "SSG LANDERS",
               dataLogo: "SSG",
-              logo: <IconPreview index={6} size="md" />,
+              logo: <IconPreview logoImg="https://i.postimg.cc/nhNmb3Nn/logo1.png" size="md" />,
             }}
             home={{
               ko: "기아 타이거즈",
               en: "KIA TIGERS",
               dataLogo: "기아",
-              logo: <IconPreview index={7} size="md" />,
+              logo: <IconPreview logoImg="https://i.postimg.cc/nhNmb3Nn/logo1.png" size="md" />,
             }}
             overlayTopText="Coming Soon"
             overlayMainText="3월 21일 16:00 오픈"
@@ -719,13 +717,13 @@ export default function Components() {
               ko: "SSG 랜더스",
               en: "SSG LANDERS",
               dataLogo: "SSG",
-              logo: <IconPreview index={8} size="md" />,
+              logo: <IconPreview logoImg="https://i.postimg.cc/nhNmb3Nn/logo1.png" size="md" />,
             }}
             home={{
               ko: "기아 타이거즈",
               en: "KIA TIGERS",
               dataLogo: "기아",
-              logo: <IconPreview index={9} size="md" />,
+              logo: <IconPreview logoImg="https://i.postimg.cc/nhNmb3Nn/logo1.png" size="md" />,
             }}
             overlayTopText="Sold Out"
             overlayMainText="예매 마감"
@@ -744,13 +742,13 @@ export default function Components() {
               ko: "SSG 랜더스",
               en: "SSG LANDERS",
               dataLogo: "SSG",
-              logo: <IconPreview index={8} size="md" />,
+              logo: <IconPreview logoImg="https://i.postimg.cc/nhNmb3Nn/logo1.png" size="md" />,
             }}
             home={{
               ko: "기아 타이거즈",
               en: "KIA TIGERS",
               dataLogo: "기아",
-              logo: <IconPreview index={9} size="md" />,
+              logo: <IconPreview logoImg="https://i.postimg.cc/nhNmb3Nn/logo1.png" size="md" />,
             }}
             overlayTopText="Sold Out"
             overlayMainText="예매 마감"
@@ -826,7 +824,7 @@ export default function Components() {
           <TeamInfoCard
             dataLogo="두산"
             teamName="두산 베어스"
-            logo={<IconPreview index={7} size="md" />}
+            logo={<IconPreview logoImg="https://i.postimg.cc/nhNmb3Nn/logo1.png" size="md" />}
             onButtonClick={() => console.log("상세 보기")}
           />
         </ToneRow>

--- a/goorm-gongbang/app/layout.tsx
+++ b/goorm-gongbang/app/layout.tsx
@@ -31,11 +31,9 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <Providers>
           <Header />
-          <div className="px-4 sm:px-6 md:px-10 lg:px-16 xl:px-24 2xl:px-[180px]">
-            <main>
+            <main className="overflow-x-hidden">
               {children}
             </main>
-          </div>
         </Providers>
         <Toaster />
       </body>

--- a/goorm-gongbang/app/loading.tsx
+++ b/goorm-gongbang/app/loading.tsx
@@ -1,14 +1,14 @@
+"use client";
+
 /* ===========================
    로딩 UI
 =========================== */
+import { Spinner } from "@/components/ui/spinner"
 export default function Loading() {
   return (
-    <div className="flex h-screen items-center justify-center">
-      <div className="flex items-center gap-3">
-        <div className="h-5 w-5 animate-spin rounded-full border-2 border-muted border-t-primary" />
-        <span className="text-muted-foreground">
-          로딩 중...
-        </span>
+    <div className="grid min-h-screen place-items-center">
+      <div className="flex flex-col items-center gap-3">
+        <Spinner className="h-6 w-6" />
       </div>
     </div>
   );

--- a/goorm-gongbang/app/matches/[matchId]/page.tsx
+++ b/goorm-gongbang/app/matches/[matchId]/page.tsx
@@ -1,6 +1,10 @@
-export default async function MatchDetailPage({ params }: { params: Promise<{ matchId: string }> }) {
-  const { matchId } = await params;
-  
+"use client";
+
+import * as React from "react";
+
+export default function MatchDetailPage({ params }: { params: Promise<{ matchId: string }> }) {
+  const { matchId } = React.use(params);
+
   return (
     <div className="p-6">
       <h1 className="text-xl font-semibold">Match Detail</h1>

--- a/goorm-gongbang/app/matches/[matchId]/page.tsx
+++ b/goorm-gongbang/app/matches/[matchId]/page.tsx
@@ -1,0 +1,10 @@
+export default async function MatchDetailPage({ params }: { params: Promise<{ matchId: string }> }) {
+  const { matchId } = await params;
+  
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-semibold">Match Detail</h1>
+      <p>matchId: {matchId}</p>
+    </div>
+  );
+}

--- a/goorm-gongbang/app/my/page.tsx
+++ b/goorm-gongbang/app/my/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useAuthStore } from "@/stores/authStore";
+import { toast } from "sonner";
+
+export default function Page() {
+  const router = useRouter();
+
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const logout = useAuthStore((s) => s.logout);
+
+  const handleLogout = async () => {
+    const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
+
+    try {
+      const res = await fetch(`${API_BASE_URL}/api/auth/logout`, { // ★ 이부분 auth/logout 으로 추후 변경 
+        method: "POST",
+        credentials: "include",
+        headers: {
+          ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}), // accessToken 없으면 보내지 않음(401 유도)
+          Accept: "application/json",
+        },
+      });
+
+      /* 백엔드 예외처리 */
+      if (res.status === 401) {
+        const json = await res.json().catch(() => null);
+        toast.error(json?.message ?? "인증이 만료되었습니다. 다시 로그인해주세요.");
+      } else if (!res.ok) {
+        const json = await res.json().catch(() => null);
+        toast.error(json?.message ?? `로그아웃 실패 (HTTP ${res.status})`);
+      } else {
+        const json = await res.json().catch(() => null);
+        toast.success(json?.message ?? "로그아웃 완료");
+      }
+    } catch (e) {
+      console.error("⚠️ LOGOUT ERROR:", e);
+      toast.error("네트워크 오류로 로그아웃 요청에 실패했습니다.");
+    } finally {
+      logout(); // access 토큰 삭제
+      router.replace("/auth/login"); // 로그인 창 이동
+    }
+  };
+
+  return (
+    <div className="p-6">
+      <button
+        type="button"
+        onClick={handleLogout}
+        className="h-10 px-4 rounded-md bg-black text-white"
+      >
+        로그아웃
+      </button>
+    </div>
+  );
+}

--- a/goorm-gongbang/app/my/tickets/page.tsx
+++ b/goorm-gongbang/app/my/tickets/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div />;
+}

--- a/goorm-gongbang/app/page.tsx
+++ b/goorm-gongbang/app/page.tsx
@@ -1,19 +1,314 @@
 "use client";
 
-/* ===========================
-   메인 페이지 (/)
-=========================== */
+import { useEffect, useMemo, useState } from "react";
 import { TodayInitSelectableDateStrip } from "@/components/common/TodayInitSelectableDateStrip";
 import { MatchCard } from "@/components/common/MatchCard";
 import { IconPreview } from "@/components/common/IconPreview";
 import { TeamInfoCard } from "@/components/common/TeamInfoCard";
 import { cn } from "@/lib/utils";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useAuthStore } from "@/stores/authStore";
+import { useRouter } from "next/navigation";
+
+/* ===========================
+   API TYPES
+=========================== */
+type ApiResponse<T> = {
+  code: string;
+  message: string;
+  data: T;
+}
+
+// 경기 목록 조회 API
+type ApiSaleStatus = "ON_SALE" | "UPCOMING" | "SOLD_OUT" | "ENDED";
+
+type ApiMatchFromApi = {
+  matchId: number;
+  matchAt: string; // "2026-03-28T18:30:00"
+  saleStatus: ApiSaleStatus;
+  salesOpenAt: string; // "2026-02-13T11:00:00"
+  homeClub: ApiClub;
+  awayClub: ApiClub;
+  stadium: ApiStadium;
+};
+
+type ApiStadium = {
+  koName: string;
+  enName: string;
+};
+
+type MatchesPayloadFromApi = {
+  date: string; // YYYY-MM-DD
+  matchCount: number;
+  matches: ApiMatchFromApi[];
+};
+
+// 구단 목록 조회 API
+type ApiClub = {
+  clubId: number;
+  koName: string;
+  enName: string;
+  logoImg: string;
+}
+
+type TeamsPayload = {
+  clubs: ApiClub[];
+}
+
+/* ===========================
+   UTIL
+=========================== */
+function formatKoreanDateLabel(isoDate: string) {
+  // "2026-03-28" -> "3월 28일"
+  const [, m, d] = isoDate.split("-").map((v) => Number(v));
+  if (!m || !d) return isoDate;
+  return `${m}월 ${d}일`;
+}
+
+const DOW_KO = ["일", "월", "화", "수", "목", "금", "토"] as const;
+
+function formatMatchAt(matchAt: string) {
+  // matchAt: "2026-03-28T18:30:00" -> 3월 28일, 토 · 14 : 00
+  const dt = new Date(matchAt);
+
+  const yyyy = dt.getFullYear();
+  const mm = String(dt.getMonth() + 1).padStart(2, "0");
+  const dd = String(dt.getDate()).padStart(2, "0");
+
+  const hh = String(dt.getHours()).padStart(2, "0");
+  const mi = String(dt.getMinutes()).padStart(2, "0");
+
+  const dateISO = `${yyyy}-${mm}-${dd}`;
+  const dateText = formatKoreanDateLabel(dateISO);
+  const weekdayKo = DOW_KO[dt.getDay()];
+  const timeText = `${weekdayKo} · ${hh}:${mi}`;
+
+  return { dateISO, dateText, timeText };
+}
+
+function formatSalesOpenAtKorean(salesOpenAt: string) {
+  // salesOpenAt: "2026-03-21T16:00:00" -> 3월 21일 16:00
+  if (!salesOpenAt) return "";
+
+  const dt = new Date(salesOpenAt);
+
+  if (Number.isNaN(dt.getTime())) return salesOpenAt; // 혹시 파싱 실패하면 원문 방어
+
+  const m = dt.getMonth() + 1;
+  const d = dt.getDate();
+  const hh = String(dt.getHours()).padStart(2, "0");
+  const mi = String(dt.getMinutes()).padStart(2, "0");
+
+  return `${m}월 ${d}일 ${hh}:${mi}`;
+}
+
+function toMatchCardVariant(saleState?: ApiSaleStatus) {
+  // MatchCard variant: comingSoon / soldOut / undefined
+  if (saleState === "UPCOMING") return "comingSoon" as const;
+  if (saleState === "SOLD_OUT") return "soldOut" as const;
+  if (saleState === "ENDED") return "ended" as const;
+  return undefined;
+}
+
+function overlayTexts(saleState: ApiSaleStatus, salesOpenAt?: string) {
+  switch (saleState) {
+    case "UPCOMING": {
+      const openText = salesOpenAt ? `${formatSalesOpenAtKorean(salesOpenAt)} 오픈` : "오픈 예정";
+      return { top: "Coming Soon", main: openText };
+    }
+
+    case "SOLD_OUT":
+      return { top: "Sold Out", main: "예매 마감" };
+
+    case "ENDED":
+      return { top: "Ended", main: "경기 종료" };
+
+    default:
+      return { top: undefined, main: undefined };
+  }
+}
+
+function TeamLogo({ club }: { club: ApiClub }) {
+  return <IconPreview logoImg={club.logoImg} size="md" />;
+}
+
+function MatchCardSkeleton({ elevated }: { elevated?: boolean }) {
+  return (
+    <div
+      className={cn(
+        "w-full max-w-[1074px] rounded-2xl bg-[var(--foundation-neutral-white)]",
+        elevated
+          ? "outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-880)] shadow-sm"
+          : "outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-880)]",
+        "px-6 py-5"
+      )}
+    >
+      {/* 상단: 날짜/시간 + 상태 뱃지 자리 */}
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-5 w-20 rounded-md" /> {/* 3월 28일 */}
+          <Skeleton className="h-5 w-24 rounded-md" /> {/* 토 · 14:00 */}
+        </div>
+        <Skeleton className="h-6 w-24 rounded-full" /> {/* Coming Soon 등 */}
+      </div>
+
+      {/* 중단: 구장명 */}
+      <div className="mt-3 flex flex-col gap-2">
+        <Skeleton className="h-5 w-[60%] rounded-md" />
+        <Skeleton className="h-4 w-[45%] rounded-md" />
+      </div>
+
+      {/* 하단: 원정/홈 팀 */}
+      <div className="mt-5 flex items-center justify-between gap-6">
+        {/* away */}
+        <div className="flex items-center gap-3 min-w-0">
+          <Skeleton className="h-10 w-10 rounded-xl" /> {/* 로고 */}
+          <div className="flex flex-col gap-2 min-w-0">
+            <Skeleton className="h-4 w-28 rounded-md" />
+            <Skeleton className="h-4 w-32 rounded-md" />
+          </div>
+        </div>
+
+        {/* vs */}
+        <Skeleton className="h-6 w-10 rounded-md" />
+
+        {/* home */}
+        <div className="flex items-center gap-3 min-w-0 justify-end">
+          <div className="flex flex-col gap-2 items-end min-w-0">
+            <Skeleton className="h-4 w-28 rounded-md" />
+            <Skeleton className="h-4 w-32 rounded-md" />
+          </div>
+          <Skeleton className="h-10 w-10 rounded-xl" /> {/* 로고 */}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TeamCardSkeleton() {
+  return (
+    <div className="w-full rounded-2xl bg-[var(--foundation-neutral-white)] outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-120)] px-4 py-4">
+      <div className="flex items-center gap-3">
+        <Skeleton className="h-10 w-10 rounded-xl" /> {/* 로고 */}
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-4 w-24 rounded-md" /> {/* 팀명 */}
+          <Skeleton className="h-4 w-16 rounded-md" /> {/* 서브텍스트 자리 */}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+
+/* ===========================
+   API FETCH
+=========================== */
+async function apiGet<T>(url: string, opts?: { signal?: AbortSignal; accessToken?: string | null }): Promise<T> {
+  const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
+
+  const res = await fetch(`${API_BASE_URL}${url}`, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      ...(opts?.accessToken ? { Authorization: `Bearer ${opts.accessToken}` } : {}),
+    },
+    signal: opts?.signal,
+    cache: "no-store",
+  });
+
+  const json = (await res.json().catch(() => null)) as ApiResponse<T> | null;
+  console.log("응답 data", json);
+
+  if (!json) throw new Error("응답 파싱 실패");
+
+  if (!res.ok || json.code !== "OK") {
+    throw new Error(json.message ?? `요청 실패 (HTTP ${res.status})`);
+  }
+
+  return json.data;
+}
 
 export default function Home() {
+  const router = useRouter();
+  const todayISO = useMemo(() => {
+    const d = new Date();
+    const yyyy = d.getFullYear();
+    const mm = String(d.getMonth() + 1).padStart(2, "0");
+    const dd = String(d.getDate()).padStart(2, "0");
+    return `${yyyy}-${mm}-${dd}`;
+  }, []);
+
+  const [selectedDate, setSelectedDate] = useState<string>(todayISO); // 날짜(달력)
+  const [matchesPayload, setMatchesPayload] = useState<MatchesPayloadFromApi | null>(null); // 경기 일정
+  const [teamsPayload, setTeamsPayload] = useState<TeamsPayload | null>(null); // 팀 리스트
+  const [loadingMatches, setLoadingMatches] = useState(false); // 로딩(spinner) - 경기 일정
+  const [loadingTeams, setLoadingTeams] = useState(false); // 로딩(spinner) - 팀 리스트
+
+  const accessToken = useAuthStore((s) => s.accessToken);
+
+  /* 경기 일정 - 날짜 변경 될 때마다 재 요청 */
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoadingMatches(true);
+
+    (async () => {
+      try {
+        const data = await apiGet<MatchesPayloadFromApi>(`/api/matches?date=${selectedDate}`, {  // ★ 이 부분은 API 명세에 맞게 수정해야합니다. /matches?date={YYYY-MM-DD}
+          signal: controller.signal,
+          accessToken,
+        });
+        setMatchesPayload(data);
+
+      } catch (e) {
+        if ((e as any)?.name === "AbortError") return;
+        setMatchesPayload(null);
+
+      } finally {
+        setLoadingMatches(false);
+      }
+    })();
+
+    return () => controller.abort();
+  }, [selectedDate, accessToken]);
+
+  /* 팀 리스트 요청 - 1회 요청 */
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoadingTeams(true);
+
+    (async () => {
+      try {
+        const data = await apiGet<TeamsPayload>(`/api/clubs`, { // ★ 이 부분은 API 명세에 맞게 수정해야합니다. -> /clubs
+          signal: controller.signal,
+          accessToken,
+        });
+        setTeamsPayload(data);
+
+      } catch (e) {
+        if ((e as any)?.name === "AbortError") return;
+        setTeamsPayload(null);
+
+      } finally {
+        setLoadingTeams(false);
+      }
+    })();
+
+    return () => controller.abort();
+  }, [accessToken]);
+
+  /* 3월 28일은 총 5개의 경기가 있습니다. */
+  const countText = useMemo(() => {
+    const dateLabel = formatKoreanDateLabel(selectedDate); // 날짜
+    const count = matchesPayload?.matchCount ?? 0; // 개수
+    return `${dateLabel}은 총 ${count}개의 경기가 있습니다.`
+  }, [selectedDate, matchesPayload]);
+
+  const matchCards = matchesPayload?.matches ?? []; // 경기 일정
+  const clubs = teamsPayload?.clubs ?? []; // 팀 리스트
+
   return (
-    <div className="w-full">
+    <div className="px-4 sm:px-6 md:px-10 lg:px-16 xl:px-24 2xl:px-[120px]">
       <main className="w-full">
-        {/* Root container (1440) */}
         <div className="w-full max-w-[1440px] mx-auto flex flex-col gap-12">
           <section className="w-full flex flex-col gap-1">
             {/* 섹션 타이틀 */}
@@ -30,12 +325,14 @@ export default function Home() {
 
             {/* 달력 + count + cards */}
             <div className="w-full flex flex-col items-center gap-4">
-              {/* Date strip wrapper */}
               <div className="w-full flex flex-col items-center gap-3">
                 <div className="w-full max-w-[1088px] flex flex-col items-center gap-3">
                   <TodayInitSelectableDateStrip
                     onChange={(date) => {
-                      console.log("선택된 날짜:", date);
+                      const yyyy = date.getFullYear();
+                      const mm = String(date.getMonth() + 1).padStart(2, "0");
+                      const dd = String(date.getDate()).padStart(2, "0");
+                      setSelectedDate(`${yyyy}-${mm}-${dd}`);
                     }}
                   />
                 </div>
@@ -44,124 +341,54 @@ export default function Home() {
               {/* count text */}
               <div className="w-full max-w-[1088px]">
                 <div className="w-full text-left text-[var(--foundation-primary-500)] text-sm font-medium font-['Pretendard'] leading-5">
-                  3월 28일은 총 5개의 경기가 있습니다.
+                  {loadingMatches ? "0월 00일은 총 0개의 경기가 있습니다." : countText}
                 </div>
               </div>
 
               {/* MatchCard list */}
               <div className="w-full flex flex-col items-center gap-3">
-                <div className="w-full max-w-[1074px]">
-                  <MatchCard
-                    elevated
-                    withOutline
-                    dateText="3월 28일"
-                    timeText="토 · 14 : 00"
-                    stadiumKo="대구 삼성 라이온즈 파크"
-                    stadiumEn="Daegu Samsung Lions Park"
-                    away={{
-                      ko: "SSG 랜더스",
-                      en: "SSG LANDERS",
-                      dataLogo: "SSG",
-                      logo: <IconPreview index={2} size="md" />,
-                    }}
-                    home={{
-                      ko: "기아 타이거즈",
-                      en: "KIA TIGERS",
-                      dataLogo: "기아",
-                      logo: <IconPreview index={3} size="md" />,
-                    }}
-                  />
-                </div>
+                {loadingMatches ? (
+                  <div className="w-full flex flex-col items-center gap-3">
+                    {Array.from({ length: 5 }).map((_, i) => (
+                      <MatchCardSkeleton key={i} elevated={i === 0} />
+                    ))}
+                  </div>
+                ) : (
+                  matchCards.map((m, idx) => {
+                    const { dateText, timeText } = formatMatchAt(m.matchAt); // 3월 28일, 토 · 14 : 00
+                    const variant = toMatchCardVariant(m.saleStatus); // comming soon, soild out, ended
+                    const overlay = overlayTexts(m.saleStatus, m.salesOpenAt); // 예매 중(ON_SALE), 판매 예정(UPCOMING), 매진(SOLD_OUT), 경기 종료(ENDED)
+                    const isClickable = m.saleStatus === "ON_SALE";
 
-                <div className="w-full max-w-[1074px]">
-                  <MatchCard
-                    dateText="3월 28일"
-                    timeText="토 · 14 : 00"
-                    stadiumKo="대구 삼성 라이온즈 파크"
-                    stadiumEn="Daegu Samsung Lions Park"
-                    away={{
-                      ko: "SSG 랜더스",
-                      en: "SSG LANDERS",
-                      dataLogo: "SSG",
-                      logo: <IconPreview index={0} size="md" />,
-                    }}
-                    home={{
-                      ko: "기아 타이거즈",
-                      en: "KIA TIGERS",
-                      dataLogo: "기아",
-                      logo: <IconPreview index={1} size="md" />,
-                    }}
-                  />
-                </div>
-
-                <div className="w-full max-w-[1074px]">
-                  <MatchCard
-                    dateText="3월 28일"
-                    timeText="토 · 14 : 00"
-                    stadiumKo="대구 삼성 라이온즈 파크"
-                    stadiumEn="Daegu Samsung Lions Park"
-                    away={{
-                      ko: "SSG 랜더스",
-                      en: "SSG LANDERS",
-                      dataLogo: "SSG",
-                      logo: <IconPreview index={0} size="md" />,
-                    }}
-                    home={{
-                      ko: "기아 타이거즈",
-                      en: "KIA TIGERS",
-                      dataLogo: "기아",
-                      logo: <IconPreview index={1} size="md" />,
-                    }}
-                  />
-                </div>
-
-                <div className="w-full max-w-[1074px]">
-                  <MatchCard
-                    variant="comingSoon"
-                    dateText="3월 28일"
-                    timeText="토 · 14 : 00"
-                    stadiumKo="대구 삼성 라이온즈 파크"
-                    stadiumEn="Daegu Samsung Lions Park"
-                    away={{
-                      ko: "SSG 랜더스",
-                      en: "SSG LANDERS",
-                      dataLogo: "SSG",
-                      logo: <IconPreview index={4} size="md" />,
-                    }}
-                    home={{
-                      ko: "기아 타이거즈",
-                      en: "KIA TIGERS",
-                      dataLogo: "기아",
-                      logo: <IconPreview index={5} size="md" />,
-                    }}
-                    overlayTopText="Coming Soon"
-                    overlayMainText="3월 21일 16:00 오픈"
-                  />
-                </div>
-
-                <div className="w-full max-w-[1074px]">
-                  <MatchCard
-                    variant="soldOut"
-                    dateText="3월 28일"
-                    timeText="토 · 14 : 00"
-                    stadiumKo="대구 삼성 라이온즈 파크"
-                    stadiumEn="Daegu Samsung Lions Park"
-                    away={{
-                      ko: "SSG 랜더스",
-                      en: "SSG LANDERS",
-                      dataLogo: "SSG",
-                      logo: <IconPreview index={8} size="md" />,
-                    }}
-                    home={{
-                      ko: "기아 타이거즈",
-                      en: "KIA TIGERS",
-                      dataLogo: "기아",
-                      logo: <IconPreview index={9} size="md" />,
-                    }}
-                    overlayTopText="Sold Out"
-                    overlayMainText="예매 마감"
-                  />
-                </div>
+                    return (
+                      <button key={m.matchId} type="button" disabled={!isClickable} onClick={() => router.push(`/matches/${m.matchId}`)} className="w-full max-w-[1074px] text-left cursor-pointer">
+                        <MatchCard
+                          elevated={idx === 0}
+                          withOutline={idx === 0}
+                          variant={variant} // comming soon, soild out, ended
+                          dateText={dateText} // 3월 28일
+                          timeText={timeText} // 토 · 14 : 00
+                          stadiumKo={m.stadium.koName} // 대구 삼성 라이온즈 파크
+                          stadiumEn={m.stadium.enName} // Daegu Samsung Lions Park
+                          away={{
+                            ko: m.awayClub.koName, // SSG 랜더스
+                            en: m.awayClub.enName, // SSG LANDERS
+                            dataLogo: m.awayClub.koName, // SSG
+                            logo: <TeamLogo club={m.awayClub} />, // logoImg
+                          }}
+                          home={{
+                            ko: m.homeClub.koName, // 기아 타이거즈
+                            en: m.homeClub.enName, // KIA TIGERS
+                            dataLogo: m.homeClub.koName, // 기아
+                            logo: <TeamLogo club={m.homeClub} />, // logoImg
+                          }}
+                          overlayTopText={overlay.top}
+                          overlayMainText={overlay.main}
+                        />
+                      </button>
+                    );
+                  })
+                )}
               </div>
             </div>
           </section>
@@ -170,7 +397,7 @@ export default function Home() {
               Team Info Section (full-bleed bg + inner padding)
           =========================== */}
           <section className="w-screen relative left-1/2 right-1/2 -ml-[50vw] -mr-[50vw] bg-[var(--background-grey)] pb-48">
-            <div className="px-4 sm:px-8 md:px-12 lg:px-18 xl:px-26 2xl:px-[180px]">
+            <div className="px-4 sm:px-8 md:px-12 lg:px-18 xl:px-26 2xl:px-[120px]">
               <div className="w-full max-w-[1440px] mx-auto">
                 {/* 섹션 타이틀 */}
                 <div className="w-full flex justify-center">
@@ -193,23 +420,24 @@ export default function Home() {
                       "grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5"
                     )}
                   >
-                    <TeamInfoCard dataLogo="두산" teamName="두산 베어스" logo={<IconPreview index={7} size="md" />} />
-                    <TeamInfoCard dataLogo="삼성" teamName="삼성 라이온즈" logo={<IconPreview index={0} size="md" />} />
-                    <TeamInfoCard dataLogo="키움" teamName="키움 히어로즈" logo={<IconPreview index={1} size="md" />} />
-                    <TeamInfoCard dataLogo="한화" teamName="한화 이글스" logo={<IconPreview index={2} size="md" />} />
-                    <TeamInfoCard dataLogo="롯데" teamName="롯데 자이언츠" logo={<IconPreview index={3} size="md" />} />
-
-                    <TeamInfoCard dataLogo="LG" teamName="LG 트윈스" logo={<IconPreview index={4} size="md" />} />
-                    <TeamInfoCard dataLogo="NC" teamName="NC 다이노즈" logo={<IconPreview index={5} size="md" />} />
-                    <TeamInfoCard dataLogo="SSG" teamName="SSG 랜더스" logo={<IconPreview index={6} size="md" />} />
-                    <TeamInfoCard dataLogo="KT" teamName="KT 위즈" logo={<IconPreview index={8} size="md" />} />
-                    <TeamInfoCard dataLogo="KIA" teamName="KIA 타이거즈" logo={<IconPreview index={9} size="md" />} />
+                    {loadingTeams ? (
+                      Array.from({ length: 10 }).map((_, i) => <TeamCardSkeleton key={i} />)
+                    ) : (
+                      clubs.map((t) => (
+                        <TeamInfoCard
+                          key={t.clubId}
+                          dataLogo={t.koName} // 두산 베어스
+                          teamName={t.koName} // 두산 베어스
+                          logo={<TeamLogo club={t} />} // <IconPreview index={7} size="md" />
+                          onButtonClick={() => router.push(`/clubs/${t.clubId}`)}
+                        />
+                      ))
+                    )}
                   </div>
                 </div>
               </div>
             </div>
           </section>
-          
         </div>
       </main>
     </div>

--- a/goorm-gongbang/components/common/IconPreview.tsx
+++ b/goorm-gongbang/components/common/IconPreview.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 type Size = "xl" | "lg" | "md" | "sm";
 
 type Props = {
-  index: number;     // 0~9
+  logoImg: string;
   size?: Size;
 
   /** object-fit */
@@ -53,8 +53,14 @@ const SIZE_PRESETS: Record<
   },
 };
 
+const CLUBS_CDN_BASE = process.env.NEXT_PUBLIC_CDN_CLUBS_BASE_URL;
+function resolveLogoSrc(input: string) {
+  if (/^https?:\/\//i.test(input)) return input; // input이 이미 https:// 로 시작하면 그대로 사용
+  return new URL(input.replace(/^\//, ""), CLUBS_CDN_BASE).toString(); // base + 상대경로 결합
+}
+
 export function IconPreview({
-  index,
+  logoImg,
   size = "xl",
   fit = "contain",
   className,
@@ -66,8 +72,8 @@ export function IconPreview({
     <div className={cn(preset.container, className)}>
       <div className={preset.inner}>
         <img
-          src={`/logo/logo${index + 1}.png`}
-          alt={`icon-${index + 1}`}
+          src={resolveLogoSrc(logoImg)}
+          alt={`alt-${logoImg}`}
           className={cn(preset.img, fit === "contain" ? "object-contain" : "object-cover", imgClassName)}
         />
       </div>

--- a/goorm-gongbang/components/common/MatchCard.tsx
+++ b/goorm-gongbang/components/common/MatchCard.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 import { ChevronRight } from "lucide-react";
 
-type MatchCardVariant = "default" | "comingSoon" | "soldOut";
+type MatchCardVariant = "default" | "comingSoon" | "soldOut" | "ended";
 
 type Team = {
     ko: string;
@@ -67,7 +67,7 @@ export function MatchCard({
     const overlayGradient =
         variant === "comingSoon"
             ? "from-[var(--foundation-neutral-white)] to-[var(--foundation-neutral-480)] opacity-40"
-            : variant === "soldOut"
+            : variant === "soldOut" || variant === "ended"
                 ? "from-[var(--foundation-neutral-white)] to-[var(--foundation-neutral-720)] opacity-60"
                 : "";
 
@@ -77,10 +77,23 @@ export function MatchCard({
 
     const overlayTop =
         overlayTopText ??
-        (variant === "comingSoon" ? "Coming Soon" : variant === "soldOut" ? "Sold Out" : "");
+        (variant === "comingSoon"
+            ? "Coming Soon"
+            : variant === "soldOut"
+                ? "Sold Out"
+                : variant === "ended"
+                    ? "Ended"
+                    : "");
+
     const overlayMain =
         overlayMainText ??
-        (variant === "comingSoon" ? "3월 21일 16:00 오픈" : variant === "soldOut" ? "예매 마감" : "");
+        (variant === "comingSoon"
+            ? "0월 0일 00:00 오픈"
+            : variant === "soldOut"
+                ? "예매 마감"
+                : variant === "ended"
+                    ? "경기 종료"
+                    : "");
 
     const renderLogo = (team: Team, imgClassName: string) => {
         if (team.logo) return team.logo;
@@ -217,7 +230,7 @@ export function MatchCard({
                             <ChevronRight
                                 className={cn(
                                     "h-12 w-12 md:h-12 md:w-12",
-                                    variant === "soldOut"
+                                    variant === "soldOut" || variant === "ended"
                                         ? "text-[var(--foundation-secondary-900)]"
                                         : "text-[var(--foundation-primary-500)]"
                                 )}
@@ -239,7 +252,7 @@ export function MatchCard({
                                 title={overlayMain}
                                 className={cn(
                                     "self-stretch text-right text-xl font-semibold font-['Pretendard'] leading-8 truncate",
-                                    variant === "soldOut"
+                                    variant === "soldOut" || variant === "ended"
                                         ? "text-[var(--foundation-secondary-900)]"
                                         : "text-[var(--foundation-primary-700)]"
                                 )}

--- a/goorm-gongbang/components/common/TodayInitSelectableDateStrip.tsx
+++ b/goorm-gongbang/components/common/TodayInitSelectableDateStrip.tsx
@@ -110,10 +110,13 @@ export function TodayInitSelectableDateStrip({ className, sideCount, onChange }:
                   data-icon="on"
                   data-state="Default"
                   className={cn(
-                    "w-20 h-9 min-w-20 px-4 py-2",
+                    "w-20 h-9 min-w-20 px-4 py-2 cursor-pointer",
                     "bg-[var(--background-white)] rounded-md",
                     "outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-880)]",
-                    "inline-flex justify-center items-center"
+                    "inline-flex justify-center items-center",
+                    open
+                      ? "bg-[var(--foundation-primary-10)] outline-[var(--foundation-primary-500)]"
+                      : "bg-[var(--background-white)] outline-[var(--foundation-neutral-880)]"
                   )}
                   aria-label="날짜 선택"
                 >
@@ -155,7 +158,7 @@ export function TodayInitSelectableDateStrip({ className, sideCount, onChange }:
             <button
               type="button"
               onClick={goPrevMonth}
-              className="w-8 h-8 flex items-center justify-center"
+              className="w-8 h-8 flex items-center justify-center cursor-pointer"
               aria-label="이전 달"
             >
               <ChevronLeft className="w-5 h-5 text-[var(--light-foreground)]" strokeWidth={2} />
@@ -176,7 +179,7 @@ export function TodayInitSelectableDateStrip({ className, sideCount, onChange }:
             <button
               type="button"
               onClick={goNextMonth}
-              className="w-8 h-8 flex items-center justify-center"
+              className="w-8 h-8 flex items-center justify-center cursor-pointer"
               aria-label="다음 달"
             >
               <ChevronRight className="w-5 h-5 text-[var(--light-foreground)]" strokeWidth={2} />
@@ -193,7 +196,7 @@ export function TodayInitSelectableDateStrip({ className, sideCount, onChange }:
                 className={cn(
                   "shrink-0 rounded-full outline outline-1 outline-offset-[-1px]",
                   "bg-[var(--foundation-neutral-white)] outline-[var(--foundation-neutral-800)]",
-                  "w-9 h-9 sm:w-10 sm:h-10 flex items-center justify-center"
+                  "w-9 h-9 sm:w-10 sm:h-10 flex items-center justify-center cursor-pointer"
                 )}
                 aria-label="이전 날짜"
               >
@@ -263,7 +266,7 @@ export function TodayInitSelectableDateStrip({ className, sideCount, onChange }:
                 className={cn(
                   "shrink-0 rounded-full outline outline-1 outline-offset-[-1px]",
                   "bg-[var(--foundation-neutral-white)] outline-[var(--foundation-neutral-800)]",
-                  "w-9 h-9 sm:w-10 sm:h-10 flex items-center justify-center"
+                  "w-9 h-9 sm:w-10 sm:h-10 flex items-center justify-center cursor-pointer"
                 )}
                 aria-label="다음 날짜"
               >

--- a/goorm-gongbang/components/layout/Header.tsx
+++ b/goorm-gongbang/components/layout/Header.tsx
@@ -3,46 +3,37 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 import { User, Ticket } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useAuthStore } from "@/stores/authStore";
 
 type Props = {
   className?: string;
-
-  /** 초기 로그인 상태(옵션). 외부에서 제어하고 싶으면 아래 controlled props 사용 추천 */
-  defaultLoggedIn?: boolean;
-
-  /** controlled로 쓰고 싶을 때 */
-  loggedIn?: boolean;
-  onLoginClick?: () => void;
   onMyInfoClick?: () => void;
   onMyTicketClick?: () => void;
 };
 
-export function Header({
-  className,
-  defaultLoggedIn = false,
-  loggedIn,
-  onLoginClick,
-  onMyInfoClick,
-  onMyTicketClick,
-}: Props) {
-  // uncontrolled fallback
-  const [internalLoggedIn, setInternalLoggedIn] = React.useState(defaultLoggedIn);
-  const isLoggedIn = loggedIn ?? internalLoggedIn;
+export function Header({ className, onMyInfoClick, onMyTicketClick }: Props) {
+  const router = useRouter();
+  const bootstrapped = useAuthStore((s) => s.bootstrapped);
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const user = useAuthStore((s) => s.user);
+
+  const isLoggedIn = bootstrapped && !!accessToken && !!user;
 
   const handleLogin = () => {
-    onLoginClick?.();
-    if (loggedIn === undefined) setInternalLoggedIn(true);
+    const next = typeof window !== "undefined" ? window.location.pathname + window.location.search : "/"; // 로그인 후 돌아오도록
+    router.push(`/auth/login?next=${encodeURIComponent(next)}`);
   };
 
   return (
     <div
       className={cn(
-        "w-full self-stretch h-12 px-4 sm:px-6 md:px-10 lg:px-16 xl:px-24 2xl:px-[180px] bg-[var(--foundation-neutral-980)] inline-flex justify-between items-center",
+        "w-full self-stretch h-12 px-4 sm:px-6 md:px-10 lg:px-16 xl:px-24 2xl:px-[120px] bg-[var(--foundation-neutral-980)] inline-flex justify-between items-center",
         className
       )}
     >
       {/* Logo */}
-      <div className="self-stretch flex justify-start items-center">
+      <div onClick={() => router.push("/")} className="cursor-pointer self-stretch flex justify-start items-center">
         <div className="justify-start text-gray-900 text-lg font-bold font-['Pretendard'] leading-9">
           Pyo
         </div>
@@ -71,8 +62,8 @@ export function Header({
         <div className="flex justify-start items-center gap-8">
           <button
             type="button"
-            onClick={onMyInfoClick}
-            className="w-20 h-6 flex justify-start items-center gap-2"
+            onClick={onMyInfoClick ?? (() => router.push("/my"))}
+            className="cursor-pointer w-20 h-6 flex justify-start items-center gap-2"
           >
             <User className="w-5 h-5 text-gray-700" aria-hidden="true" />
             <div className="flex-1 flex justify-center items-center gap-2">
@@ -84,8 +75,8 @@ export function Header({
 
           <button
             type="button"
-            onClick={onMyTicketClick}
-            className="h-6 flex justify-start items-center gap-2"
+            onClick={onMyTicketClick ?? (() => router.push("/my/tickets"))}
+            className="cursor-pointer h-6 flex justify-start items-center gap-2"
           >
             <Ticket className="w-5 h-5 text-gray-700" aria-hidden="true" />
             <div className="flex justify-center items-center gap-2">

--- a/goorm-gongbang/components/ui/skeleton.tsx
+++ b/goorm-gongbang/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("bg-accent animate-pulse rounded-md", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }


### PR DESCRIPTION
- 홈 페이지의 기능 개발 완료
- 약간의 레이아웃 수정 (180px->120px)
- api mock 개발 완료
- header 내정보에 임시 로그아웃 버튼 추가
- header 기능 개발
- 약간의 버그 수정 fixes: #36

🔧 작업 내용

홈 화면에서 구단 목록(/clubs) 조회 후 구단 카드 렌더링 기능 추가

홈 화면에서 날짜별 경기 목록(/matches?date=YYYY-MM-DD) 조회 후 MatchCard 렌더링 기능 추가

경기 상태(ON_SALE/UPCOMING/SOLD_OUT/ENDED)에 따른 MatchCard UI/오버레이 문구 처리 적용

UPCOMING인 경우 salesOpenAt 기반으로 “M월 D일 HH:MM 오픈” 문구 노출

UPCOMING/SOLD_OUT/ENDED 상태 경기의 클릭 비활성(상세 진입 방지) 처리

ON_SALE 경기 클릭 시 /matches/[matchId] 상세 페이지로 이동하도록 라우팅 연결

구단 카드의 “상세 보기” 버튼 클릭 시 /clubs/[clubId] 상세 페이지로 이동하도록 연결

🧩 구현 상세 (선택)

홈 화면 데이터 로딩 상태에서 스켈레톤 UI 노출로 UX 개선

날짜 변경 시 AbortController 적용하여 중복 요청/레이스 컨디션 방지

API 응답 타입(MatchesPayloadFromApi, TeamsPayload)을 명세에 맞춰 정리하고, UI에서 필요한 데이터는 formatter로 변환하여 사용

📌 관련 Jira Issue

GBGB-134

🧪 테스트 방법(선택)

홈 화면 진입

날짜 스트립에서 날짜 변경 → 경기 목록 정상 갱신 확인

UPCOMING 경기: 오버레이에 “M월 D일 HH:MM 오픈” 노출 확인

SOLD_OUT/ENDED/UPCOMING 경기 클릭 → 상세 이동 안 되는지 확인

ON_SALE 경기 클릭 → /matches/{matchId}로 이동 확인

구단 카드 “상세 보기” 클릭 → /clubs/{clubId}로 이동 확인

❗ 참고 사항

mock API route 기준으로 동작 확인 (추후 실서버 연결 시 NEXT_PUBLIC_API_URL만 교체 예정)

동적 라우트 파라미터 키는 폴더명([clubId], [matchId])과 동일해야 함

Fixes: #36
