### PR TITLE
feat(GBGB-272-fe-queue-api): 대기열 API 연동 완료

### DIFF
--- a/goorm-gongbang/app/(dev)/design/components/page.tsx
+++ b/goorm-gongbang/app/(dev)/design/components/page.tsx
@@ -530,14 +530,14 @@ export default function Components() {
       </Section>
 
       {/* SeatPreferenceRecommendCard */}
-      <Section title="SeatPreferenceRecommendCard">
+      {/* <Section title="SeatPreferenceRecommendCard">
         <ToneRow title="SeatPreferenceRecommendCard">
           <SeatPreferenceRecommendCard
             enabled={enabled}
             onChange={setEnabled}
           />
         </ToneRow>
-      </Section>
+      </Section> */}
 
 
       <Section title="Header">

--- a/goorm-gongbang/app/(protected)/recommend/[matchId]/page.tsx
+++ b/goorm-gongbang/app/(protected)/recommend/[matchId]/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, useRef } from "react";
 import { ChevronLeft, ChevronDown } from "lucide-react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { BlockSeatDetailView } from "@/components/common/BlockSeatDetailView";
-import { PrimaryButton, SecondaryButton } from "@/components/common/Button";
+import { PrimaryButton } from "@/components/common/Button";
 import { RecommendExitModal } from "@/components/common/RecommendExitModal";
 import { RecommendSeatUnavailableModal } from "@/components/common/RecommendSeatUnavailableModal";
 import { RecommendSoldOutModal } from "@/components/common/RecommendSoldOutModal";
@@ -14,6 +14,9 @@ import { TicketingNavigator } from "@/components/common/TicketingNavigator";
 import { Toggle } from "@/components/common/Toggle";
 import { StadiumMap } from "@/components/my/StadiumMap";
 import { CDN_CLUBS_BASE_URL } from "@/lib/api/config";
