### PR TITLE
Feat/club detail api- 월간 데이터 추가

### DIFF
--- a/goorm-gongbang/app/(public)/clubs/[clubId]/page.tsx
+++ b/goorm-gongbang/app/(public)/clubs/[clubId]/page.tsx
@@ -18,8 +18,8 @@ import {
   eachDayOfInterval,
 } from "date-fns";
 import { ChevronLeft, ChevronRight, Copy } from "lucide-react";
-import { getClubById } from "@/lib/services";
-import type { ClubDetail, SaleStatus } from "@/lib/types";
+import { getClubById, getClubSchedule } from "@/lib/services";
+import type { ClubDetail, SaleStatus, ClubMonthMatches } from "@/lib/types";
 import { CDN_CLUBS_BASE_URL } from "@/lib/api/config";
 import { ApiError } from "@/lib/api";
 
@@ -58,7 +58,10 @@ export default function ClubDetailPage() {
   const [error, setError] = useState<string | null>(null);
   const [club, setClub] = useState<ClubDetail | null>(null);
   const [copied, setCopied] = useState(false);
+  const [matches, setMatches] = useState<CalendarMatch[]>([]);
+  const [matchLoading, setMatchLoading] = useState(false);
 
+  // 주소 복사
   const handleCopyStadium = async () => {
     try {
       await navigator.clipboard.writeText(stadiumName);
@@ -79,7 +82,7 @@ export default function ClubDetailPage() {
     const n = str ? Number(str) : NaN;
     return Number.isFinite(n) && n > 0 ? n : null;
   }, [params]);
-  console.log("clubId", clubId);
+
   useEffect(() => {
     if (!clubId) return;
 
@@ -93,7 +96,7 @@ export default function ClubDetailPage() {
         if (!alive) return;
         setClub((data as ClubDetail) ?? null);
 
-        console.log("detail data:", data);
+        //console.log("detail data:", data);
       } catch (e) {
         if (!alive) return;
         if (e instanceof ApiError) {
@@ -113,16 +116,46 @@ export default function ClubDetailPage() {
     };
   }, [clubId]);
 
+  // 월별 경기 데이터 호출
+  useEffect(() => {
+    if (!clubId) return;
+
+    const fetchSchedule = async () => {
+      setMatchLoading(true);
+      try {
+        const year = currentMonth.getFullYear();
+
+        const month = currentMonth.getMonth() + 1;
+        const res = await getClubSchedule(clubId, year, month);
+        if (res && res.matches) {
+          setMatches(res.matches);
+        }
+      } catch (err) {
+        console.error("일정 로드 실패:", err);
+      } finally {
+        setMatchLoading(false);
+      }
+    };
+
+    fetchSchedule();
+  }, [clubId, currentMonth]); // 달이 바뀌거나 clubId가 바뀌면 다시 호출
+
   const days = useMemo(() => {
     const start = startOfWeek(startOfMonth(currentMonth));
     const end = endOfWeek(endOfMonth(currentMonth));
     return eachDayOfInterval({ start, end });
   }, [currentMonth]);
 
+  // matchMap을 matches 데이터를 기반으로 재구성
   const matchMap = useMemo(() => {
     const map: Record<string, CalendarMatch> = {};
+    matches.forEach((m) => {
+      // "2026-03-28T18:30:00" -> "2026-03-28" 키 생성
+      const dateKey = format(new Date(m.matchAt), "yyyy-MM-dd");
+      map[dateKey] = m;
+    });
     return map;
-  }, []);
+  }, [matches]);
 
   const nextMonth = () => setCurrentMonth(addMonths(currentMonth, 1));
   const prevMonth = () => setCurrentMonth(subMonths(currentMonth, 1));
@@ -456,7 +489,7 @@ export default function ClubDetailPage() {
                           >
                             <div className="relative w-12 h-12 sm:w-14 sm:h-14 lg:w-16 lg:h-14 mt-1 sm:mt-2 transition-transform group-hover:scale-110">
                               <Image
-                                src={match.opponentClub.logoImg}
+                                src={resolveLogoSrc(match.opponentClub.logoImg)}
                                 alt={match.opponentClub.koName}
                                 fill
                                 className="object-contain"

--- a/goorm-gongbang/app/(public)/clubs/[clubId]/page.tsx
+++ b/goorm-gongbang/app/(public)/clubs/[clubId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, type CSSProperties } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
@@ -57,14 +57,29 @@ export default function ClubDetailPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [club, setClub] = useState<ClubDetail | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyStadium = async () => {
+    try {
+      await navigator.clipboard.writeText(stadiumName);
+      setCopied(true);
+
+      setTimeout(() => {
+        setCopied(false);
+      }, 2000); // 2초 후 원복
+    } catch (err) {
+      console.error("복사 실패", err);
+    }
+  };
 
   const clubId = useMemo(() => {
-    const raw = (params as Record<string, string | string[] | undefined>)?.clubId;
+    const raw = (params as Record<string, string | string[] | undefined>)
+      ?.clubId;
     const str = Array.isArray(raw) ? raw[0] : raw;
     const n = str ? Number(str) : NaN;
     return Number.isFinite(n) && n > 0 ? n : null;
   }, [params]);
-
+  console.log("clubId", clubId);
   useEffect(() => {
     if (!clubId) return;
 
@@ -142,6 +157,8 @@ export default function ClubDetailPage() {
   const bgColor = club.clubColor || "#121130";
   const stadiumName = club.stadium?.koName ?? "";
 
+  const isYellowClub = clubId === 4;
+
   return (
     <div className="w-full min-h-screen bg-white">
       {/* ===== Hero Section ===== */}
@@ -149,7 +166,7 @@ export default function ClubDetailPage() {
         className="w-full px-4 py-10 sm:px-6 sm:py-12 lg:px-8 lg:py-16 flex justify-center"
         style={{ background: bgColor }}
       >
-        <div className="w-full max-w-6xl flex flex-col lg:flex-row items-center lg:items-stretch gap-8 lg:gap-12 xl:gap-16">
+        <div className="w-full max-w-6xl flex flex-col lg:flex-row  lg:items-start gap-8 lg:gap-12 xl:gap-16">
           {/* 1. 로고 영역 */}
           <div className="flex-shrink-0 w-36 h-36 sm:w-48 sm:h-48 lg:w-56 lg:h-56 xl:w-64 xl:h-64 bg-white rounded-2xl flex items-center justify-center shadow-lg">
             <div className="relative w-24 h-24 sm:w-32 sm:h-32 lg:w-40 lg:h-40 xl:w-48 xl:h-48">
@@ -163,20 +180,31 @@ export default function ClubDetailPage() {
           </div>
 
           {/* 2. 팀 정보 영역 */}
-          <div className="flex flex-col gap-4 sm:gap-5 lg:gap-6 text-white min-w-0 w-full lg:w-auto text-center lg:text-left">
+          <div className="flex flex-col justify-end  h-full gap-4 sm:gap-5 lg:gap-6 text-white min-w-0 w-full lg:w-auto text-center lg:text-left ">
             <div>
               <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight mb-2 break-words">
                 {club.koName}
               </h1>
 
-              <div className="flex flex-wrap items-center justify-center lg:justify-start gap-2 text-red-200 text-xs sm:text-sm">
+              <div
+                className={cn(
+                  "flex flex-wrap  justify-center lg:justify-start gap-2  text-xs sm:text-sm",
+                  isYellowClub
+                    ? "text-[var(--foundation-yellow-300)]"
+                    : "text-[var(--foundation-red-300)]",
+                )}
+              >
                 <span className="opacity-80">구장</span>
                 <span className="text-white font-medium">{stadiumName}</span>
                 <button
                   type="button"
-                  className="flex items-center gap-1 hover:text-white transition-colors border-b border-red-200"
+                  onClick={handleCopyStadium}
+                  className={cn(
+                    "flex items-center gap-1 hover:text-white transition-colors border-b ",
+                    isYellowClub ? "border-yellow-200" : "border-red-200",
+                  )}
                 >
-                  주소 <Copy size={14} />
+                  {copied ? "복사됨" : "주소"} <Copy size={14} />
                 </button>
               </div>
             </div>
@@ -198,9 +226,16 @@ export default function ClubDetailPage() {
           </div>
 
           {/* 3. 시즌 성적 영역 */}
-          <div className="flex flex-col gap-6 sm:gap-8 flex-1 w-full lg:min-w-0 lg:ml-4 xl:ml-10">
-            <div className="text-red-300 font-semibold tracking-wider text-xs sm:text-sm text-center lg:text-left">
-              2026 시즌
+          <div className="flex flex-col justify-end h-full gap-6 sm:gap-8 flex-1 w-full lg:min-w-0 lg:ml-4 xl:ml-10 mb-2">
+            <div
+              className={cn(
+                " font-semibold tracking-wider text-xs sm:text-sm text-center lg:text-left",
+                isYellowClub
+                  ? "text-[var(--foundation-yellow-300)]"
+                  : "text-[var(--foundation-red-300)]",
+              )}
+            >
+              {club.currentSeasonStats?.seasonYear ?? "2026"} 시즌
             </div>
 
             <div className="grid grid-cols-1 gap-y-6 sm:gap-y-8">
@@ -208,20 +243,34 @@ export default function ClubDetailPage() {
                 <>
                   <div className="grid grid-cols-2 lg:grid-cols-4 w-full gap-y-4">
                     {[
-                      { label: "순위", value: club.currentSeasonStats.rank },
-                      { label: "승", value: club.currentSeasonStats.win },
-                      { label: "무", value: club.currentSeasonStats.draw },
-                      { label: "패", value: club.currentSeasonStats.lose },
+                      {
+                        label: "순위",
+                        value: club.currentSeasonStats.seasonRanking,
+                      },
+                      { label: "승", value: club.currentSeasonStats.wins },
+                      { label: "무", value: club.currentSeasonStats.draws },
+                      { label: "패", value: club.currentSeasonStats.losses },
                     ].map((stat, idx) => (
                       <div
                         key={stat.label}
                         className={cn(
                           "px-3 sm:px-4",
-                          "lg:border-r lg:border-red-400/30 lg:last:border-none",
-                          idx % 2 === 0 ? "border-r border-red-400/20 lg:border-r" : "border-r-0"
+                          isYellowClub
+                            ? "lg:border-yellow-400/30"
+                            : "lg:border-red-400/30",
+                          "lg:border-r lg:last:border-none",
+                          idx % 2 === 0
+                            ? cn(
+                                "border-r",
+                                isYellowClub
+                                  ? "border-yellow-400/20"
+                                  : "border-red-400/20",
+                                "lg:border-r",
+                              )
+                            : "border-r-0",
                         )}
                       >
-                        <div className="text-red-200 text-[11px] sm:text-xs mb-1 opacity-80">
+                        <div className="text-white text-[11px] sm:text-xs mb-1 opacity-80">
                           {stat.label}
                         </div>
                         <div className="text-2xl sm:text-3xl font-bold text-white">
@@ -233,20 +282,40 @@ export default function ClubDetailPage() {
 
                   <div className="grid grid-cols-2 lg:grid-cols-4 w-full gap-y-4">
                     {[
-                      { label: "승률", value: club.currentSeasonStats.winningRate },
-                      { label: "타율", value: club.currentSeasonStats.battingAvg },
+                      {
+                        label: "승률",
+                        value: club.currentSeasonStats.winRate,
+                      },
+                      {
+                        label: "타율",
+                        value: club.currentSeasonStats.battingAverage,
+                      },
                       { label: "평균자책", value: club.currentSeasonStats.era },
-                      { label: "승차", value: club.currentSeasonStats.gamesBehind },
+                      {
+                        label: "승차",
+                        value: club.currentSeasonStats.gamesBehind,
+                      },
                     ].map((stat, idx) => (
                       <div
                         key={stat.label}
                         className={cn(
                           "px-3 sm:px-4",
-                          "lg:border-r lg:border-red-400/30 lg:last:border-none",
-                          idx % 2 === 0 ? "border-r border-red-400/20 lg:border-r" : "border-r-0"
+                          isYellowClub
+                            ? "lg:border-yellow-400/30"
+                            : "lg:border-red-400/30",
+                          "lg:border-r lg:last:border-none",
+                          idx % 2 === 0
+                            ? cn(
+                                "border-r",
+                                isYellowClub
+                                  ? "border-yellow-400/20"
+                                  : "border-red-400/20",
+                                "lg:border-r",
+                              )
+                            : "border-r-0",
                         )}
                       >
-                        <div className="text-red-200 text-[11px] sm:text-xs mb-1 opacity-80">
+                        <div className="text-white text-[11px] sm:text-xs mb-1 opacity-80">
                           {stat.label}
                         </div>
                         <div className="text-2xl sm:text-3xl font-bold text-white break-words">
@@ -257,7 +326,12 @@ export default function ClubDetailPage() {
                   </div>
                 </>
               ) : (
-                <div className="text-sm text-red-100 text-center lg:text-left">
+                <div
+                  className={cn(
+                    "text-sm text-center lg:text-left",
+                    isYellowClub ? "text-yellow-100" : "text-red-100",
+                  )}
+                >
                   현재 시즌 정보가 준비 중입니다.
                 </div>
               )}
@@ -316,7 +390,7 @@ export default function ClubDetailPage() {
                     key={day}
                     className={cn(
                       "text-center",
-                      i === 1 ? "text-emerald-500" : "text-slate-600"
+                      i === 1 ? "text-emerald-500" : "text-slate-600",
                     )}
                   >
                     {day}
@@ -329,7 +403,9 @@ export default function ClubDetailPage() {
                   const dateKey = format(day, "yyyy-MM-dd");
                   const match = matchMap[dateKey];
                   const isCurrentMonth = isSameMonth(day, currentMonth);
-                  const config = match ? SALE_STATUS_CONFIG[match.saleStatus] : null;
+                  const config = match
+                    ? SALE_STATUS_CONFIG[match.saleStatus]
+                    : null;
 
                   return (
                     <div
@@ -338,7 +414,7 @@ export default function ClubDetailPage() {
                         "min-h-[160px] sm:min-h-[180px] lg:min-h-[200px]",
                         "border border-slate-200 rounded-lg flex flex-col items-center transition-all overflow-hidden",
                         !match && "bg-[var(--background-grey)]",
-                        !isCurrentMonth && "opacity-30"
+                        !isCurrentMonth && "opacity-30",
                       )}
                     >
                       <div className="w-full flex items-center px-2 sm:px-3 py-2 border-b border-slate-300">
@@ -348,7 +424,7 @@ export default function ClubDetailPage() {
                               "text-[11px] font-bold",
                               match
                                 ? "text-[var(--text-normal-n240)]"
-                                : "text-slate-400"
+                                : "text-slate-400",
                             )}
                           >
                             {format(day, "d")}
@@ -358,10 +434,12 @@ export default function ClubDetailPage() {
                               "text-[11px] font-bold",
                               match
                                 ? "text-[var(--text-normal-n240)]"
-                                : "text-slate-400"
+                                : "text-slate-400",
                             )}
                           >
-                            {match ? format(new Date(match.matchAt), "HH:mm") : "-"}
+                            {match
+                              ? format(new Date(match.matchAt), "HH:mm")
+                              : "-"}
                           </span>
                         </div>
 
@@ -392,7 +470,7 @@ export default function ClubDetailPage() {
                             <div
                               className={cn(
                                 "mt-auto text-[10px] font-bold w-full py-1.5 transition-all text-center",
-                                config.color
+                                config.color,
                               )}
                             >
                               {config.label}

--- a/goorm-gongbang/app/(public)/clubs/[clubId]/page.tsx
+++ b/goorm-gongbang/app/(public)/clubs/[clubId]/page.tsx
@@ -32,6 +32,10 @@ function resolveLogoSrc(input: string) {
   return new URL(input.replace(/^\//, ""), CDN_CLUBS_BASE_URL).toString();
 }
 
+const COPIED_STATE_RESET_DELAY_MS = 2000;
+const HANHWA_EAGLES_CLUB_ID = 4; // 한화 이글스 클럽 ID 상수화
+const CURRENT_YEAR = new Date().getFullYear(); // 현재 연도 동적 추출
+
 interface CalendarMatch {
   matchId: number;
   matchAt: string;
@@ -53,27 +57,15 @@ const SALE_STATUS_CONFIG = {
 
 export default function ClubDetailPage() {
   const params = useParams();
-  const [currentMonth, setCurrentMonth] = useState(new Date(2026, 2, 1));
+  const [currentMonth, setCurrentMonth] = useState(
+    new Date(CURRENT_YEAR, 2, 1),
+  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [club, setClub] = useState<ClubDetail | null>(null);
   const [copied, setCopied] = useState(false);
   const [matches, setMatches] = useState<CalendarMatch[]>([]);
   const [matchLoading, setMatchLoading] = useState(false);
-
-  // 주소 복사
-  const handleCopyStadium = async () => {
-    try {
-      await navigator.clipboard.writeText(stadiumName);
-      setCopied(true);
-
-      setTimeout(() => {
-        setCopied(false);
-      }, 2000); // 2초 후 원복
-    } catch (err) {
-      console.error("복사 실패", err);
-    }
-  };
 
   const clubId = useMemo(() => {
     const raw = (params as Record<string, string | string[] | undefined>)
@@ -190,7 +182,21 @@ export default function ClubDetailPage() {
   const bgColor = club.clubColor || "#121130";
   const stadiumName = club.stadium?.koName ?? "";
 
-  const isYellowClub = clubId === 4;
+  const isYellowClub = clubId === HANHWA_EAGLES_CLUB_ID;
+
+  // 주소 복사
+  const handleCopyStadium = async () => {
+    try {
+      await navigator.clipboard.writeText(stadiumName);
+      setCopied(true);
+
+      setTimeout(() => {
+        setCopied(false);
+      }, COPIED_STATE_RESET_DELAY_MS); // 2초 후 원복
+    } catch (err) {
+      console.error("복사 실패", err);
+    }
+  };
 
   return (
     <div className="w-full min-h-screen bg-white">
@@ -268,7 +274,7 @@ export default function ClubDetailPage() {
                   : "text-[var(--foundation-red-300)]",
               )}
             >
-              {club.currentSeasonStats?.seasonYear ?? "2026"} 시즌
+              {club.currentSeasonStats?.seasonYear ?? CURRENT_YEAR} 시즌
             </div>
 
             <div className="grid grid-cols-1 gap-y-6 sm:gap-y-8">

--- a/goorm-gongbang/lib/services/order-core.service.ts
+++ b/goorm-gongbang/lib/services/order-core.service.ts
@@ -18,6 +18,7 @@ import type {
   ClubDetail,
   OnboardingStatusResponse,
   OnboardingPreferencesRequest,
+  ClubMonthMatches,
 } from "@/lib/types";
 
 // Re-export types for convenience
@@ -45,17 +46,31 @@ export const getMatchById = (matchId: string | number) =>
   pub.get<MatchDetail>(`${API_BASE_URL}/order/matches/${matchId}`);
 
 /* 구단 목록 조회 */
-export const getClubs = () =>
-  pub.get<ClubsData>(`${API_BASE_URL}/order/clubs`);
+export const getClubs = () => pub.get<ClubsData>(`${API_BASE_URL}/order/clubs`);
 
 /* 구단 상세 조회 */
 export const getClubById = (clubId: string | number) =>
   pub.get<ClubDetail>(`${API_BASE_URL}/order/clubs/${clubId}`);
 
+/* 구단 경기 일정(월 단위) 조회 */
+export const getClubSchedule = (
+  clubId: string | number,
+  year: string | number,
+  month: string | number,
+) =>
+  pub.get<ClubMonthMatches>(
+    `${API_BASE_URL}/order/clubs/${clubId}/matches?year=${year}&month=${month}`,
+  );
+
 /* 온보딩 선호도 조회 */
 export const getOnboardingStatus = () =>
-  auth.get<{ onboardingStatus: boolean }>(`${API_BASE_URL}/order/onboarding/preferences`);
+  auth.get<{ onboardingStatus: boolean }>(
+    `${API_BASE_URL}/order/onboarding/preferences`,
+  );
 
 /* 온보딩 선호도 저장 */
 export const saveOnboardingPreferences = (body: OnboardingPreferencesRequest) =>
-  auth.post<void, OnboardingPreferencesRequest>(`${API_BASE_URL}/order/onboarding/preferences`, body);
+  auth.post<void, OnboardingPreferencesRequest>(
+    `${API_BASE_URL}/order/onboarding/preferences`,
+    body,
+  );

--- a/goorm-gongbang/lib/types/order-core.types.ts
+++ b/goorm-gongbang/lib/types/order-core.types.ts
@@ -9,7 +9,7 @@ export type Club = {
   koName: string; // 구단명(한국어)
   enName: string; // 구단명(영어)
   logoImg: string; // 로고 이미지
-  clubColor?: string; // 브랜드 컬러 
+  clubColor?: string; // 브랜드 컬러
 };
 
 /** 경기장 정보 */
@@ -27,14 +27,15 @@ export type ClubStadium = {
 
 /** 구단 현재 시즌 성적 */
 export type ClubSeasonStats = {
-  rank: number;
-  win: number;
-  draw: number;
-  lose: number;
-  winningRate: number;
-  battingAvg: number;
+  battingAverage: number;
+  draws: number;
   era: number;
   gamesBehind: number;
+  losses: number;
+  seasonRanking: number;
+  seasonYear: number;
+  winRate: number;
+  wins: number;
 };
 
 /** 구단 상세 정보 */
@@ -109,7 +110,13 @@ export type OnboardingStatusResponse = {
 };
 
 /** 온보딩 선호도 - 시점 */
-export type Viewpoint = "CENTER" | "INFIELD_1B" | "INFIELD_3B" | "OUTFIELD_L" | "OUTFIELD_C" | "OUTFIELD_R";
+export type Viewpoint =
+  | "CENTER"
+  | "INFIELD_1B"
+  | "INFIELD_3B"
+  | "OUTFIELD_L"
+  | "OUTFIELD_C"
+  | "OUTFIELD_R";
 
 /** 온보딩 선호도 - 좌석 높이 */
 export type SeatHeight = "LOW" | "MID" | "HIGH" | "ANY";
@@ -127,7 +134,11 @@ export type EnvironmentPref = "SHADE" | "SUN_OK" | "ANY";
 export type MoodPref = "CHEERFUL" | "QUIET" | "ANY";
 
 /** 온보딩 선호도 - 시야 방해 민감도 */
-export type ObstructionSensitivity = "NET_SENSITIVE" | "RAIL_PILLAR_SENSITIVE" | "NORMAL" | "ANY";
+export type ObstructionSensitivity =
+  | "NET_SENSITIVE"
+  | "RAIL_PILLAR_SENSITIVE"
+  | "NORMAL"
+  | "ANY";
 
 /** 온보딩 선호도 - 가격 모드 */
 export type PriceMode = "ANY" | "RANGE";
@@ -148,7 +159,10 @@ export type Preference = {
 };
 
 /** 온보딩 선호도 기본값 (1단계) */
-export type PreferenceBase = Pick<Preference, "priority" | "viewpoint" | "seatHeight" | "section">;
+export type PreferenceBase = Pick<
+  Preference,
+  "priority" | "viewpoint" | "seatHeight" | "section"
+>;
 
 /** 온보딩 선호도 저장 요청 */
 export type OnboardingPreferencesRequest = {

--- a/goorm-gongbang/lib/types/order-core.types.ts
+++ b/goorm-gongbang/lib/types/order-core.types.ts
@@ -169,3 +169,28 @@ export type OnboardingPreferencesRequest = {
   marketingConsent: { marketingAgreed: boolean };
   preferences: Preference[];
 };
+
+/** 구단 월별 경기 조회  - 상대팀 정보 */
+export type OpponentClub = {
+  clubId: number;
+  koName: string;
+  logoImg: string;
+};
+
+/** 구단 월별 경기 조회 - 경기 정보 */
+export type Matches = {
+  matchId: number;
+  matchAt: string;
+  opponentClub: OpponentClub;
+  saleStatus: SaleStatus;
+  isHomeMatch: boolean;
+};
+
+/** 구단 월별 경기 조회 */
+export type ClubMonthMatches = {
+  clubId: number;
+  year: number;
+  month: number;
+  totalMatchCount: number;
+  matches: Matches[];
+};


### PR DESCRIPTION
## 🔧 작업 내용
- 구단 상세 정보 및 월별 경기 일정 페이지 개발: 구단의 시즌 성적, 경기 일정(달력형)을 확인할 수 있는 상세 페이지를 구현.

- 특정 구단 테마 적용: 한화 이글스(clubId: 4) 등 특정 구단 선택 시 UI 테마가 노란색으로 변경되도록 수정(기존 색상 유지시 한화의 배경색과 어울리지 않고 잘 보이지 않는 문제가 있음).

- API 연동 및 데이터 매핑: 구단 기본 정보 및 월별 일정 조회 API를 연동하고, 서버 데이터를 달력 UI에 맞게 가공하는 로직 구현.

## 🧩 구현 상세 (선택)
- 조건부 스타일링: isYellowClub 변수를 선언하여 Number(clubId) === 4 조건에 따라 CSS 변수(--foundation-red-300) 및 Tailwind 클래스를 동적으로 적용.

- 쿼리 스트링 API 호출: pub.get 환경에 맞춰 URL에 직접 year, month 파라미터를 조합하여 월별 데이터를 호출다.

### 📌 관련 Jira Issue
- GRGB-204

## 🧪 테스트 방법 (선택)
- 테스트 대상
- Endpoint / 함수 / 스크립트
- 파라미터 및 체크 포인트

## ❗ 참고 사항
- 리뷰 시 유의할 점
- 후속 작업 예정
- 배포 시 주의 사항
