### PR TITLE
feat(CI): ci action yaml before vercel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: goorm-gongbang/package-lock.json
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [dev, staging, prod]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: goorm-gongbang
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: goorm-gongbang/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check & Build
+        run: npm run build
+
+      - name: Notify Discord on Failure
+        if: failure()
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          curl -X POST "$WEBHOOK" -H "Content-Type: application/json" -d '{
+            "embeds": [{
+              "title": "❌ CI 빌드 실패",
+              "color": 15158332,
+              "fields": [
+                {"name": "PR", "value": "['"$PR_TITLE"']('"$PR_URL"')", "inline": false},
+                {"name": "Author", "value": "'"$PR_AUTHOR"'", "inline": true}
+              ],
+              "footer": {"text": "goormgb-frontend"},
+              "timestamp": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
+            }]
+          }'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
           node-version: '20'
 
       - name: Install dependencies
-        run: npm ci
+        run: |
+          npm ci
+          npm rebuild lightningcss
 
       - name: Type check & Build
         run: npm run build


### PR DESCRIPTION
## 🔧 작업 내용
  - npm 캐시가 다른 플랫폼(macOS 등)에서 만들어진 node_modules 포함
  - Linux runner에서는 lightningcss.linux-x64-gnu.node가 필요한데, 캐시에 없음


- cache: 'npm' 옵션 제거 → 매번 fresh install

코드 수정하였습니다 