+import { QueueStatusType } from "@/lib/types";
+import { getQueueStatus } from "@/lib/services";
+import { toast } from "sonner";
 
 type SeatListItem = {
   name: string;
@@ -166,6 +169,35 @@ const seatSections: SeatSection[] = [
 ];
 
 export default function Page() {
+  const searchParams = useSearchParams();
+  const recommendationEnabled =
+    searchParams.get("recommendationEnabled") === "true";
+
+  const nearbySeatEnabled = recommendationEnabled
+    ? searchParams.get("nearbySeatEnabled") === "true"
+    : false;
+
+  const ticketCount = recommendationEnabled
+    ? searchParams.get("ticketCount")
+      ? Number(searchParams.get("ticketCount"))
+      : null
+    : null;
+
+  const initialQueueRank = searchParams.get("queueRank")
+    ? Number(searchParams.get("queueRank"))
+    : null;
+
+  const initialQueueTotalWaitingCount = searchParams.get("queueTotalWaitingCount")
+    ? Number(searchParams.get("queueTotalWaitingCount"))
+    : null;
+
+  const [queueStatus, setQueueStatus] = useState<QueueStatusType | null>(null);
+  const [queueRank, setQueueRank] = useState<number | null>(initialQueueRank);
+  const [totalWaitingCount, setTotalWaitingCount] = useState<number | null>(initialQueueTotalWaitingCount);
+  const [expiresIn, setExpiresIn] = useState<number | null>(null);
+  const [pollingMs, setPollingMs] = useState<number>(3000);
+
+
   const router = useRouter();
   const params = useParams();
   const matchId = useMemo(() => {
@@ -177,7 +209,9 @@ export default function Page() {
 
   const [loading, setLoading] = useState(false);
 
-  const [isPreferredRecommendOn, setIsPreferredRecommendOn] = useState(true);
+  const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  const [isPreferredRecommendOn, setIsPreferredRecommendOn] = useState(recommendationEnabled);
   const [selectedRecommendId, setSelectedRecommendId] = useState<string | null>(null);
   const [hoveredRecommendBlock, setHoveredRecommendBlock] = useState<number | null>(null);
 
@@ -264,18 +298,84 @@ export default function Page() {
   }
 
   useEffect(() => {
-    if (isPreferredRecommendOn) {
-      setIsFindingSeat(true);
+    if (!matchId) return;
 
-      const timer = setTimeout(() => {
-        setIsFindingSeat(false);
-      }, 1500);
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
 
-      return () => clearTimeout(timer);
-    }
+    const poll = async () => {
+      try {
+        const response = await getQueueStatus(matchId);
 
-    setIsFindingSeat(false);
-  }, [isPreferredRecommendOn]);
+        if (cancelled) return;
+
+        const status = response.status ?? null; // 현재 대기 상태
+        const rank = response.rank ?? null; // 현재 사용자 대기 순번
+        const total = response.totalWaitingCount ?? null; // 전체 대기 인원 수
+        const nextPollingMs = response.pollingMs ?? 3000; // 상태 확인(polling)할 권장 주기
+        const nextExpiresIn = response.expiresIn ?? null; // 토큰 만료까지 남은 시간(초)
+
+        setQueueStatus(status);
+        setQueueRank(rank);
+        setTotalWaitingCount(total);
+        setPollingMs(nextPollingMs);
+        setExpiresIn(nextExpiresIn);
+
+        console.log("[recommend] queueStatus", response);
+
+        // stattus 응답에 따른 분기
+        if (status === "WAITING") { // 대기열에서 순번을 기다리는 상태
+          setIsFindingSeat(true);
+          timer = setTimeout(poll, nextPollingMs);
+          return;
+        }
+
+        if (status === "READY") { // Seat 서비스에 입장 가능한 상태
+          setIsFindingSeat(false);
+          return;
+        }
+
+        if (status === "EXPIRED") { // 입장 가능 시간이 만료된 상태
+          setIsFindingSeat(false);
+
+          // polling 중단
+          if (pollingIntervalRef.current) {
+            clearInterval(pollingIntervalRef.current);
+            pollingIntervalRef.current = null;
+          }
+
+          toast.error("입장 가능 시간이 만료되었습니다.");
+          router.push(`/matches/${matchId}`);
+          return;
+        }
+
+        if (status === "ENTERED") { // Seat 서비스 입장을 완료한 상태
+          setIsFindingSeat(false);
+
+          // polling 중단
+          if (pollingIntervalRef.current) {
+            clearInterval(pollingIntervalRef.current);
+            pollingIntervalRef.current = null;
+          }
+          
+          return;
+        }
+      } catch (e) {
+        if (cancelled) return;
+        setIsFindingSeat(true);
+        console.error("queue polling failed:", e);
+        timer = setTimeout(poll, 3000);
+      }
+    };
+
+    poll();
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [matchId, router]);
+
 
   useEffect(() => {
     if (!loading && isRecommendEmpty) {
@@ -593,7 +693,11 @@ export default function Page() {
 
       {/* 대기열 모달 */}
       {isFindingSeat && (
-        <SeatFindingModal open={isFindingSeat} />
+        <SeatFindingModal
+          open={isFindingSeat && queueStatus === "WAITING"}
+          rank={queueRank}
+          totalWaitingCount={totalWaitingCount}
+        />
       )}
 
     </div>

--- a/goorm-gongbang/app/(protected)/recommend/[matchId]/page.tsx
+++ b/goorm-gongbang/app/(protected)/recommend/[matchId]/page.tsx
@@ -17,6 +17,7 @@ import { CDN_CLUBS_BASE_URL } from "@/lib/api/config";
 import { QueueStatusType } from "@/lib/types";
 import { getQueueStatus } from "@/lib/services";
 import { toast } from "sonner";
+import { ApiError } from "@/lib/api";
 
 type SeatListItem = {
   name: string;
@@ -209,7 +210,18 @@ export default function Page() {
 
   const [loading, setLoading] = useState(false);
 
-  const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  const pollingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hasHandledQueueEndRef = useRef(false);
+  const clearQueuePolling = () => {
+    if (pollingTimeoutRef.current) {
+      clearTimeout(pollingTimeoutRef.current);
+      pollingTimeoutRef.current = null;
+    }
+  };
+  const scheduleNextPoll = (ms: number, callback: () => void) => {
+    clearQueuePolling();
+    pollingTimeoutRef.current = setTimeout(callback, ms);
+  };
 
   const [isPreferredRecommendOn, setIsPreferredRecommendOn] = useState(recommendationEnabled);
   const [selectedRecommendId, setSelectedRecommendId] = useState<string | null>(null);
@@ -300,8 +312,10 @@ export default function Page() {
   useEffect(() => {
     if (!matchId) return;
 
+    hasHandledQueueEndRef.current = false;
+    clearQueuePolling();
+
     let cancelled = false;
-    let timer: ReturnType<typeof setTimeout> | null = null;
 
     const poll = async () => {
       try {
@@ -326,7 +340,7 @@ export default function Page() {
         // stattus 응답에 따른 분기
         if (status === "WAITING") { // 대기열에서 순번을 기다리는 상태
           setIsFindingSeat(true);
-          timer = setTimeout(poll, nextPollingMs);
+          scheduleNextPoll(nextPollingMs, poll);
           return;
         }
 
@@ -336,35 +350,41 @@ export default function Page() {
         }
 
         if (status === "EXPIRED") { // 입장 가능 시간이 만료된 상태
+          if (hasHandledQueueEndRef.current) return;
+          hasHandledQueueEndRef.current = true;
+
           setIsFindingSeat(false);
+          clearQueuePolling();
 
-          // polling 중단
-          if (pollingIntervalRef.current) {
-            clearInterval(pollingIntervalRef.current);
-            pollingIntervalRef.current = null;
-          }
+          toast.error("입장 가능 시간이 만료되었습니다. 다시 대기열에 진입해주세요.");
+          router.push(`/matches/${matchId}`);
 
-          toast.error("입장 가능 시간이 만료되었습니다.");
+          return;
+        }
+
+        if (status === "ENTERED") {
+          if (hasHandledQueueEndRef.current) return;
+          hasHandledQueueEndRef.current = true;
+
+          setIsFindingSeat(false);
+          clearQueuePolling();
+          return;
+        }
+      } catch (e) {
+        if (cancelled || hasHandledQueueEndRef.current) return;
+
+        if (e instanceof ApiError && e.message === "해당 경기의 대기열에 등록되어 있지 않습니다.") {
+          hasHandledQueueEndRef.current = true;
+          setIsFindingSeat(false);
+          clearQueuePolling();
+          toast.error("입장 가능 시간이 만료되었습니다. 다시 대기열에 진입해주세요.");
           router.push(`/matches/${matchId}`);
           return;
         }
 
-        if (status === "ENTERED") { // Seat 서비스 입장을 완료한 상태
-          setIsFindingSeat(false);
-
-          // polling 중단
-          if (pollingIntervalRef.current) {
-            clearInterval(pollingIntervalRef.current);
-            pollingIntervalRef.current = null;
-          }
-          
-          return;
-        }
-      } catch (e) {
-        if (cancelled) return;
         setIsFindingSeat(true);
         console.error("queue polling failed:", e);
-        timer = setTimeout(poll, 3000);
+        scheduleNextPoll(pollingMs ?? 3000, poll);
       }
     };
 
@@ -372,7 +392,7 @@ export default function Page() {
 
     return () => {
       cancelled = true;
-      if (timer) clearTimeout(timer);
+      clearQueuePolling();
     };
   }, [matchId, router]);
 

--- a/goorm-gongbang/app/(public)/matches/[matchId]/page.tsx
+++ b/goorm-gongbang/app/(public)/matches/[matchId]/page.tsx
@@ -177,6 +177,7 @@ export default function MatchDetailSectionResponsive({
     } catch (e) {
       if (e instanceof ApiError) {
         console.error("handleRev failed:", e.message);
+        toast.error(e.message);
       } else {
         console.error("handleRev failed:", e);
       }

--- a/goorm-gongbang/app/(public)/matches/[matchId]/page.tsx
+++ b/goorm-gongbang/app/(public)/matches/[matchId]/page.tsx
@@ -9,8 +9,8 @@ import { MatchRecommendTab } from "@/components/common/match-detail/tabs/MatchRe
 import { MatchRefundTab } from "@/components/common/match-detail/tabs/MatchRefundTab";
 import { useParams } from "next/navigation";
 import { Spinner } from "@/components/ui/spinner";
-import { getMatchById } from "@/lib/services";
-import { SaleStatus, PurchaseStatus, MatchDetail } from "@/lib/types";
+import { getMatchById, getOnboardingPreferences, saveOnboardingPreferencesBlocks, saveBookingOptions, enterQueue } from "@/lib/services";
+import { SaleStatus, PurchaseStatus, MatchDetail, BookingOptionsRequest, BookingOptionsResponse, QueueEnterResponse } from "@/lib/types";
 import { CDN_CLUBS_BASE_URL } from "@/lib/api/config";
 import { ApiError } from "@/lib/api";
 import { useRouter } from "next/navigation";
@@ -19,6 +19,7 @@ import { useAuthStore } from "@/stores/authStore";
 import { LoginRequiredModal } from "@/components/common/LoginRequiredModal";
 import { PreferredZoneModal } from "@/components/common/PreferredZoneModal";
 import Image from "next/image";
+import { toast } from "sonner";
 
 /* ===========================
     UI TYPES
@@ -117,8 +118,10 @@ export default function MatchDetailSectionResponsive({
   }, [params]);
 
   const [enabled, setEnabled] = useState(true);
+  const [nearbySeatEnabled, setNearbySeatEnabled] = useState(true);
   const [activeTab, setActiveTab] = React.useState<TabKey>("INFO");
   const [selectedBlocks, setSelectedBlocks] = useState<number[]>([]);
+  const [people, setPeople] = useState(2);
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -142,13 +145,89 @@ export default function MatchDetailSectionResponsive({
     );
   };
 
-  const handleRev = () => {
+  {/* 예매하기 버튼 클릭 */ }
+  const handleRev = async () => {
     if (!matchId) return;
+
     if (!isLoggedIn) {
       setIsLoginRequiredModalOpen(true);
       return;
     }
-    router.push(`/recommend/${matchId}`);
+
+    const bookingBody: BookingOptionsRequest = {
+      recommendationEnabled: enabled,
+      nearAdjacentToggle: enabled ? nearbySeatEnabled : false,
+      ticketCount: enabled ? people : null,
+    };
+
+    try {
+      const bookingResponse: BookingOptionsResponse = await saveBookingOptions(matchId, bookingBody);
+
+      const queueResponse: QueueEnterResponse = await enterQueue(matchId);
+
+      const params = new URLSearchParams({
+        recommendationEnabled: String(bookingResponse.recommendationEnabled ?? false),
+        nearbySeatEnabled: String(bookingResponse.nearAdjacentToggle ?? false),
+        ticketCount: String(bookingResponse.ticketCount ?? ""),
+        queueRank: String(queueResponse.rank ?? ""),
+        queueTotalWaitingCount: String(queueResponse.totalWaitingCount ?? ""),
+      });
+
+      router.push(`/recommend/${matchId}?${params.toString()}`);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        console.error("handleRev failed:", e.message);
+      } else {
+        console.error("handleRev failed:", e);
+      }
+    }
+  };
+
+
+  {/* 설정하기 버튼 클릭 */ }
+  const handlePreferredZonesClick = async () => {
+    if (!isLoggedIn) {
+      setIsLoginRequiredModalOpen(true);
+      return;
+    }
+
+    try {
+      const data = await getOnboardingPreferences();
+      setSelectedBlocks(data.preferredBlockIds ?? []);
+      setIsPreferredZoneModalOpen(true);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        console.error("onboarding preferences fetch failed:", e.message);
+      } else {
+        console.error("onboarding preferences fetch failed:", e);
+      }
+      setIsPreferredZoneModalOpen(true);
+    }
+  };
+
+  {/* 수정하기 버튼 클릭 */ }
+  const handlePreferredZoneConfirm = async () => {
+    if (!isLoggedIn) {
+      setIsLoginRequiredModalOpen(true);
+      return;
+    }
+
+    try {
+      await saveOnboardingPreferencesBlocks({
+        preferredBlockIds: selectedBlocks,
+      });
+
+      toast.success("선호 구역이 수정되었어요.");
+      setIsPreferredZoneModalOpen(false);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        toast.error("선호 구역 수정에 실패했어요.");
+        console.error("saveOnboardingPreferencesBlocks failed:", e.message);
+      } else {
+        toast.error("선호 구역 수정에 실패했어요.");
+        console.error("saveOnboardingPreferencesBlocks failed:", e);
+      }
+    }
   };
 
   useEffect(() => {
@@ -475,7 +554,11 @@ export default function MatchDetailSectionResponsive({
                         <SeatPreferenceRecommendCard
                           enabled={enabled}
                           onChange={setEnabled}
-                          onPreferredZonesClick={() => setIsPreferredZoneModalOpen(true)}
+                          nearbySeatEnabled={nearbySeatEnabled}
+                          onNearbySeatChange={setNearbySeatEnabled}
+                          onPreferredZonesClick={handlePreferredZonesClick}
+                          people={people}
+                          onPeopleChange={setPeople}
                         />
                       </div>
                     </div>
@@ -513,7 +596,7 @@ export default function MatchDetailSectionResponsive({
           onToggleBlock={handleBlockToggle}
           onReset={() => setSelectedBlocks([])}
           onClose={() => setIsPreferredZoneModalOpen(false)}
-          onConfirm={() => setIsPreferredZoneModalOpen(false)}
+          onConfirm={handlePreferredZoneConfirm}
         />
       )}
 

--- a/goorm-gongbang/components/common/SeatFindingModal.tsx
+++ b/goorm-gongbang/components/common/SeatFindingModal.tsx
@@ -2,21 +2,29 @@
 
 type Props = {
   open: boolean;
+  rank: number | null;
+  totalWaitingCount: number | null;
 };
 
-export function SeatFindingModal({ open }: Props) {
+export function SeatFindingModal({ open, rank, totalWaitingCount }: Props) {
   if (!open) return null;
+
+  const safeRank = rank ?? 0;
+  const safeTotalWaitingCount = totalWaitingCount ?? 0;
+  const progressPercent = safeRank > 0 && safeTotalWaitingCount > 0 ? ((safeTotalWaitingCount - safeRank + 1) / safeTotalWaitingCount) * 100 : 0;
+  const clampedProgress = Math.min(100, Math.max(progressPercent, 0));
+  const progressWidth = clampedProgress > 0 ? Math.max(clampedProgress, 6) : 0;
 
   return (
     <div className="fixed inset-0 z-50 overflow-hidden bg-gradient-to-b from-black/90 to-teal-950/50 backdrop-blur-[5px]">
       <div className="absolute left-1/2 top-1/2 inline-flex w-110 -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-12">
         <div className="flex h-40 flex-col items-center justify-end gap-4">
           <div className="w-96 text-center text-5xl font-extrabold leading-[72px] text-white font-['Pretendard']">
-            12245번째
+            {rank !== null ? `${rank.toLocaleString()}번째` : "-"}
           </div>
 
           <div className="relative h-4 w-96 overflow-hidden rounded-full bg-[var(--foundation-neutral-940)]">
-            <div className="absolute left-0 top-0 h-4 w-20 bg-gradient-to-r from-[var(--foundation-secondary-600)] to-[var(--foundation-primary-500)]" />
+            <div style={{ width: `${progressWidth}%` }} className="absolute left-0 top-0 h-4 w-20 bg-gradient-to-r from-[var(--foundation-secondary-600)] to-[var(--foundation-primary-500)]" />
           </div>
         </div>
 

--- a/goorm-gongbang/components/common/SeatPreferenceRecommendCard.tsx
+++ b/goorm-gongbang/components/common/SeatPreferenceRecommendCard.tsx
@@ -10,6 +10,10 @@ import { Info } from "lucide-react";
 type Props = {
   enabled: boolean;
   onChange: (next: boolean) => void;
+  nearbySeatEnabled: boolean;
+  onNearbySeatChange: (next: boolean) => void;
+  people: number;
+  onPeopleChange: (next: number) => void;
   onPreferredZonesClick?: () => void;
   className?: string;
 };
@@ -17,10 +21,14 @@ type Props = {
 export function SeatPreferenceRecommendCard({
   enabled,
   onChange,
+  nearbySeatEnabled,
+  onNearbySeatChange,
+  people,
+  onPeopleChange,
   onPreferredZonesClick,
   className,
 }: Props) {
-  const [people, setPeople] = useState(2);
+  
   const [isNearbySeatInfoOpen, setIsNearbySeatInfoOpen] = useState(false);
 
   return (
@@ -94,7 +102,7 @@ export function SeatPreferenceRecommendCard({
               </button>
             </div>
 
-            <Toggle />
+            <Toggle checked={nearbySeatEnabled} onCheckedChange={onNearbySeatChange} />
           </div>
 
           <div className="inline-flex w-full items-center justify-between">
@@ -104,7 +112,7 @@ export function SeatPreferenceRecommendCard({
               </div>
             </div>
 
-            <DropDown value={people} onChange={setPeople} max={10} />
+            <DropDown value={people} onChange={onPeopleChange} max={10} />
           </div>
 
           <div className="inline-flex w-full items-center justify-between">

--- a/goorm-gongbang/lib/services/order-core.service.ts
+++ b/goorm-gongbang/lib/services/order-core.service.ts
@@ -19,6 +19,8 @@ import type {
   OnboardingStatusResponse,
   OnboardingPreferencesRequest,
   ClubMonthMatches,
+  OnboardingPreferencesResponse,
+  PreferredBlockUpdateRequest,
 } from "@/lib/types";
 
 // Re-export types for convenience
@@ -33,6 +35,8 @@ export type {
   ClubDetail,
   OnboardingStatusResponse,
   OnboardingPreferencesRequest,
+  OnboardingPreferencesResponse,
+  PreferredBlockUpdateRequest
 };
 
 /* 경기 목록 조회 */
@@ -74,3 +78,11 @@ export const getOnboardingStatus = () =>
 /* 온보딩 선호도 저장 */
 export const saveOnboardingPreferences = (body: OnboardingPreferencesRequest) =>
   auth.post(`${API_BASE_URL}/order/onboarding/preferences`, body);
+
+/* 온보딩 선호도 응답 */
+export const getOnboardingPreferences = () =>
+  auth.get<OnboardingPreferencesResponse>(`${API_BASE_URL}/order/onboarding/preferences`);
+
+/* 선호 구역 수정 */
+export const saveOnboardingPreferencesBlocks = (body: PreferredBlockUpdateRequest) =>
+  auth.put(`${API_BASE_URL}/order/onboarding/preferred-blocks`, body);

--- a/goorm-gongbang/lib/services/queue.service.ts
+++ b/goorm-gongbang/lib/services/queue.service.ts
@@ -6,19 +6,27 @@
 
 import { API_BASE_URL } from "@/lib/api/config";
 import { auth } from "@/lib/api/fetch";
-import type { QueueStatus, QueueStatusResponse } from "@/lib/types";
+import type {
+  QueueEnterResponse,
+  QueueStatusResponse,
+  QueueStatusType,
+} from "@/lib/types";
 
 // Re-export types for convenience
-export type { QueueStatus, QueueStatusResponse };
+export type {
+  QueueEnterResponse,
+  QueueStatusResponse,
+  QueueStatusType,
+};
 
 /* 대기열 진입 */
 export const enterQueue = (matchId: string | number) =>
-  auth.post<QueueStatusResponse>(`${API_BASE_URL}/queue/enter`, { matchId });
+  auth.post<QueueEnterResponse>(
+    `${API_BASE_URL}/queue/matches/${matchId}/enter`,
+  );
 
 /* 대기열 상태 조회 */
 export const getQueueStatus = (matchId: string | number) =>
-  auth.get<QueueStatusResponse>(`${API_BASE_URL}/queue/status?matchId=${matchId}`);
-
-/* 대기열 이탈 */
-export const leaveQueue = (matchId: string | number) =>
-  auth.post<void>(`${API_BASE_URL}/queue/leave`, { matchId });
+  auth.get<QueueStatusResponse>(
+    `${API_BASE_URL}/queue/matches/${matchId}/status`,
+  );

--- a/goorm-gongbang/lib/services/seat.service.ts
+++ b/goorm-gongbang/lib/services/seat.service.ts
@@ -6,19 +6,26 @@
 
 import { API_BASE_URL } from "@/lib/api/config";
 import { auth, pub } from "@/lib/api/fetch";
-import type { SeatStatus, Seat, SeatsData, SeatReservationRequest } from "@/lib/types";
+import type { SeatStatus, Seat, SeatsData, SeatReservationRequest, BookingOptionsRequest, BookingOptionsResponse } from "@/lib/types";
 
 // Re-export types for convenience
 export type { SeatStatus, Seat, SeatsData, SeatReservationRequest };
 
 /* 좌석 목록 조회 (public) */
 export const getSeats = (matchId: string | number) =>
-  pub.get<SeatsData>(`${API_BASE_URL}/seats?matchId=${matchId}`);
+  pub.get<SeatsData>(`${API_BASE_URL}/seat?matchId=${matchId}`);
 
 /* 좌석 예약 */
 export const reserveSeats = (body: SeatReservationRequest) =>
-  auth.post<{ reservationId: string }, SeatReservationRequest>(`${API_BASE_URL}/seats/reserve`, body);
+  auth.post<{ reservationId: string }, SeatReservationRequest>(`${API_BASE_URL}/seat/reserve`, body);
 
 /* 좌석 예약 취소 */
 export const cancelReservation = (reservationId: string | number) =>
-  auth.delete<void>(`${API_BASE_URL}/seats/reservations/${reservationId}`);
+  auth.delete<void>(`${API_BASE_URL}/seat/reservations/${reservationId}`);
+
+/* 예매 조건 저장 */
+export const saveBookingOptions = (matchId: string | number, body: BookingOptionsRequest) =>
+  auth.post<BookingOptionsResponse, BookingOptionsRequest>(
+    `${API_BASE_URL}/seat/matches/${matchId}/booking-options`,
+    body,
+  );

--- a/goorm-gongbang/lib/types/order-core.types.ts
+++ b/goorm-gongbang/lib/types/order-core.types.ts
@@ -174,6 +174,30 @@ export type OnboardingPreferencesRequest = {
   preferences: Preference[];
 };
 
+/* 온보딩 선호도 응답 */
+export type OnboardingPreferencesResponse = {
+  favoriteClubId: number;
+  favoriteClubName: string;
+  cheerProximityPref: "NEAR" | "FAR" | "ANY";
+  preferredBlockIds: number[];
+  preferences: Array<{
+    priority: number;
+    viewpoint: "CENTER" | "INFIELD_1B" | "INFIELD_3B" | "OUTFIELD_L" | "OUTFIELD_C" | "OUTFIELD_R";
+    seatHeight: "LOW" | "MID" | "HIGH" | "ANY";
+    section: "CENTER_SIDE" | "MIDDLE" | "CORNER" | "ANY";
+    seatPositionPref: "AISLE" | "MIDDLE" | "ANY";
+    environmentPref: "SHADE" | "SUN_OK" | "ANY";
+    moodPref: "CHEERFUL" | "QUIET" | "ANY";
+    obstructionSensitivity: "NET_SENSITIVE" | "RAIL_PILLAR_SENSITIVE" | "NORMAL" | "ANY";
+    priceMode: "ANY" | "RANGE";
+    priceMin: number;
+    priceMax: number;
+  }>;
+};
+
+/* 선호 구역 수정 */
+export type PreferredBlockUpdateRequest = { preferredBlockIds: number[] }
+
 /** 구단 월별 경기 조회  - 상대팀 정보 */
 export type OpponentClub = {
   clubId: number;

--- a/goorm-gongbang/lib/types/queue.types.ts
+++ b/goorm-gongbang/lib/types/queue.types.ts
@@ -3,42 +3,22 @@
  * 대기열 관련 타입 정의
  */
 
-/** 대기열 상태 */
-export type QueueStatus = {
-  position: number;
-  estimatedWaitTime: number;
-  totalInQueue: number;
-};
+/** 대기열 상태값 */
+export type QueueStatusType = "WAITING" | "READY" | "EXPIRED" | "ENTERED";
 
-/** 대기열 상태 응답 */
-export type QueueStatusResponse = {
-  code: string;
-  message: string;
-  data: QueueStatus;
-};
-
-/** 대기열 입장 요청 */
-export type QueueEnterRequest = {
-  matchId: number;
-  userId: string;
-};
-
-/** 대기열 입장 응답 */
+/** 대기열 진입 응답 */
 export type QueueEnterResponse = {
-  code: string;
-  message: string;
-  data: {
-    queueToken: string;
-    position: number;
-  };
+  status?: QueueStatusType;
+  rank?: number;
+  totalWaitingCount?: number;
 };
 
-/** 대기열 토큰 검증 응답 */
-export type QueueValidateResponse = {
-  code: string;
-  message: string;
-  data: {
-    isValid: boolean;
-    canProceed: boolean;
-  };
+/** 대기열 상태 조회 응답 */
+export type QueueStatusResponse = {
+  status?: QueueStatusType;
+  rank?: number;
+  totalWaitingCount?: number;
+  admissionToken?: string;
+  expiresIn?: number;
+  pollingMs?: number;
 };

--- a/goorm-gongbang/lib/types/seat.types.ts
+++ b/goorm-gongbang/lib/types/seat.types.ts
@@ -56,3 +56,18 @@ export type OutfieldPriceRow = {
   weekday: string;
   weekend: string;
 };
+
+/* 예매 조건 저장 */
+export type BookingOptionsRequest = {
+  recommendationEnabled?: boolean,
+  nearAdjacentToggle?: boolean,
+  ticketCount: number | null;
+};
+
+/* 예매 조건 응답 */
+export type BookingOptionsResponse = {
+  matchId: number,
+  recommendationEnabled?: boolean,
+  nearAdjacentToggle?: boolean,
+  ticketCount: number | null;
+};


### PR DESCRIPTION
feat(GBGB-272-fe-queue-api): 대기열 API 연동 완료

🔧 작업 내용
- 추천 좌석 페이지에서 대기열 상태 조회 API를 연동했습니다.
- 대기열 상태(`WAITING`, `READY`, `EXPIRED`, `ENTERED`)에 따라 화면 흐름이 분기되도록 처리했습니다.
- `WAITING` 상태일 때 `SeatFindingModal`이 노출되도록 연결했습니다.
- `EXPIRED` 상태일 때 토스트를 띄운 뒤 `/matches/{matchId}`로 이동하도록 처리했습니다.
- `ENTERED` 상태일 때 polling이 종료되도록 처리했습니다.

🧩 구현 상세 (선택)
- `getQueueStatus(matchId)`를 주기적으로 호출해 대기열 상태를 갱신합니다.
- 응답값의 `rank`, `totalWaitingCount`, `pollingMs`, `expiresIn`를 상태값으로 관리합니다.
- `WAITING` 상태에서는 polling을 유지하고 모달에 순번 및 대기 인원을 표시합니다.
- `READY` 상태에서는 좌석 진입 가능 상태로 판단해 대기 모달을 종료합니다.
- `EXPIRED`, `ENTERED` 상태에서는 polling을 종료하도록 분기했습니다.

📌 관련 Jira Issue
GBGB-272-fe-queue-api

🧪 테스트 방법(선택)
- 추천 좌석 페이지 진입 후 대기열 상태 조회 API가 호출되는지 확인합니다.
- `WAITING` 응답 시 `SeatFindingModal`이 노출되고 순번이 표시되는지 확인합니다.
- `ENTERED` 응답 시 polling이 중단되고 모달이 닫히는지 확인합니다.
- `EXPIRED` 응답 시 만료 토스트가 노출되고 `/matches/{matchId}`로 이동하는지 확인합니다.

❗ 참고 사항
- 현재 대기열 polling은 `pollingMs` 응답값을 기준으로 동작합니다.
- `SeatFindingModal`은 `queueStatus === "WAITING"`일 때만 노출됩니다.

Fixes: GBGB-272
