### PR TITLE
hotfix(auth): 카카오 로그인 온보딩 분기 로직 수정

### DIFF
--- a/goorm-gongbang/app/(auth)/kakao/callback/page.tsx
+++ b/goorm-gongbang/app/(auth)/kakao/callback/page.tsx
@@ -38,12 +38,11 @@ export default function KakaoCallbackPage() {
         setAccessToken(accessToken);
 
         // 온보딩 분기
-        // if (data?.onboardingRequired) router.replace("/onboarding");
-        // else router.replace("/");
         if (data?.user) {
           setUser({ id: String(data.user.userId), status: data.user.status });
         }
         if (data?.onboardingRequired) router.replace("/onboarding");
+        else router.replace("/");
 
         toast.success("로그인 성공");
       } catch (e) {


### PR DESCRIPTION
## 🔧 작업 내용
- 카카오 로그인 콜백 페이지에서 온보딩 분기 후 기본 이동 경로(`/`)가 설정되지 않던 문제를 수정.
- 온보딩이 필요하지 않은 사용자가 로그인 시 아무 라우팅이 일어나지 않는 케이스를 방지.

## 🧩 구현 상세 (선택)
- 카카오 로그인 응답에서 `data.user`가 존재하면 먼저 `setUser`로 사용자 상태를 저장하도록 유지했습니다.
- `data.onboardingRequired`가 `true`일 경우 `/onboarding`으로, 그렇지 않은 경우 `else` 블록에서 `/`로 이동하도록 분기 구조를 정리했습니다.
- 기존에 주석 처리되어 있던 온보딩 분기 코드를 삭제하고 실제 동작 코드로 반영하여 로직과 코드가 일치하도록 했습니다.

### 📌 관련 Jira Issue
- GRGB-200

## 🧪 테스트 방법 (선택)
- 카카오 로그인 플로우를 통해 `/auth/kakao/callback` 진입
  - 온보딩이 필요한 신규 사용자: 로그인 완료 후 `/onboarding`으로 리다이렉트 되는지 확인
  - 온보딩이 완료된 사용자: 로그인 완료 후 `/`로 리다이렉트 되는지 확인
- 두 케이스 모두에서 `user` 상태(`id`, `status`)가 정상적으로 설정되는지 확인

## ❗ 참고 사항
- 카카오 로그인 API 응답 스펙(`onboardingRequired`, `user`) 변경 시 분기 로직도 함께 검토가 필요합니다.
- 배포 후 카카오 로그인 및 온보딩 플로우를 실제 환경에서 한 번씩 점검하는 것을 권장합니다.