### PR TITLE
chore(pr-automation): PR 라벨 자동 지정 로직 개선 (단어 단위 매칭 적용)

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -20,7 +20,7 @@ jobs:
             const author = context.payload.pull_request.user.login;
             const assignees = context.payload.pull_request.assignees.map(a => a.login);
 
-            // PR 제목 기반 라벨 매핑
+            // PR 제목 기반 라벨 매핑 (단어 단위 매칭)
             const labelMap = [
               { patterns: ['feat', 'feature'], label: 'feature' },
               { patterns: ['refactor'],        label: 'refactor' },
@@ -29,10 +29,10 @@ jobs:
               { patterns: ['hotfix'],          label: 'hotfix' },
             ];
 
-            // 매칭되는 라벨 전부 찾기
+            // 매칭되는 라벨 전부 찾기 (여러 개 가능, 단어 단위 매칭)
             const matchedLabels = [];
             for (const { patterns, label } of labelMap) {
-              if (patterns.some(p => title.includes(p))) {
+              if (patterns.some(p => new RegExp(`\\b${p}\\b`).test(title))) {
                 matchedLabels.push(label);
               }
             }

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types:
       - opened
+      - edited
 
 jobs:
   auto-label-and-assign:


### PR DESCRIPTION
## 🔧 작업 내용
- title.includes() 방식에서 정규식 단어 단위 매칭(\b)으로 변경
- fixture, prefix 등 키워드가 포함된 단어에 의한 오탐 방지

## 🧩 구현 상세 (선택)
- 기존 title.includes(p) → new RegExp(`\\b${p}\\b`).test(title) 로 변경
- 단어 경계(\b) 사용으로 독립된 키워드만 매칭

### 📌 관련 Jira Issue
- GRGB-179
