### PR TITLE
[FE] PR 자동화 GitHub Actions 워크플로 구현 (Jira 이슈키 자동 추가 / 라벨 및 Assignee 자동 지정)

### DIFF
--- a/.github/workflows/pr-jira-title.yml
+++ b/.github/workflows/pr-jira-title.yml
@@ -1,0 +1,54 @@
+name: Add Jira Key to PR Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+
+jobs:
+  update-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      # PR 본문에서 GRGB 이슈키 추출 후 제목 맨 뒤에 자동 추가
+      - name: Extract Jira Key and Update PR Title
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const title = context.payload.pull_request.title;
+            const body = context.payload.pull_request.body || '';
+
+            // 제목에 이미 GRGB 키가 있으면 스킵
+            if (/GRGB-\d+/.test(title)) {
+              console.log('Jira key already in title, skipping');
+              return;
+            }
+
+            // PR 본문에서 GRGB 이슈키 추출 (ex. GRGB-161)
+            const match = body.match(/GRGB-\d+/);
+            if (!match) {
+              console.log('No Jira key found in PR body, skipping');
+              return;
+            }
+
+            const jiraKey = match[0];
+            const newTitle = `${title} [${jiraKey}]`;
+
+            // PR 제목 맨 뒤에 Jira 이슈키 추가
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              title: newTitle
+            });
+
+            // 성공 시 PR 댓글 자동 등록
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `🔗 원활한 Jira 자동화를 위해 PR 제목에 이슈키 **${jiraKey}** 를 추가했어요!`
+            });
+
+            console.log(`Updated PR title: ${newTitle}`);

--- a/.github/workflows/pr-jira-title.yml
+++ b/.github/workflows/pr-jira-title.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types:
       - opened
-      - edited
 
 jobs:
   auto-label-and-assign:

--- a/.github/workflows/pr-jira-title.yml
+++ b/.github/workflows/pr-jira-title.yml
@@ -1,4 +1,4 @@
-name: Add Jira Key to PR Title
+name: Auto Label and Assign PR
 
 on:
   pull_request:
@@ -7,48 +7,59 @@ on:
       - edited
 
 jobs:
-  update-pr-title:
+  auto-label-and-assign:
     runs-on: ubuntu-latest
     steps:
-      # PR 본문에서 GRGB 이슈키 추출 후 제목 맨 뒤에 자동 추가
-      - name: Extract Jira Key and Update PR Title
+      # PR 제목 기반 라벨 자동 추가 + 작성자 assignee 자동 지정
+      - name: Auto Label and Assign
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const title = context.payload.pull_request.title;
-            const body = context.payload.pull_request.body || '';
+            const title = context.payload.pull_request.title.toLowerCase();
+            const prNumber = context.payload.pull_request.number;
+            const author = context.payload.pull_request.user.login;
+            const assignees = context.payload.pull_request.assignees.map(a => a.login);
 
-            // 제목에 이미 GRGB 키가 있으면 스킵
-            if (/GRGB-\d+/.test(title)) {
-              console.log('Jira key already in title, skipping');
-              return;
+            // PR 제목 기반 라벨 매핑
+            const labelMap = [
+              { patterns: ['feat', 'feature'], label: 'feature' },
+              { patterns: ['refactor'],        label: 'refactor' },
+              { patterns: ['bug', 'fix'],      label: 'bug' },
+              { patterns: ['chore'],           label: 'chore' },
+              { patterns: ['hotfix'],          label: 'hotfix' },
+            ];
+
+            // 매칭되는 라벨 전부 찾기
+            const matchedLabels = [];
+            for (const { patterns, label } of labelMap) {
+              if (patterns.some(p => title.includes(p))) {
+                matchedLabels.push(label);
+              }
             }
 
-            // PR 본문에서 GRGB 이슈키 추출 (ex. GRGB-161)
-            const match = body.match(/GRGB-\d+/);
-            if (!match) {
-              console.log('No Jira key found in PR body, skipping');
-              return;
+            // 라벨 추가
+            if (matchedLabels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                labels: matchedLabels
+              });
+              console.log(`Added labels: ${matchedLabels}`);
+            } else {
+              console.log('No matching label found, skipping');
             }
 
-            const jiraKey = match[0];
-            const newTitle = `${title} [${jiraKey}]`;
-
-            // PR 제목 맨 뒤에 Jira 이슈키 추가
-            await github.rest.pulls.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              title: newTitle
-            });
-
-            // 성공 시 PR 댓글 자동 등록
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body: `🔗 원활한 Jira 자동화를 위해 PR 제목에 이슈키 **${jiraKey}** 를 추가했어요!`
-            });
-
-            console.log(`Updated PR title: ${newTitle}`);
+            // assignee 미지정 시 PR 작성자 자동 지정
+            if (assignees.length === 0) {
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                assignees: [author]
+              });
+              console.log(`Assigned to author: ${author}`);
+            } else {
+              console.log('Assignee already set, skipping');
+            }


### PR DESCRIPTION
## 🔧 작업 내용
- PR 제목 기반 라벨 자동 추가 GitHub Actions 워크플로 구현
- PR 작성자 assignee 자동 지정 기능 구현
- 프론트 팀원들이 라벨/담당자 지정을 누락하는 문제 자동화로 해결
- actions/github-script 사용하여 GitHub API 직접 호출 방식으로 구현

## 🧩 구현 상세 (선택)
- PR 제목을 소문자로 변환 후 키워드 패턴 매핑으로 라벨 결정
- feat/feature → feature, refactor → refactor, bug/fix → bug, chore → chore, hotfix → hotfix
- 여러 키워드 매칭 시 복수 라벨 동시 추가 가능
- assignees 배열이 비어있을 때만 PR 작성자 자동 지정 (이미 지정된 경우 스킵)
- 매칭되는 라벨 없을 경우 스킵 처리

### 📌 관련 Jira Issue
- GRGB-178

## 🧪 테스트 방법 (선택)
- feat, refactor, bug, fix, chore, hotfix 키워드 포함한 제목으로 PR 생성
- 라벨 자동 추가 확인
- assignee 미지정 상태로 PR 생성 후 작성자 자동 지정 확인
- 키워드 없는 제목으로 PR 생성 시 스킵 확인

## ❗ 참고 사항
- opened, edited 이벤트 모두 트리거되므로 PR 제목 수정 시 라벨 중복 추가 가능
- 프론트엔드 레포 대상으로 먼저 적용 후 백엔드 레포 적용 여부 검토 필요