### PR TITLE
Feat/clubdetail UI

### DIFF
--- a/goorm-gongbang/app/clubs/[clubId]/page.tsx
+++ b/goorm-gongbang/app/clubs/[clubId]/page.tsx
@@ -3,10 +3,10 @@
 import * as React from "react";
 import { useState, useMemo, useEffect } from "react";
 import { useParams } from "next/navigation";
+import Link from "next/link";
 import Image from "next/image";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button"; // shadcn/ui
 import {
   format,
   addMonths,
@@ -17,164 +17,14 @@ import {
   endOfWeek,
   isSameMonth,
   isSameDay,
-  addDays,
   eachDayOfInterval,
 } from "date-fns";
 import { ko } from "date-fns/locale";
 import { ChevronLeft, ChevronRight, Copy } from "lucide-react";
 
 /* ===========================
-    API TYPES (Mocked)
+    MOCK DATA & TYPES
 =========================== */
-type ClubDetail = {
-  clubId: number;
-  koName: string;
-  enName: string;
-  logoImg: string;
-  clubColor: string;
-  stadiumName: string;
-  stadiumAddress: string;
-  description?: string;
-};
-
-type MatchSummary = {
-  matchId: number;
-  matchAt: string;
-  homeClub: { koName: string; enName: string; logoImg: string };
-  awayClub: { koName: string; enName: string; logoImg: string };
-  stadiumName: string;
-  saleStatus: "ON_SALE" | "UPCOMING" | "SOLD_OUT" | "ENDED";
-};
-
-/* ===========================
-    MOCK DATA
-=========================== */
-const seasonStats = [
-  { label: "순위", value: "3" },
-  { label: "승", value: "32" },
-  { label: "무", value: "2" },
-  { label: "패", value: "13" },
-];
-
-const detailedStats = [
-  { label: "승률", value: "0.582" },
-  { label: "타율", value: "0.311" },
-  { label: "평균자책", value: "2.9" },
-  { label: "승차", value: "0.0" },
-];
-
-const MOCK_CLUB_DATA: Record<string, ClubDetail> = {
-  "1": {
-    clubId: 1,
-    koName: "두산 베어스",
-    enName: "Doosan Bears",
-    logoImg: "/logo/logo1.png",
-    clubColor: "#131230",
-    stadiumName: "잠실 야구장",
-    stadiumAddress: "서울특별시 송파구 올림픽로 25",
-    description: "서울을 연고지로 하는 KBO 리그의 프로야구단입니다.",
-  },
-  "2": {
-    clubId: 2,
-    koName: "LG 트윈스",
-    enName: "LG Twins",
-    logoImg: "/logo/logo2.png",
-    clubColor: "#C30452",
-    stadiumName: "잠실 야구장",
-    stadiumAddress: "서울특별시 송파구 올림픽로 25",
-    description: "서울을 연고지로 하는 KBO 리그의 프로야구단입니다.",
-  },
-};
-
-// 3월과 4월에 걸친 가상 경기 데이터
-const MOCK_MATCHES: MatchSummary[] = [
-  {
-    matchId: 101,
-    matchAt: "2026-03-24T18:30:00",
-    homeClub: {
-      koName: "두산 베어스",
-      enName: "Doosan Bears",
-      logoImg: "/logo/logo1.png",
-    },
-    awayClub: {
-      koName: "삼성 라이온즈",
-      enName: "Samsung Lions",
-      logoImg: "/logo/logo3.png",
-    },
-    stadiumName: "잠실 야구장",
-    saleStatus: "ENDED",
-  },
-  {
-    matchId: 102,
-    matchAt: "2026-03-29T14:00:00",
-    homeClub: {
-      koName: "두산 베어스",
-      enName: "Doosan Bears",
-      logoImg: "/logo/logo1.png",
-    },
-    awayClub: {
-      koName: "SSG 랜더스",
-      enName: "SSG Landers",
-      logoImg: "/logo/logo4.png",
-    },
-    stadiumName: "잠실 야구장",
-    saleStatus: "ON_SALE",
-  },
-  {
-    matchId: 103,
-    matchAt: "2026-04-05T14:00:00",
-    homeClub: {
-      koName: "키움 히어로즈",
-      enName: "Kiwoom Heroes",
-      logoImg: "/logo/logo5.png",
-    },
-    awayClub: {
-      koName: "두산 베어스",
-      enName: "Doosan Bears",
-      logoImg: "/logo/logo1.png",
-    },
-    stadiumName: "고척 스카이돔",
-    saleStatus: "UPCOMING",
-  },
-];
-
-/* --- API Response Mock Data --- */
-const MOCK_API_RESPONSE = {
-  code: "OK",
-  message: "조회 성공",
-  data: {
-    clubId: 6,
-    year: 2026,
-    month: 3,
-    totalMatchCount: 2,
-    matches: [
-      {
-        matchId: 101,
-        matchAt: "2026-03-28T18:30:00",
-        opponentClub: {
-          clubId: 1,
-          koName: "두산 베어스",
-          logoImg: "/logo/doosan-bears.png", // 실제 경로에 맞춰 수정
-        },
-        saleStatus: "ON_SALE",
-        isHomeMatch: true,
-      },
-      {
-        matchId: 102,
-        matchAt: "2026-03-29T18:30:00",
-        opponentClub: {
-          clubId: 2,
-          koName: "삼성 라이온즈",
-          logoImg: "/logo/samsung-lions.png",
-        },
-        saleStatus: "UPCOMING",
-        isHomeMatch: false,
-      },
-    ],
-  },
-};
-
-/* --- 타입 정의 (API 규격 기준) --- */
 type SaleStatus = "ON_SALE" | "UPCOMING" | "SOLD_OUT" | "ENDED";
 
 interface Match {
@@ -189,93 +39,109 @@ interface Match {
   isHomeMatch: boolean;
 }
 
+const seasonStats = [
+  { label: "순위", value: "3" },
+  { label: "승", value: "32" },
+  { label: "무", value: "2" },
+  { label: "패", value: "13" },
+];
+
+const detailedStats = [
+  { label: "승률", value: "0.582" },
+  { label: "타율", value: "0.311" },
+  { label: "평균자책", value: "2.9" },
+  { label: "승차", value: "0.0" },
+];
+
+// 제공해주신 API 응답 데이터 (달력 렌더링용)
+const MOCK_API_RESPONSE = {
+  data: {
+    matches: [
+      {
+        matchId: 101,
+        matchAt: "2026-03-28T14:00:00",
+        opponentClub: {
+          clubId: 1,
+          koName: "kt 위즈",
+          logoImg: "/logo/logo4.png",
+        },
+        saleStatus: "SOLD_OUT" as SaleStatus,
+        isHomeMatch: true,
+      },
+      {
+        matchId: 102,
+        matchAt: "2026-03-29T14:00:00",
+        opponentClub: {
+          clubId: 2,
+          koName: "kt 위즈",
+          logoImg: "/logo/logo4.png",
+        },
+        saleStatus: "ON_SALE" as SaleStatus,
+        isHomeMatch: true,
+      },
+      {
+        matchId: 103,
+        matchAt: "2026-03-31T18:30:00",
+        opponentClub: {
+          clubId: 3,
+          koName: "기아 타이거즈",
+          logoImg: "/logo/logo1.png",
+        },
+        saleStatus: "UPCOMING" as SaleStatus,
+        isHomeMatch: false,
+      },
+    ],
+  },
+};
+
 export default function ClubDetailPage() {
   const params = useParams();
-  const clubId = useMemo(() => {
-    const raw = (params as Record<string, string | string[] | undefined>)
-      ?.clubId;
-    return Array.isArray(raw) ? raw[0] : raw;
-  }, [params]);
-
-  const [currentMonth, setCurrentMonth] = useState(new Date(2026, 2, 1)); // 2026년 3월 기준
+  const [currentMonth, setCurrentMonth] = useState(new Date(2026, 2, 1));
   const [loading, setLoading] = useState(false);
-  const [clubData, setClubData] = useState<ClubDetail | null>(null);
-  const [matches, setMatches] = useState<MatchSummary[]>([]);
 
   useEffect(() => {
-    if (!clubId) return;
     setLoading(true);
-    setTimeout(() => {
-      setClubData(MOCK_CLUB_DATA[clubId] || MOCK_CLUB_DATA["1"]);
-      setMatches(MOCK_MATCHES);
-      setLoading(false);
-    }, 500);
-  }, [clubId]);
+    const timer = setTimeout(() => setLoading(false), 500);
+    return () => clearTimeout(timer);
+  }, [params.clubId]);
 
-  /* 달력 생성 로직 */
+  /* 1. 달력 날짜 생성 (useMemo) */
   const days = useMemo(() => {
-    const monthStart = startOfMonth(currentMonth);
-    const monthEnd = endOfMonth(monthStart);
-    const startDate = startOfWeek(monthStart);
-    const endDate = endOfWeek(monthEnd);
-    return eachDayOfInterval({ start: startDate, end: endDate });
+    const start = startOfWeek(startOfMonth(currentMonth));
+    const end = endOfWeek(endOfMonth(currentMonth));
+    return eachDayOfInterval({ start, end });
   }, [currentMonth]);
 
-  if (loading) {
+  /* 2. 경기 데이터 매핑 최적화 (useMemo) */
+  const matchMap = useMemo(() => {
+    const map: Record<string, Match> = {};
+    MOCK_API_RESPONSE.data.matches.forEach((match) => {
+      const dateKey = format(new Date(match.matchAt), "yyyy-MM-dd");
+      map[dateKey] = match;
+    });
+    return map;
+  }, []);
+
+  const nextMonth = () => setCurrentMonth(addMonths(currentMonth, 1));
+  const prevMonth = () => setCurrentMonth(subMonths(currentMonth, 1));
+
+  if (loading)
     return (
       <div className="grid min-h-screen place-items-center">
         <Spinner className="h-6 w-6" />
       </div>
     );
-  }
-
-  if (!clubData) return null;
-
-  const nextMonth = () => setCurrentMonth(addMonths(currentMonth, 1));
-  const prevMonth = () => setCurrentMonth(subMonths(currentMonth, 1));
 
   return (
-    <div className="w-full min-h-screen bg-[var(--background-white)]">
-      {/* ===== Hero Section ===== */}
-      {/* <section className="relative w-full h-[300px] sm:h-[400px] overflow-hidden bg-black">
-        <div className="absolute inset-0">
-          <Image
-            src="/match/detail.png"
-            alt="Club Background"
-            fill
-            className="object-cover blur-[4px] opacity-60"
-            priority
-          />
-          <div className="absolute inset-0 bg-gradient-to-b from-transparent to-black/80" />
-        </div>
-
-        <div className="relative h-full max-w-[1440px] mx-auto px-4 sm:px-6 lg:px-28 flex flex-col justify-end pb-8 sm:pb-12">
-          <div className="flex items-center gap-6 sm:gap-10">
-            <div className="shrink-0 bg-white/10 rounded-2xl p-4 backdrop-blur-sm outline outline-1 outline-white/20">
-              <img
-                src={clubData.logoImg}
-                alt={clubData.koName}
-                className="w-24 h-24 sm:w-32 sm:h-32 object-contain"
-              />
-            </div>
-            <div className="flex flex-col gap-1 sm:gap-2">
-              <h1 className="text-[var(--foundation-neutral-white)] text-3xl sm:text-5xl font-bold font-['Pretendard']">
-                {clubData.koName}
-              </h1>
-              <p className="text-[var(--foundation-neutral-840)] text-sm sm:text-lg font-normal font-['Pretendard']">
-                {clubData.enName}
-              </p>
-            </div>
-          </div>
-        </div>
-      </section> */}
+    <div className="w-full min-h-screen bg-white">
+      {/* ===== Hero Section: 사용자 요청대로 이전 사이즈/스타일 완전 복원 ===== */}
       <div className="w-full bg-[#a32c41] py-16 px-4 flex justify-center items-center">
         <div className="max-w-6xl w-full flex flex-row items-center gap-16">
           {/* 1. 로고 영역 */}
           <div className="flex-shrink-0 w-64 h-64 bg-white rounded-2xl flex items-center justify-center shadow-lg">
             <div className="relative w-48 h-48">
               <Image
-                src="/logo/logo4.png" // 실제 경로로 수정 필요
+                src="/logo/logo4.png"
                 alt="LG 트윈스 로고"
                 fill
                 className="object-contain"
@@ -299,10 +165,8 @@ export default function ClubDetailPage() {
                 </button>
               </div>
             </div>
-
             <a
-              href="https://www.lgtwins.com"
-              target="_blank"
+              href="#"
               className="flex items-center gap-1 text-sm font-medium hover:underline w-fit group"
             >
               공식 홈페이지로 이동하기
@@ -313,14 +177,12 @@ export default function ClubDetailPage() {
             </a>
           </div>
 
-          {/* 3. 시즌 성적 영역 (Grid) */}
+          {/* 3. 시즌 성적 영역 (이전 디자인 그대로) */}
           <div className="flex flex-col gap-8 flex-1 ml-10">
             <div className="text-red-300 font-semibold tracking-wider text-sm">
               2026 시즌
             </div>
-
             <div className="grid grid-cols-1 gap-y-8">
-              {/* 상단 스탯 (순위, 승, 무, 패) */}
               <div className="grid grid-cols-4 w-full">
                 {seasonStats.map((stat, idx) => (
                   <div
@@ -336,8 +198,6 @@ export default function ClubDetailPage() {
                   </div>
                 ))}
               </div>
-
-              {/* 하단 스탯 (승률, 타율 등) */}
               <div className="grid grid-cols-4 w-full">
                 {detailedStats.map((stat, idx) => (
                   <div
@@ -358,144 +218,131 @@ export default function ClubDetailPage() {
         </div>
       </div>
 
-      {/* ===== Main Content ===== */}
-      <section className="mx-auto w-full max-w-[1200px] px-4 sm:px-6 py-12">
-        <div className="flex flex-col gap-10">
-          {/* Calendar Section */}
-          <div className="flex flex-col gap-8">
-            <div className="flex items-center justify-between">
-              <h2 className="text-2xl font-bold text-[var(--foundation-neutral-20)] font-['Pretendard']">
-                경기 일정
-              </h2>
+      {/* ===== Calendar Section ===== */}
+      <section className="mx-auto w-full max-w-[1200px] px-4 py-12 font-sans">
+        <div className="flex flex-col gap-8">
+          <div className="flex flex-col gap-1">
+            <span className="text-[11px] font-bold text-emerald-500 uppercase tracking-widest">
+              Team Schedules
+            </span>
+            <h2 className="text-2xl font-bold text-slate-900">
+              LG 트윈스의 모든 경기일정
+            </h2>
+          </div>
 
-              {/* Calendar Controller */}
-              <div className="flex items-center gap-6 bg-[var(--background-grey)] px-4 py-2 rounded-full border border-[var(--foundation-neutral-880)]">
-                <button
-                  onClick={prevMonth}
-                  className="p-1 hover:bg-white rounded-full transition-colors"
+          <div className="flex items-center justify-center gap-10 py-4">
+            <button
+              onClick={prevMonth}
+              className="p-2 hover:bg-slate-100 rounded-full transition-colors"
+            >
+              <ChevronLeft size={24} />
+            </button>
+            <h3 className="text-2xl font-bold tracking-tight">
+              {format(currentMonth, "yyyy. MM")}
+            </h3>
+            <button
+              onClick={nextMonth}
+              className="p-2 hover:bg-slate-100 rounded-full transition-colors"
+            >
+              <ChevronRight size={24} />
+            </button>
+          </div>
+
+          <div className="flex justify-end items-center gap-1.5 mb-2">
+            <div className="w-2 h-2 rounded-full bg-emerald-500" />
+            <span className="text-[11px] font-semibold text-slate-500">
+              홈 경기
+            </span>
+          </div>
+
+          {/* 달력 컨테이너: 요일 헤더에서 월요일에만 색상 부여 */}
+          <div className="w-full">
+            <div className="grid grid-cols-7 border-y border-slate-200 text-[11px] font-bold py-4">
+              {["일", "월", "화", "수", "목", "금", "토"].map((day, i) => (
+                <div
+                  key={day}
+                  className={cn(
+                    "text-center",
+                    i === 1 ? "text-emerald-500" : "text-slate-600",
+                  )}
                 >
-                  <ChevronLeft className="w-5 h-5" />
-                </button>
-                <span className="text-lg font-bold min-w-[100px] text-center">
-                  {format(currentMonth, "yyyy. MM", { locale: ko })}
-                </span>
-                <button
-                  onClick={nextMonth}
-                  className="p-1 hover:bg-white rounded-full transition-colors"
-                >
-                  <ChevronRight className="w-5 h-5" />
-                </button>
-              </div>
+                  {day}
+                </div>
+              ))}
             </div>
 
-            {/* Large Calendar Grid */}
-            <div className="w-full bg-white rounded-3xl border border-[var(--foundation-neutral-880)] overflow-hidden shadow-sm">
-              {/* Day Headers */}
-              <div className="grid grid-cols-7 bg-[var(--background-grey)] border-b border-[var(--foundation-neutral-880)]">
-                {["일", "월", "화", "수", "목", "금", "토"].map((day, i) => (
+            {/* 날짜 그리드: 각 날짜가 개별 카드 형태 */}
+            <div className="grid grid-cols-7 gap-2 mt-4">
+              {days.map((day) => {
+                const dateKey = format(day, "yyyy-MM-dd");
+                const match = matchMap[dateKey];
+                const isCurrentMonth = isSameMonth(day, currentMonth);
+
+                return (
                   <div
-                    key={day}
+                    key={dateKey}
                     className={cn(
-                      "py-4 text-center text-sm font-semibold",
-                      i === 0
-                        ? "text-red-500"
-                        : i === 6
-                          ? "text-blue-500"
-                          : "text-[var(--foundation-neutral-400)]",
+                      "min-h-[200px] p-3 border border-slate-200 rounded-lg flex flex-col items-center transition-all",
+                      !match && "bg-slate-50", // 경기가 없으면 회색 배경 처리
+                      !isCurrentMonth && "opacity-30",
                     )}
                   >
-                    {day}
-                  </div>
-                ))}
-              </div>
-
-              {/* Grid Cells */}
-              <div className="grid grid-cols-7">
-                {days.map((day, idx) => {
-                  const dayMatches = matches.filter((m) =>
-                    isSameDay(new Date(m.matchAt), day),
-                  );
-                  const isCurrentMonth = isSameMonth(day, currentMonth);
-
-                  return (
-                    <div
-                      key={day.toString()}
-                      className={cn(
-                        "min-h-[140px] p-2 border-r border-b border-[var(--foundation-neutral-940)] flex flex-col gap-2",
-                        !isCurrentMonth &&
-                          "bg-[var(--background-grey)]/30 opacity-40",
-                        (idx + 1) % 7 === 0 && "border-r-0",
-                      )}
-                    >
-                      <span
-                        className={cn(
-                          "text-xs font-bold px-1.5 py-0.5 rounded-md self-start",
-                          isSameDay(day, new Date())
-                            ? "bg-[var(--foundation-primary-500)] text-white"
-                            : "text-[var(--foundation-neutral-600)]",
-                        )}
-                      >
+                    <div className="w-full flex items-center gap-1 mb-6">
+                      <span className="text-[11px] font-bold text-slate-400">
                         {format(day, "d")}
                       </span>
-
-                      {/* Match Content in Cell */}
-                      <div className="flex flex-col gap-1.5 overflow-y-auto max-h-[100px] scrollbar-hide">
-                        {dayMatches.map((match) => {
-                          const isHome =
-                            match.homeClub.koName === clubData.koName;
-                          const opponent = isHome
-                            ? match.awayClub
-                            : match.homeClub;
-                          const status = match.saleStatus;
-
-                          return (
-                            <div
-                              key={match.matchId}
-                              className={cn(
-                                "p-2 rounded-xl text-[10px] sm:text-xs font-medium border flex flex-col gap-1 cursor-pointer transition-all hover:scale-[1.02]",
-                                isHome
-                                  ? "bg-[var(--foundation-primary-50)] border-[var(--foundation-primary-200)]"
-                                  : "bg-white border-[var(--foundation-neutral-880)]",
-                              )}
-                            >
-                              <div className="flex items-center justify-between gap-1">
-                                <span
-                                  className={cn(
-                                    "px-1 rounded",
-                                    isHome
-                                      ? "text-[var(--foundation-primary-600)]"
-                                      : "text-[var(--foundation-neutral-400)]",
-                                  )}
-                                >
-                                  {isHome ? "HOME" : "AWAY"}
-                                </span>
-                                <span className="text-[var(--foundation-neutral-600)]">
-                                  {format(new Date(match.matchAt), "HH:mm")}
-                                </span>
-                              </div>
-                              <div className="flex items-center gap-2">
-                                <img
-                                  src={opponent.logoImg}
-                                  className="w-4 h-4 object-contain"
-                                  alt=""
-                                />
-                                <span className="truncate font-bold">
-                                  vs {opponent.koName}
-                                </span>
-                              </div>
-                              {status === "ON_SALE" && (
-                                <div className="mt-1 text-[9px] text-center bg-[var(--foundation-red-500)] text-white py-0.5 rounded-full">
-                                  예매중
-                                </div>
-                              )}
-                            </div>
-                          );
-                        })}
-                      </div>
+                      <span className="text-[10px] text-slate-200">-</span>
+                      {match?.isHomeMatch && (
+                        <div className="ml-auto w-1.5 h-1.5 rounded-full bg-emerald-500" />
+                      )}
                     </div>
-                  );
-                })}
-              </div>
+
+                    {match ? (
+                      <Link
+                        href={`/matches/${match.matchId}`}
+                        className="w-full flex-1 flex flex-col items-center gap-3 group cursor-pointer"
+                      >
+                        <div className="text-[11px] font-bold text-slate-800">
+                          {format(new Date(match.matchAt), "HH:mm")}
+                        </div>
+                        <div className="relative w-16 h-14 transition-transform group-hover:scale-110">
+                          <Image
+                            src={match.opponentClub.logoImg}
+                            alt={match.opponentClub.koName}
+                            fill
+                            className="object-contain"
+                          />
+                        </div>
+                        <div className="text-[12px] font-black text-slate-900">
+                          {match.opponentClub.koName}
+                        </div>
+                        <div
+                          className={cn(
+                            "mt-auto text-[10px] font-bold w-full py-1.5 transition-all text-center",
+                            match.saleStatus === "ON_SALE"
+                              ? "text-emerald-500"
+                              : match.saleStatus === "SOLD_OUT"
+                                ? "text-slate-500"
+                                : "text-blue-500",
+                          )}
+                        >
+                          {match.saleStatus === "ON_SALE"
+                            ? "예매 가능"
+                            : match.saleStatus === "SOLD_OUT"
+                              ? "매진"
+                              : "판매 예정"}
+                        </div>
+                      </Link>
+                    ) : (
+                      <div className="flex-1 flex items-center justify-center text-center">
+                        <span className="text-[10px] text-slate-400 font-medium leading-tight">
+                          경기가 없습니다
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
             </div>
           </div>
         </div>

--- a/goorm-gongbang/app/clubs/[clubId]/page.tsx
+++ b/goorm-gongbang/app/clubs/[clubId]/page.tsx
@@ -91,6 +91,13 @@ const MOCK_API_RESPONSE = {
   },
 };
 
+const SALE_STATUS_CONFIG = {
+  ON_SALE: { label: "예매 가능", color: "text-emerald-500" },
+  SOLD_OUT: { label: "매진", color: "text-slate-500" },
+  UPCOMING: { label: "판매 예정", color: "text-blue-500" },
+  ENDED: { label: "판매 종료", color: "text-slate-400" }, // 종료는 조금 더 흐리게 처리 가능
+} as const;
+
 export default function ClubDetailPage() {
   const params = useParams();
   const [currentMonth, setCurrentMonth] = useState(new Date(2026, 2, 1));
@@ -181,9 +188,9 @@ export default function ClubDetailPage() {
             </div>
             <div className="grid grid-cols-1 gap-y-8">
               <div className="grid grid-cols-4 w-full">
-                {seasonStats.map((stat, idx) => (
+                {seasonStats.map((stat) => (
                   <div
-                    key={idx}
+                    key={stat.label}
                     className="border-r border-red-400/30 last:border-none px-4"
                   >
                     <div className="text-red-200 text-xs mb-1 opacity-80">
@@ -196,9 +203,9 @@ export default function ClubDetailPage() {
                 ))}
               </div>
               <div className="grid grid-cols-4 w-full">
-                {detailedStats.map((stat, idx) => (
+                {detailedStats.map((stat) => (
                   <div
-                    key={idx}
+                    key={stat.label}
                     className="border-r border-red-400/30 last:border-none px-4"
                   >
                     <div className="text-red-200 text-xs mb-1 opacity-80">
@@ -274,6 +281,9 @@ export default function ClubDetailPage() {
                 const dateKey = format(day, "yyyy-MM-dd");
                 const match = matchMap[dateKey];
                 const isCurrentMonth = isSameMonth(day, currentMonth);
+                const config = match
+                  ? SALE_STATUS_CONFIG[match.saleStatus]
+                  : null;
 
                 return (
                   <div
@@ -320,7 +330,7 @@ export default function ClubDetailPage() {
 
                     {/* 하단 경기 정보 영역 */}
                     <div className="flex-1 w-full p-3 flex flex-col items-center">
-                      {match ? (
+                      {match && config ? (
                         <Link
                           href={`/matches/${match.matchId}`}
                           className="w-full h-full flex flex-col items-center gap-3 group cursor-pointer"
@@ -340,18 +350,10 @@ export default function ClubDetailPage() {
                           <div
                             className={cn(
                               "mt-auto text-[10px] font-bold w-full py-1.5 transition-all text-center",
-                              match.saleStatus === "ON_SALE"
-                                ? "text-emerald-500"
-                                : match.saleStatus === "SOLD_OUT"
-                                  ? "text-slate-500"
-                                  : "text-blue-500",
+                              config.color,
                             )}
                           >
-                            {match.saleStatus === "ON_SALE"
-                              ? "예매 가능"
-                              : match.saleStatus === "SOLD_OUT"
-                                ? "매진"
-                                : "판매 예정"}
+                            {config.label}
                           </div>
                         </Link>
                       ) : (

--- a/goorm-gongbang/app/clubs/[clubId]/page.tsx
+++ b/goorm-gongbang/app/clubs/[clubId]/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import * as React from "react";
 import { useState, useMemo, useEffect } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
@@ -19,7 +18,6 @@ import {
   isSameDay,
   eachDayOfInterval,
 } from "date-fns";
-import { ko } from "date-fns/locale";
 import { ChevronLeft, ChevronRight, Copy } from "lucide-react";
 
 /* ===========================
@@ -53,7 +51,6 @@ const detailedStats = [
   { label: "승차", value: "0.0" },
 ];
 
-// 제공해주신 API 응답 데이터 (달력 렌더링용)
 const MOCK_API_RESPONSE = {
   data: {
     matches: [
@@ -134,7 +131,7 @@ export default function ClubDetailPage() {
 
   return (
     <div className="w-full min-h-screen bg-white">
-      {/* ===== Hero Section: 사용자 요청대로 이전 사이즈/스타일 완전 복원 ===== */}
+      {/* ===== Hero Section ===== */}
       <div className="w-full bg-[#a32c41] py-16 px-4 flex justify-center items-center">
         <div className="max-w-6xl w-full flex flex-row items-center gap-16">
           {/* 1. 로고 영역 */}
@@ -177,7 +174,7 @@ export default function ClubDetailPage() {
             </a>
           </div>
 
-          {/* 3. 시즌 성적 영역 (이전 디자인 그대로) */}
+          {/* 3. 시즌 성적 영역 */}
           <div className="flex flex-col gap-8 flex-1 ml-10">
             <div className="text-red-300 font-semibold tracking-wider text-sm">
               2026 시즌
@@ -282,64 +279,89 @@ export default function ClubDetailPage() {
                   <div
                     key={dateKey}
                     className={cn(
-                      "min-h-[200px] p-3 border border-slate-200 rounded-lg flex flex-col items-center transition-all",
-                      !match && "bg-slate-50", // 경기가 없으면 회색 배경 처리
+                      "min-h-[200px] border border-slate-200 rounded-lg flex flex-col items-center transition-all overflow-hidden",
+                      !match && "bg-[var(--background-grey)]", // 경기가 없으면 회색 배경 처리
                       !isCurrentMonth && "opacity-30",
                     )}
                   >
-                    <div className="w-full flex items-center gap-1 mb-6">
-                      <span className="text-[11px] font-bold text-slate-400">
-                        {format(day, "d")}
-                      </span>
-                      <span className="text-[10px] text-slate-200">-</span>
+                    {/* 날짜 및 시간 헤더 영역 */}
+                    <div className="w-full flex items-center px-3 py-2 border-b border-slate-300">
+                      <div className="flex items-center gap-1.5">
+                        <span
+                          className={cn(
+                            "text-[11px] font-bold",
+                            match
+                              ? "text-[var(--text-normal-n240)]"
+                              : "text-slate-400",
+                          )}
+                        >
+                          {format(day, "d")}
+                        </span>
+                        <span
+                          className={cn(
+                            "text-[11px] font-bold",
+                            match
+                              ? "text-[var(--text-normal-n240)]"
+                              : "text-slate-400",
+                          )}
+                        >
+                          {/* 경기가 있으면 시간(14:00), 없으면 '-' 표시 */}
+                          {match
+                            ? format(new Date(match.matchAt), "HH:mm")
+                            : "-"}
+                        </span>
+                      </div>
+
+                      {/* 홈 경기일 경우 우측 상단 초록색 점 */}
                       {match?.isHomeMatch && (
                         <div className="ml-auto w-1.5 h-1.5 rounded-full bg-emerald-500" />
                       )}
                     </div>
 
-                    {match ? (
-                      <Link
-                        href={`/matches/${match.matchId}`}
-                        className="w-full flex-1 flex flex-col items-center gap-3 group cursor-pointer"
-                      >
-                        <div className="text-[11px] font-bold text-slate-800">
-                          {format(new Date(match.matchAt), "HH:mm")}
-                        </div>
-                        <div className="relative w-16 h-14 transition-transform group-hover:scale-110">
-                          <Image
-                            src={match.opponentClub.logoImg}
-                            alt={match.opponentClub.koName}
-                            fill
-                            className="object-contain"
-                          />
-                        </div>
-                        <div className="text-[12px] font-black text-slate-900">
-                          {match.opponentClub.koName}
-                        </div>
-                        <div
-                          className={cn(
-                            "mt-auto text-[10px] font-bold w-full py-1.5 transition-all text-center",
-                            match.saleStatus === "ON_SALE"
-                              ? "text-emerald-500"
-                              : match.saleStatus === "SOLD_OUT"
-                                ? "text-slate-500"
-                                : "text-blue-500",
-                          )}
+                    {/* 하단 경기 정보 영역 */}
+                    <div className="flex-1 w-full p-3 flex flex-col items-center">
+                      {match ? (
+                        <Link
+                          href={`/matches/${match.matchId}`}
+                          className="w-full h-full flex flex-col items-center gap-3 group cursor-pointer"
                         >
-                          {match.saleStatus === "ON_SALE"
-                            ? "예매 가능"
-                            : match.saleStatus === "SOLD_OUT"
-                              ? "매진"
-                              : "판매 예정"}
+                          {/* 로고와 팀명 표시 */}
+                          <div className="relative w-16 h-14 mt-2 transition-transform group-hover:scale-110">
+                            <Image
+                              src={match.opponentClub.logoImg}
+                              alt={match.opponentClub.koName}
+                              fill
+                              className="object-contain"
+                            />
+                          </div>
+                          <div className="text-[12px] font-black text-slate-900">
+                            {match.opponentClub.koName}
+                          </div>
+                          <div
+                            className={cn(
+                              "mt-auto text-[10px] font-bold w-full py-1.5 transition-all text-center",
+                              match.saleStatus === "ON_SALE"
+                                ? "text-emerald-500"
+                                : match.saleStatus === "SOLD_OUT"
+                                  ? "text-slate-500"
+                                  : "text-blue-500",
+                            )}
+                          >
+                            {match.saleStatus === "ON_SALE"
+                              ? "예매 가능"
+                              : match.saleStatus === "SOLD_OUT"
+                                ? "매진"
+                                : "판매 예정"}
+                          </div>
+                        </Link>
+                      ) : (
+                        <div className="h-full flex items-center justify-center text-center">
+                          <span className="text-[10px] text-slate-400 font-medium leading-tight">
+                            경기가 없습니다
+                          </span>
                         </div>
-                      </Link>
-                    ) : (
-                      <div className="flex-1 flex items-center justify-center text-center">
-                        <span className="text-[10px] text-slate-400 font-medium leading-tight">
-                          경기가 없습니다
-                        </span>
-                      </div>
-                    )}
+                      )}
+                    </div>
                   </div>
                 );
               })}

--- a/goorm-gongbang/app/clubs/[clubId]/page.tsx
+++ b/goorm-gongbang/app/clubs/[clubId]/page.tsx
@@ -1,14 +1,505 @@
 "use client";
 
 import * as React from "react";
+import { useState, useMemo, useEffect } from "react";
+import { useParams } from "next/navigation";
+import Image from "next/image";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button"; // shadcn/ui
+import {
+  format,
+  addMonths,
+  subMonths,
+  startOfMonth,
+  endOfMonth,
+  startOfWeek,
+  endOfWeek,
+  isSameMonth,
+  isSameDay,
+  addDays,
+  eachDayOfInterval,
+} from "date-fns";
+import { ko } from "date-fns/locale";
+import { ChevronLeft, ChevronRight, Copy } from "lucide-react";
 
-export default function ClubDetailPage({ params }: { params: Promise<{ clubId: string }> }) {
-  const { clubId } = React.use(params);
+/* ===========================
+    API TYPES (Mocked)
+=========================== */
+type ClubDetail = {
+  clubId: number;
+  koName: string;
+  enName: string;
+  logoImg: string;
+  clubColor: string;
+  stadiumName: string;
+  stadiumAddress: string;
+  description?: string;
+};
+
+type MatchSummary = {
+  matchId: number;
+  matchAt: string;
+  homeClub: { koName: string; enName: string; logoImg: string };
+  awayClub: { koName: string; enName: string; logoImg: string };
+  stadiumName: string;
+  saleStatus: "ON_SALE" | "UPCOMING" | "SOLD_OUT" | "ENDED";
+};
+
+/* ===========================
+    MOCK DATA
+=========================== */
+const seasonStats = [
+  { label: "순위", value: "3" },
+  { label: "승", value: "32" },
+  { label: "무", value: "2" },
+  { label: "패", value: "13" },
+];
+
+const detailedStats = [
+  { label: "승률", value: "0.582" },
+  { label: "타율", value: "0.311" },
+  { label: "평균자책", value: "2.9" },
+  { label: "승차", value: "0.0" },
+];
+
+const MOCK_CLUB_DATA: Record<string, ClubDetail> = {
+  "1": {
+    clubId: 1,
+    koName: "두산 베어스",
+    enName: "Doosan Bears",
+    logoImg: "/logo/logo1.png",
+    clubColor: "#131230",
+    stadiumName: "잠실 야구장",
+    stadiumAddress: "서울특별시 송파구 올림픽로 25",
+    description: "서울을 연고지로 하는 KBO 리그의 프로야구단입니다.",
+  },
+  "2": {
+    clubId: 2,
+    koName: "LG 트윈스",
+    enName: "LG Twins",
+    logoImg: "/logo/logo2.png",
+    clubColor: "#C30452",
+    stadiumName: "잠실 야구장",
+    stadiumAddress: "서울특별시 송파구 올림픽로 25",
+    description: "서울을 연고지로 하는 KBO 리그의 프로야구단입니다.",
+  },
+};
+
+// 3월과 4월에 걸친 가상 경기 데이터
+const MOCK_MATCHES: MatchSummary[] = [
+  {
+    matchId: 101,
+    matchAt: "2026-03-24T18:30:00",
+    homeClub: {
+      koName: "두산 베어스",
+      enName: "Doosan Bears",
+      logoImg: "/logo/logo1.png",
+    },
+    awayClub: {
+      koName: "삼성 라이온즈",
+      enName: "Samsung Lions",
+      logoImg: "/logo/logo3.png",
+    },
+    stadiumName: "잠실 야구장",
+    saleStatus: "ENDED",
+  },
+  {
+    matchId: 102,
+    matchAt: "2026-03-29T14:00:00",
+    homeClub: {
+      koName: "두산 베어스",
+      enName: "Doosan Bears",
+      logoImg: "/logo/logo1.png",
+    },
+    awayClub: {
+      koName: "SSG 랜더스",
+      enName: "SSG Landers",
+      logoImg: "/logo/logo4.png",
+    },
+    stadiumName: "잠실 야구장",
+    saleStatus: "ON_SALE",
+  },
+  {
+    matchId: 103,
+    matchAt: "2026-04-05T14:00:00",
+    homeClub: {
+      koName: "키움 히어로즈",
+      enName: "Kiwoom Heroes",
+      logoImg: "/logo/logo5.png",
+    },
+    awayClub: {
+      koName: "두산 베어스",
+      enName: "Doosan Bears",
+      logoImg: "/logo/logo1.png",
+    },
+    stadiumName: "고척 스카이돔",
+    saleStatus: "UPCOMING",
+  },
+];
+
+/* --- API Response Mock Data --- */
+const MOCK_API_RESPONSE = {
+  code: "OK",
+  message: "조회 성공",
+  data: {
+    clubId: 6,
+    year: 2026,
+    month: 3,
+    totalMatchCount: 2,
+    matches: [
+      {
+        matchId: 101,
+        matchAt: "2026-03-28T18:30:00",
+        opponentClub: {
+          clubId: 1,
+          koName: "두산 베어스",
+          logoImg: "/logo/doosan-bears.png", // 실제 경로에 맞춰 수정
+        },
+        saleStatus: "ON_SALE",
+        isHomeMatch: true,
+      },
+      {
+        matchId: 102,
+        matchAt: "2026-03-29T18:30:00",
+        opponentClub: {
+          clubId: 2,
+          koName: "삼성 라이온즈",
+          logoImg: "/logo/samsung-lions.png",
+        },
+        saleStatus: "UPCOMING",
+        isHomeMatch: false,
+      },
+    ],
+  },
+};
+
+/* --- 타입 정의 (API 규격 기준) --- */
+type SaleStatus = "ON_SALE" | "UPCOMING" | "SOLD_OUT" | "ENDED";
+
+interface Match {
+  matchId: number;
+  matchAt: string;
+  opponentClub: {
+    clubId: number;
+    koName: string;
+    logoImg: string;
+  };
+  saleStatus: SaleStatus;
+  isHomeMatch: boolean;
+}
+
+export default function ClubDetailPage() {
+  const params = useParams();
+  const clubId = useMemo(() => {
+    const raw = (params as Record<string, string | string[] | undefined>)
+      ?.clubId;
+    return Array.isArray(raw) ? raw[0] : raw;
+  }, [params]);
+
+  const [currentMonth, setCurrentMonth] = useState(new Date(2026, 2, 1)); // 2026년 3월 기준
+  const [loading, setLoading] = useState(false);
+  const [clubData, setClubData] = useState<ClubDetail | null>(null);
+  const [matches, setMatches] = useState<MatchSummary[]>([]);
+
+  useEffect(() => {
+    if (!clubId) return;
+    setLoading(true);
+    setTimeout(() => {
+      setClubData(MOCK_CLUB_DATA[clubId] || MOCK_CLUB_DATA["1"]);
+      setMatches(MOCK_MATCHES);
+      setLoading(false);
+    }, 500);
+  }, [clubId]);
+
+  /* 달력 생성 로직 */
+  const days = useMemo(() => {
+    const monthStart = startOfMonth(currentMonth);
+    const monthEnd = endOfMonth(monthStart);
+    const startDate = startOfWeek(monthStart);
+    const endDate = endOfWeek(monthEnd);
+    return eachDayOfInterval({ start: startDate, end: endDate });
+  }, [currentMonth]);
+
+  if (loading) {
+    return (
+      <div className="grid min-h-screen place-items-center">
+        <Spinner className="h-6 w-6" />
+      </div>
+    );
+  }
+
+  if (!clubData) return null;
+
+  const nextMonth = () => setCurrentMonth(addMonths(currentMonth, 1));
+  const prevMonth = () => setCurrentMonth(subMonths(currentMonth, 1));
 
   return (
-    <div className="p-6">
-      <h1 className="text-xl font-semibold">Match Detail</h1>
-      <p>clubId: {clubId}</p>
+    <div className="w-full min-h-screen bg-[var(--background-white)]">
+      {/* ===== Hero Section ===== */}
+      {/* <section className="relative w-full h-[300px] sm:h-[400px] overflow-hidden bg-black">
+        <div className="absolute inset-0">
+          <Image
+            src="/match/detail.png"
+            alt="Club Background"
+            fill
+            className="object-cover blur-[4px] opacity-60"
+            priority
+          />
+          <div className="absolute inset-0 bg-gradient-to-b from-transparent to-black/80" />
+        </div>
+
+        <div className="relative h-full max-w-[1440px] mx-auto px-4 sm:px-6 lg:px-28 flex flex-col justify-end pb-8 sm:pb-12">
+          <div className="flex items-center gap-6 sm:gap-10">
+            <div className="shrink-0 bg-white/10 rounded-2xl p-4 backdrop-blur-sm outline outline-1 outline-white/20">
+              <img
+                src={clubData.logoImg}
+                alt={clubData.koName}
+                className="w-24 h-24 sm:w-32 sm:h-32 object-contain"
+              />
+            </div>
+            <div className="flex flex-col gap-1 sm:gap-2">
+              <h1 className="text-[var(--foundation-neutral-white)] text-3xl sm:text-5xl font-bold font-['Pretendard']">
+                {clubData.koName}
+              </h1>
+              <p className="text-[var(--foundation-neutral-840)] text-sm sm:text-lg font-normal font-['Pretendard']">
+                {clubData.enName}
+              </p>
+            </div>
+          </div>
+        </div>
+      </section> */}
+      <div className="w-full bg-[#a32c41] py-16 px-4 flex justify-center items-center">
+        <div className="max-w-6xl w-full flex flex-row items-center gap-16">
+          {/* 1. 로고 영역 */}
+          <div className="flex-shrink-0 w-64 h-64 bg-white rounded-2xl flex items-center justify-center shadow-lg">
+            <div className="relative w-48 h-48">
+              <Image
+                src="/logo/logo4.png" // 실제 경로로 수정 필요
+                alt="LG 트윈스 로고"
+                fill
+                className="object-contain"
+              />
+            </div>
+          </div>
+
+          {/* 2. 팀 정보 영역 */}
+          <div className="flex flex-col gap-6 text-white min-w-[280px]">
+            <div>
+              <h1 className="text-5xl font-bold tracking-tight mb-2">
+                LG 트윈스
+              </h1>
+              <div className="flex items-center gap-2 text-red-200 text-sm">
+                <span className="opacity-80">구장</span>
+                <span className="text-white font-medium">
+                  잠실종합운동장 잠실야구장
+                </span>
+                <button className="flex items-center gap-1 hover:text-white transition-colors border-b border-red-200 ml-1">
+                  주소 <Copy size={14} />
+                </button>
+              </div>
+            </div>
+
+            <a
+              href="https://www.lgtwins.com"
+              target="_blank"
+              className="flex items-center gap-1 text-sm font-medium hover:underline w-fit group"
+            >
+              공식 홈페이지로 이동하기
+              <ChevronRight
+                size={16}
+                className="group-hover:translate-x-1 transition-transform"
+              />
+            </a>
+          </div>
+
+          {/* 3. 시즌 성적 영역 (Grid) */}
+          <div className="flex flex-col gap-8 flex-1 ml-10">
+            <div className="text-red-300 font-semibold tracking-wider text-sm">
+              2026 시즌
+            </div>
+
+            <div className="grid grid-cols-1 gap-y-8">
+              {/* 상단 스탯 (순위, 승, 무, 패) */}
+              <div className="grid grid-cols-4 w-full">
+                {seasonStats.map((stat, idx) => (
+                  <div
+                    key={idx}
+                    className="border-r border-red-400/30 last:border-none px-4"
+                  >
+                    <div className="text-red-200 text-xs mb-1 opacity-80">
+                      {stat.label}
+                    </div>
+                    <div className="text-3xl font-bold text-white">
+                      {stat.value}
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {/* 하단 스탯 (승률, 타율 등) */}
+              <div className="grid grid-cols-4 w-full">
+                {detailedStats.map((stat, idx) => (
+                  <div
+                    key={idx}
+                    className="border-r border-red-400/30 last:border-none px-4"
+                  >
+                    <div className="text-red-200 text-xs mb-1 opacity-80">
+                      {stat.label}
+                    </div>
+                    <div className="text-3xl font-bold text-white">
+                      {stat.value}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ===== Main Content ===== */}
+      <section className="mx-auto w-full max-w-[1200px] px-4 sm:px-6 py-12">
+        <div className="flex flex-col gap-10">
+          {/* Calendar Section */}
+          <div className="flex flex-col gap-8">
+            <div className="flex items-center justify-between">
+              <h2 className="text-2xl font-bold text-[var(--foundation-neutral-20)] font-['Pretendard']">
+                경기 일정
+              </h2>
+
+              {/* Calendar Controller */}
+              <div className="flex items-center gap-6 bg-[var(--background-grey)] px-4 py-2 rounded-full border border-[var(--foundation-neutral-880)]">
+                <button
+                  onClick={prevMonth}
+                  className="p-1 hover:bg-white rounded-full transition-colors"
+                >
+                  <ChevronLeft className="w-5 h-5" />
+                </button>
+                <span className="text-lg font-bold min-w-[100px] text-center">
+                  {format(currentMonth, "yyyy. MM", { locale: ko })}
+                </span>
+                <button
+                  onClick={nextMonth}
+                  className="p-1 hover:bg-white rounded-full transition-colors"
+                >
+                  <ChevronRight className="w-5 h-5" />
+                </button>
+              </div>
+            </div>
+
+            {/* Large Calendar Grid */}
+            <div className="w-full bg-white rounded-3xl border border-[var(--foundation-neutral-880)] overflow-hidden shadow-sm">
+              {/* Day Headers */}
+              <div className="grid grid-cols-7 bg-[var(--background-grey)] border-b border-[var(--foundation-neutral-880)]">
+                {["일", "월", "화", "수", "목", "금", "토"].map((day, i) => (
+                  <div
+                    key={day}
+                    className={cn(
+                      "py-4 text-center text-sm font-semibold",
+                      i === 0
+                        ? "text-red-500"
+                        : i === 6
+                          ? "text-blue-500"
+                          : "text-[var(--foundation-neutral-400)]",
+                    )}
+                  >
+                    {day}
+                  </div>
+                ))}
+              </div>
+
+              {/* Grid Cells */}
+              <div className="grid grid-cols-7">
+                {days.map((day, idx) => {
+                  const dayMatches = matches.filter((m) =>
+                    isSameDay(new Date(m.matchAt), day),
+                  );
+                  const isCurrentMonth = isSameMonth(day, currentMonth);
+
+                  return (
+                    <div
+                      key={day.toString()}
+                      className={cn(
+                        "min-h-[140px] p-2 border-r border-b border-[var(--foundation-neutral-940)] flex flex-col gap-2",
+                        !isCurrentMonth &&
+                          "bg-[var(--background-grey)]/30 opacity-40",
+                        (idx + 1) % 7 === 0 && "border-r-0",
+                      )}
+                    >
+                      <span
+                        className={cn(
+                          "text-xs font-bold px-1.5 py-0.5 rounded-md self-start",
+                          isSameDay(day, new Date())
+                            ? "bg-[var(--foundation-primary-500)] text-white"
+                            : "text-[var(--foundation-neutral-600)]",
+                        )}
+                      >
+                        {format(day, "d")}
+                      </span>
+
+                      {/* Match Content in Cell */}
+                      <div className="flex flex-col gap-1.5 overflow-y-auto max-h-[100px] scrollbar-hide">
+                        {dayMatches.map((match) => {
+                          const isHome =
+                            match.homeClub.koName === clubData.koName;
+                          const opponent = isHome
+                            ? match.awayClub
+                            : match.homeClub;
+                          const status = match.saleStatus;
+
+                          return (
+                            <div
+                              key={match.matchId}
+                              className={cn(
+                                "p-2 rounded-xl text-[10px] sm:text-xs font-medium border flex flex-col gap-1 cursor-pointer transition-all hover:scale-[1.02]",
+                                isHome
+                                  ? "bg-[var(--foundation-primary-50)] border-[var(--foundation-primary-200)]"
+                                  : "bg-white border-[var(--foundation-neutral-880)]",
+                              )}
+                            >
+                              <div className="flex items-center justify-between gap-1">
+                                <span
+                                  className={cn(
+                                    "px-1 rounded",
+                                    isHome
+                                      ? "text-[var(--foundation-primary-600)]"
+                                      : "text-[var(--foundation-neutral-400)]",
+                                  )}
+                                >
+                                  {isHome ? "HOME" : "AWAY"}
+                                </span>
+                                <span className="text-[var(--foundation-neutral-600)]">
+                                  {format(new Date(match.matchAt), "HH:mm")}
+                                </span>
+                              </div>
+                              <div className="flex items-center gap-2">
+                                <img
+                                  src={opponent.logoImg}
+                                  className="w-4 h-4 object-contain"
+                                  alt=""
+                                />
+                                <span className="truncate font-bold">
+                                  vs {opponent.koName}
+                                </span>
+                              </div>
+                              {status === "ON_SALE" && (
+                                <div className="mt-1 text-[9px] text-center bg-[var(--foundation-red-500)] text-white py-0.5 rounded-full">
+                                  예매중
+                                </div>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## 🔧 작업 내용
- 구단 상세 및 경기 일정 캘린더 구현
- 날짜별 경기 유무, 상대 팀 로고, 경기 시간 및 예매 상태(예매 가능, 매진, 판매 예정) 

## 🧩 구현 상세 (선택)
- 상태별 분기 처리
- 경기 데이터가 없는 날짜는 '경기가 없습니다' 문구를 노출.
- 티켓 상태(status)에 따라 버튼의 색상과 텍스트가 변경되는 공통 컴포넌트를 적용.

### 📌 관련 Jira Issue
- GRGB-156

## 🧪 테스트 방법 (선택)
- 2026년 3월 이전/이후 달로 이동 시 데이터가 정상적으로 갱신되는지 확인 (좌우 화살표 버튼).
- '예매 가능', '매진', '판매 예정' 각 상태값에 따른 버튼 UI의 시각적 차이 확인.

## ❗ 참고 사항
- UI 작업만 진행, 추후에 기능 추가 필요
- 임시 목 데이터를 생성하여 반영
