### PR TITLE
chore: Jira PR 자동화 GitHub Actions 워크플로우 추가

### DIFF
--- a/.github/workflows/jira-pr-sync.yml
+++ b/.github/workflows/jira-pr-sync.yml
@@ -1,0 +1,135 @@
+name: Jira PR Sync
+
+on:
+  pull_request:
+    types: [ opened, reopened, closed ]
+
+jobs:
+  jira-sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      # PR 제목에서 Jira 키를 먼저 찾고,
+      # 제목에 없으면 PR 본문에서 한 번 더 찾음
+      - name: Extract Jira key
+        id: jira
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          TITLE="$PR_TITLE"
+          BODY="$PR_BODY"
+
+          KEY=$(printf '%s\n' "$TITLE" | grep -oE 'GRGB-[0-9]+' | head -n 1 || true)
+
+          if [ -z "$KEY" ]; then
+            KEY=$(printf '%s\n' "$BODY" | grep -oE 'GRGB-[0-9]+' | head -n 1 || true)
+          fi
+
+          echo "key=$KEY" >> "$GITHUB_OUTPUT"
+          echo "Extracted Jira key: $KEY"
+
+      # Jira 키가 없으면 종료
+      - name: Stop if no Jira key
+        if: steps.jira.outputs.key == ''
+        run: exit 0
+
+      # PR이 열리거나 수정되면 Jira 상태를 "리뷰 중(In Review)" 으로 전환하고
+      # Jira 티켓에 PR 링크 댓글 추가
+      - name: Move to In Review and comment PR link
+        if: github.event.action != 'closed' && steps.jira.outputs.key != ''
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          ISSUE_KEY: ${{ steps.jira.outputs.key }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          AUTH=$(printf "%s:%s" "$JIRA_EMAIL" "$JIRA_API_TOKEN" | base64 | tr -d '\n')
+
+          echo "Jira base url: $JIRA_BASE_URL"
+          echo "Issue key: $ISSUE_KEY"
+          echo "PR URL: $PR_URL"
+
+          # 리뷰 중(In Review) transition id = 31
+          REVIEW_ID="31"
+
+          echo "=== Transition start ==="
+
+          TRANSITION_RESPONSE=$(mktemp)
+          TRANSITION_STATUS=$(curl -L -s -o "$TRANSITION_RESPONSE" -w "%{http_code}" -X POST \
+            -H "Authorization: Basic $AUTH" \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json" \
+            "$JIRA_BASE_URL/rest/api/3/issue/$ISSUE_KEY/transitions" \
+            -d "{\"transition\":{\"id\":\"$REVIEW_ID\"}}")
+
+          echo "Transition HTTP status: $TRANSITION_STATUS"
+          echo "Transition response body:"
+          cat "$TRANSITION_RESPONSE"
+
+          if [ "$TRANSITION_STATUS" -lt 200 ] || [ "$TRANSITION_STATUS" -ge 300 ]; then
+            echo "Transition request failed"
+            exit 1
+          fi
+
+          echo "=== Transition success ==="
+
+          echo "=== Comment start ==="
+
+          COMMENT_RESPONSE=$(mktemp)
+          COMMENT_STATUS=$(curl -L -s -o "$COMMENT_RESPONSE" -w "%{http_code}" -X POST \
+            -H "Authorization: Basic $AUTH" \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json" \
+            "$JIRA_BASE_URL/rest/api/3/issue/$ISSUE_KEY/comment" \
+            -d "{\"body\":{\"type\":\"doc\",\"version\":1,\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"PR 링크: $PR_URL\"}]}]}}")
+
+          echo "Comment HTTP status: $COMMENT_STATUS"
+          echo "Comment response body:"
+          cat "$COMMENT_RESPONSE"
+
+          if [ "$COMMENT_STATUS" -lt 200 ] || [ "$COMMENT_STATUS" -ge 300 ]; then
+            echo "Comment request failed"
+            exit 1
+          fi
+
+          echo "=== Comment success ==="
+
+      # PR이 merge 되어 closed 되면 Jira 상태를 "완료 (Done)" 로 전환
+      - name: Move to Done on merge
+        if: github.event.action == 'closed' && github.event.pull_request.merged == true && steps.jira.outputs.key != ''
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          ISSUE_KEY: ${{ steps.jira.outputs.key }}
+        run: |
+          AUTH=$(printf "%s:%s" "$JIRA_EMAIL" "$JIRA_API_TOKEN" | base64 | tr -d '\n')
+
+          echo "Jira base url: $JIRA_BASE_URL"
+          echo "Issue key: $ISSUE_KEY"
+
+          # 완료 (Done) transition id = 41
+          DONE_ID="41"
+
+          echo "=== Done transition start ==="
+
+          DONE_RESPONSE=$(mktemp)
+          DONE_STATUS=$(curl -L -s -o "$DONE_RESPONSE" -w "%{http_code}" -X POST \
+            -H "Authorization: Basic $AUTH" \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json" \
+            "$JIRA_BASE_URL/rest/api/3/issue/$ISSUE_KEY/transitions" \
+            -d "{\"transition\":{\"id\":\"$DONE_ID\"}}")
+
+          echo "Done transition HTTP status: $DONE_STATUS"
+          echo "Done transition response body:"
+          cat "$DONE_RESPONSE"
+
+          if [ "$DONE_STATUS" -lt 200 ] || [ "$DONE_STATUS" -ge 300 ]; then
+            echo "Done transition request failed"
+            exit 1
+          fi
+
+          echo "=== Done transition success ==="


### PR DESCRIPTION
## 🔧 작업 내용
GitHub PR 이벤트와 Jira 이슈 상태를 자동으로 동기화하는 GitHub Actions 워크플로우를 추가했습니다.

- PR 생성 / 수정 시 Jira 이슈 상태를 **In Review**로 전환
- Jira 이슈에 **PR 링크 자동 댓글 추가**
- PR merge 시 Jira 이슈 상태를 **Done**으로 자동 전환
- PR 제목에 Jira 키가 없을 경우 **본문에서 Jira 키를 추출하도록 개선**

2월까진 지라 자동화가 무제한이었지만... 3월부터 무료플랜으로 바뀌어서
수동으로 Jira 상태를 변경하던 번거로운 작업을 자동화하기 위해 구현했습니다.