### PR TITLE
feat(GBGB-280-fe-seat-api): SEAT API 연동 완료

### DIFF
--- a/goorm-gongbang/FRONTEND_DIRECTORY_STRUCTURE.md
+++ b/goorm-gongbang/FRONTEND_DIRECTORY_STRUCTURE.md
@@ -1,0 +1,368 @@
+# 프론트엔드 디렉터리 구조 정리
+
+이 문서는 현재 `goorm-gongbang` 프론트엔드 프로젝트가 어떤 기준으로 디렉터리를 나누고 있는지 소개하기 위한 문서다.
+실제 코드 기준으로 정리했으며, "어디에 무엇을 넣는지"를 빠르게 파악할 수 있도록 구성했다.
+
+## 1. 프로젝트 개요
+
+- 프레임워크: Next.js 16 App Router
+- 언어: TypeScript
+- 스타일링: Tailwind CSS 4
+- 상태 관리: Zustand
+- 공통 UI: `components/ui`
+- API/비즈니스 로직: `lib`
+
+현재 구조는 크게 다음 네 층으로 읽을 수 있다.
+
+1. `app`: 페이지와 라우팅을 담당하는 진입 계층
+2. `components`: 화면 조립에 쓰는 UI 컴포넌트 계층
+3. `lib`: API 호출, 서비스, 유틸리티를 모아 둔 로직 계층
+4. `stores`, `hooks`, `types`: 전역 상태와 재사용 타입/훅 보조 계층
+
+## 2. 최상위 디렉터리
+
+```text
+goorm-gongbang/
+|-- app/
+|-- components/
+|-- feature/
+|-- hooks/
+|-- lib/
+|-- public/
+|-- stores/
+|-- types/
+|-- instrumentation.ts
+|-- next.config.ts
+|-- package.json
+|-- tsconfig.json
+```
+
+각 디렉터리의 역할은 아래와 같다.
+
+### `app`
+
+Next.js App Router 기준의 페이지 진입점이다.
+
+- `layout.tsx`: 전체 앱 공통 레이아웃
+- `providers.tsx`: 앱 부팅 시 인증 복구, 유저 정보 초기화 등 클라이언트 Provider 역할
+- `page.tsx`: 홈 화면
+- `loading.tsx`, `error.tsx`, `not-found.tsx`: 공통 상태 페이지
+- 라우트 그룹을 이용해 인증/공개/보호/개발용 페이지를 분리하고 있다
+
+### `components`
+
+실제 화면을 구성하는 재사용 컴포넌트 모음이다.
+공용 UI와 도메인 UI가 함께 존재하지만, 폴더명으로 어느 정도 관심사를 구분하고 있다.
+
+### `feature`
+
+현재는 사실상 비어 있는 상태다.
+이름상으로는 기능 단위(feature-first) 구조를 수용하려는 의도가 보이지만, 실제 운영 코드는 아직 `app`, `components`, `lib` 중심으로 배치되어 있다.
+
+### `hooks`
+
+커스텀 훅을 두기 위한 위치다.
+현재 프로젝트에서는 사용 흔적이 크지 않으며, 앞으로 공통 훅이 늘어나면 이 디렉터리 활용도가 커질 수 있다.
+
+### `lib`
+
+API 호출, 서버/클라이언트 유틸, 서비스 로직, 타입 재수출 등을 모아 둔 폴더다.
+현재 구조상 비즈니스 로직의 중심축에 가깝다.
+
+### `public`
+
+정적 에셋을 보관한다.
+
+- 폰트
+- 로그인 관련 이미지
+- 경기/결제/티켓팅 관련 SVG, 이미지
+
+### `stores`
+
+Zustand 전역 스토어 위치다.
+
+- `authStore.ts`: 인증 토큰, 사용자 정보, 부트스트랩 상태 관리
+- `onboardingPrefStore.ts`: 온보딩 선호 정보 관리
+
+### `types`
+
+루트 레벨 공용 타입 폴더다.
+현재는 대부분의 도메인 타입이 `lib/types` 쪽에 더 많이 모여 있다.
+
+## 3. `app` 디렉터리 구조
+
+`app`은 이 프로젝트의 URL 구조와 거의 1:1로 대응한다.
+
+```text
+app/
+|-- layout.tsx
+|-- page.tsx
+|-- providers.tsx
+|-- (auth)/
+|   |-- login/page.tsx
+|   `-- kakao/callback/page.tsx
+|-- (public)/
+|   |-- clubs/[clubId]/page.tsx
+|   `-- matches/[matchId]/page.tsx
+|-- (protected)/
+|   |-- onboarding/
+|   |-- pay/[matchId]/
+|   |-- recommend/[matchId]/
+|   `-- my/
+`-- (dev)/
+    `-- design/
+```
+
+### 라우트 그룹별 의미
+
+### `(auth)`
+
+로그인과 소셜 로그인 콜백 같은 인증 진입 화면이다.
+
+- `/login`
+- `/kakao/callback`
+
+### `(public)`
+
+비로그인 상태에서도 접근 가능한 공개 페이지다.
+
+- `/clubs/[clubId]`: 구단 상세
+- `/matches/[matchId]`: 경기 상세
+
+### `(protected)`
+
+로그인 이후 사용자 행동과 연결되는 보호 영역이다.
+
+- `/onboarding`
+- `/pay/[matchId]`
+- `/recommend/[matchId]`
+- `/my/*`
+
+특히 `my` 아래는 마이페이지 성격의 하위 화면이 모여 있다.
+
+- `faq`
+- `preferences`
+- `privacy`
+- `profile`
+- `reservations`
+- `terms`
+- `tickets`
+
+`app/(protected)/my/layout.tsx`는 현재 children만 그대로 통과시키는 얇은 passthrough 레이아웃으로 작성되어 있다.
+즉, 하위 페이지는 URL 기준으로 묶여 있지만 실제 UI 레이아웃 통합은 각 페이지나 `components/my` 쪽에서 담당하는 구조에 가깝다.
+
+### `(dev)`
+
+디자인 시스템이나 아이콘, 파운데이션 확인용 내부 개발 페이지다.
+
+- `design/components`
+- `design/foundation`
+- `design/icon`
+
+운영 사용자용 기능보다 "디자인 확인/가이드" 성격에 더 가깝다.
+
+## 4. `components` 디렉터리 구조
+
+`components`는 공통 UI와 도메인 화면 조각을 함께 담고 있다.
+
+```text
+components/
+|-- club-detail/
+|-- common/
+|-- forms/
+|-- layout/
+|-- login/
+|-- my/
+`-- ui/
+```
+
+### `components/ui`
+
+가장 작은 단위의 재사용 UI 컴포넌트다.
+shadcn/ui 스타일의 베이스 컴포넌트 역할을 한다.
+
+예시:
+
+- `button.tsx`
+- `input.tsx`
+- `checkbox.tsx`
+- `calendar.tsx`
+- `switch.tsx`
+- `sonner.tsx`
+- `skeleton.tsx`
+
+새로운 화면을 만들 때 가장 먼저 조합 대상이 되는 공통 UI 계층이다.
+
+### `components/layout`
+
+앱 전체에 걸쳐 재사용되는 레이아웃 컴포넌트를 둔다.
+
+- `Header.tsx`
+
+현재 루트 레이아웃에서 `Header`를 직접 사용하고 있어, 전역 레이아웃 책임이 이 폴더에 모인다.
+
+### `components/login`
+
+로그인 화면 전용 컴포넌트다.
+
+- `KakaoButton.tsx`
+- `GoogleButton.tsx`
+
+### `components/my`
+
+마이페이지 관련 화면 조각이 모여 있다.
+
+- `MyPageLayout.tsx`
+- `ProfileEditForm.tsx`
+- `PreferenceForm.tsx`
+- `ReservationItem.tsx`
+- `TicketCard.tsx`
+- 각종 모달 컴포넌트
+
+`app/(protected)/my/*` 페이지들이 실제 UI를 구성할 때 이 폴더에 많이 의존하는 형태다.
+
+### `components/common`
+
+도메인 공용 컴포넌트가 가장 많이 모여 있는 폴더다.
+현재 프로젝트에서 실질적인 "업무형 UI 모음" 역할을 한다.
+
+예시:
+
+- 경기 카드: `MatchCard.tsx`
+- 팀 정보 카드: `TeamInfoCard.tsx`
+- 좌석/추천 관련 모달 및 카드
+- 결제/추천/티켓팅 플로우에서 재사용되는 조합형 컴포넌트
+- `common/Button/*`처럼 버튼 변형군도 별도 하위 폴더로 관리
+
+이 프로젝트는 `components/ui`가 원자 단위라면, `components/common`은 화면 기능 단위에 가까운 중간 계층이라고 볼 수 있다.
+
+### `components/club-detail`
+
+구단 상세 화면에서 쓰는 도메인 컴포넌트다.
+
+### `components/forms`
+
+이름상 폼 공통화 영역이지만, 현재 구조에서는 비중이 크지 않다.
+
+## 5. `lib` 디렉터리 구조
+
+`lib`는 로직 계층으로 사용하는 것이 가장 자연스럽다.
+
+```text
+lib/
+|-- api/
+|-- client/
+|-- server/
+|-- services/
+|-- types/
+|-- datetime.ts
+`-- utils.ts
+```
+
+### `lib/api`
+
+HTTP 호출의 공통 기반을 둔다.
+
+- `config.ts`: API 기본 설정
+- `fetch.ts`: 공통 fetch 래퍼
+- `error.ts`: API 에러 모델
+- `index.ts`: 재수출
+
+즉, 외부 API와 통신하는 가장 하위 공통 계층이다.
+
+### `lib/services`
+
+화면에서 직접 가져다 쓰는 서비스 레이어다.
+
+- `auth-guard.service.ts`
+- `order-core.service.ts`
+- `queue.service.ts`
+- `recommendation.service.ts`
+- `seat.service.ts`
+
+`app/page.tsx` 같은 화면 코드가 `@/lib/services`를 통해 데이터를 가져오는 패턴이 보인다.
+그래서 페이지는 서비스 호출, 서비스는 API 래퍼 호출이라는 흐름으로 이해하면 된다.
+
+### `lib/server`
+
+서버 사이드에서만 필요한 유틸과 관측성 코드를 둔다.
+
+- `backendFetch.ts`
+- `metrics.ts`
+- `customMetrics.ts`
+
+`next.config.ts`, `instrumentation.ts`와 함께 운영/관측성 대응 성격이 강하다.
+
+### `lib/client`
+
+클라이언트 전용 유틸 위치다.
+
+- `analytics.ts`
+
+### `lib/types`
+
+도메인 타입이 가장 체계적으로 모여 있는 폴더다.
+
+- `auth-guard.types.ts`
+- `order-core.types.ts`
+- `queue.types.ts`
+- `recommendation.types.ts`
+- `seat.types.ts`
+- `common.types.ts`
+
+현재 프로젝트에서는 루트 `types`보다 `lib/types` 쪽이 실사용 중심에 가깝다.
+
+### `lib/utils.ts`, `lib/datetime.ts`
+
+여러 화면에서 공통으로 쓰는 범용 유틸 함수들이다.
+
+## 6. 상태 관리와 앱 부팅 흐름
+
+현재 전역 상태와 초기화 흐름은 다음처럼 정리할 수 있다.
+
+1. `app/layout.tsx`에서 전체 레이아웃과 Provider를 감싼다.
+2. `app/providers.tsx`에서 클라이언트 부팅 시 인증 복구를 수행한다.
+3. `stores/authStore.ts`에 access token, user, bootstrapped 상태를 저장한다.
+4. 각 페이지는 `lib/services`를 통해 데이터를 조회하고 화면을 구성한다.
+
+즉, 구조적으로는 다음 흐름이다.
+
+```text
+app(page/layout)
+  -> components
+  -> lib/services
+  -> lib/api
+  -> stores
+```
+
+## 7. 현재 구조의 특징
+
+이 프로젝트는 완전히 feature-first 구조도 아니고, 완전히 layer-only 구조도 아니다.
+현재는 다음 성격이 섞여 있다.
+
+- 라우팅은 `app` 중심
+- 화면 조립은 `components` 중심
+- 비즈니스 로직은 `lib/services` 중심
+- 전역 상태는 `stores` 중심
+- 일부 도메인별 묶음은 `components/my`, `components/club-detail`처럼 폴더 단위로 분리
+
+즉, "App Router + 공용 컴포넌트 + 서비스 레이어" 조합의 실무형 구조라고 보는 것이 가장 정확하다.
+
+## 8. 새 코드를 어디에 둘지 기준
+
+현재 구조를 기준으로 새 파일을 추가할 때는 아래 원칙으로 두는 것이 자연스럽다.
+
+- 새 페이지: `app/.../page.tsx`
+- 페이지 전용 레이아웃: `app/.../layout.tsx`
+- 범용 UI primitive: `components/ui`
+- 여러 화면에서 재사용되는 업무형 UI: `components/common`
+- 특정 도메인 화면 전용 UI: `components/my`, `components/club-detail` 같은 도메인 폴더
+- API 호출 공통 처리: `lib/api`
+- 화면에서 직접 사용하는 서비스 함수: `lib/services`
+- 전역 상태: `stores`
+- 공통 유틸: `lib/utils.ts`, `lib/datetime.ts`
+
+## 9. 한 줄 요약
+
+현재 프론트엔드는 `app`에서 라우팅을 관리하고, `components`에서 화면을 조립하며, `lib/services`와 `lib/api`에서 데이터/비즈니스 로직을 처리하는 구조다.
+즉, 페이지, UI, 서비스, 상태를 느슨하게 분리한 Next.js App Router 기반 구조로 이해하면 된다.

--- a/goorm-gongbang/app/(dev)/design/components/page.tsx
+++ b/goorm-gongbang/app/(dev)/design/components/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import * as React from "react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   ActionButton,
   PrimaryButton,

--- a/goorm-gongbang/app/(dev)/exp/page.tsx
+++ b/goorm-gongbang/app/(dev)/exp/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+import * as React from "react";
+import { useEffect, useState } from "react";
+
+const MODAL_OPEN_KEY = "exp_modal_open";
+
+export default function Exp() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    const navEntries = performance.getEntriesByType("navigation");
+    const isReload =
+      navEntries.length > 0 &&
+      (navEntries[0] as PerformanceNavigationTiming).type === "reload";
+
+    const wasModalOpen = sessionStorage.getItem(MODAL_OPEN_KEY) === "true";
+
+    if (isReload && wasModalOpen) {
+      console.log("모달이 열린 상태에서 새로고침됨");
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      sessionStorage.setItem(MODAL_OPEN_KEY, "true");
+    } else {
+      sessionStorage.removeItem(MODAL_OPEN_KEY);
+    }
+  }, [isOpen]);
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-8 p-6">
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className="rounded-lg bg-black px-4 py-2 text-white"
+      >
+        모달 열기
+      </button>
+
+      {isOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-lg">
+            <div className="mb-2 text-lg font-semibold">모달 제목</div>
+            <p className="mb-6 text-sm text-gray-600">
+              모달이 열린 상태에서 새로고침하면 콘솔이 찍힙니다.
+            </p>
+
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={() => setIsOpen(false)}
+                className="rounded-lg bg-gray-200 px-4 py-2 text-sm font-medium text-black"
+              >
+                닫기
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/goorm-gongbang/app/(protected)/recommend/[matchId]/page.tsx
+++ b/goorm-gongbang/app/(protected)/recommend/[matchId]/page.tsx
@@ -1,25 +1,41 @@
 "use client";
 
-import { useEffect, useMemo, useState, useRef } from "react";
-import { ChevronLeft, ChevronDown } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ChevronLeft } from "lucide-react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { BlockSeatDetailView } from "@/components/common/BlockSeatDetailView";
+import { toast } from "sonner";
+import { ApiError } from "@/lib/api";
+import { CDN_CLUBS_BASE_URL } from "@/lib/api/config";
 import { PrimaryButton } from "@/components/common/Button";
+import { BlockSeatDetailView } from "@/components/common/BlockSeatDetailView";
 import { RecommendExitModal } from "@/components/common/RecommendExitModal";
 import { RecommendSeatUnavailableModal } from "@/components/common/RecommendSeatUnavailableModal";
 import { RecommendSoldOutModal } from "@/components/common/RecommendSoldOutModal";
-import { SeatFindingModal } from "@/components/common/SeatFindingModal";
 import { SeatRecommendSummaryCard, type SeatRecommendItem } from "@/components/common/SeatRecommendSummaryCard";
+import { SeatFindingModal } from "@/components/common/SeatFindingModal";
 import { TicketingNavigator } from "@/components/common/TicketingNavigator";
 import { Toggle } from "@/components/common/Toggle";
 import { StadiumMap } from "@/components/my/StadiumMap";
-import { CDN_CLUBS_BASE_URL } from "@/lib/api/config";
-import { QueueStatusType } from "@/lib/types";
-import { getQueueStatus } from "@/lib/services";
-import { toast } from "sonner";
-import { ApiError } from "@/lib/api";
+import {
+  assignRecommendedSeats,
+  getQueueStatus,
+  getRecommendationBlocks,
+  getRecommendationSeatEntry,
+  getSeatGroupsEntry,
+  getSectionBlocks,
+  createSeatHold,
+} from "@/lib/services";
+import type {
+  BlockRecommendationResponse,
+  QueueStatusType,
+  SeatEntryResponse,
+  SeatGroupsEntryResponse,
+  SectionBlock,
+  SectionBlockSeat,
+} from "@/lib/types";
 
 type SeatListItem = {
+  sectionId: number;
   name: string;
   count: number;
   blockNumbers: number[];
@@ -31,176 +47,106 @@ type SeatSection = {
   items: SeatListItem[];
 };
 
-const recommendItems: SeatRecommendItem[] = [
-  {
-    id: "205",
-    seatLabel: "오렌지석(응원석)",
-    blockLabel: "205블럭",
-    blockNumber: 205,
-    remainCount: 132,
-    priceText: "20,000원/매",
-    color: "orange",
-  },
-  {
-    id: "208",
-    seatLabel: "오렌지석(응원석)",
-    blockLabel: "208블럭",
-    blockNumber: 208,
-    remainCount: 110,
-    priceText: "20,000원/매",
-    color: "orange",
-  },
-  {
-    id: "103",
-    seatLabel: "레드석",
-    blockLabel: "103블럭",
-    blockNumber: 103,
-    remainCount: 60,
-    priceText: "20,000원/매",
-    color: "red",
-  },
-];
+type SelectedSeatDetail = {
+  seatId: number;
+  seatNo: number;
+  rowNo: number;
+  blockId: number;
+  blockCode: string;
+  blockDisplayName: string;
+  sectionName: string;
+};
 
-const seatSections: SeatSection[] = [
-  {
-    title: "프리미엄",
-    items: [
-      {
-        name: "테라존(중앙 프리미엄석)",
-        count: 20,
-        blockNumbers: [1],
-        color: "navy",
-      },
-    ],
-  },
-  {
-    title: "1루 구역",
-    items: [
-      {
-        name: "1루 퍼플석(테이블석)",
-        count: 10,
-        blockNumbers: [111, 110, 213, 212],
-        color: "navy",
-      },
-      {
-        name: "1루 익사이팅존",
-        count: 14,
-        blockNumbers: [2],
-        color: "red",
-      },
-      {
-        name: "1루 블루석",
-        count: 37,
-        blockNumbers: [107, 108, 109, 209, 210, 211],
-        color: "green",
-      },
-      {
-        name: "1루 오렌지석(응원석)",
-        count: 31,
-        blockNumbers: [205, 206, 207, 208],
-        color: "orange",
-      },
-      {
-        name: "1루 레드석",
-        count: 20,
-        blockNumbers: [101, 102, 103, 104, 105, 106, 201, 202, 203, 204],
-        color: "red",
-      },
-      {
-        name: "1루 네이비석",
-        count: 520,
-        blockNumbers: [301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317],
-        color: "navy",
-      },
-      {
-        name: "1루 그린석(외야석)",
-        count: 680,
-        blockNumbers: [401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411],
-        color: "green",
-      },
-    ],
-  },
-  {
-    title: "3루 구역",
-    items: [
-      {
-        name: "3루 퍼플석(테이블석)",
-        count: 7,
-        blockNumbers: [112, 113, 214, 215],
-        color: "navy",
-      },
-      {
-        name: "3루 익사이팅존",
-        count: 20,
-        blockNumbers: [3],
-        color: "red",
-      },
-      {
-        name: "3루 블루석",
-        count: 30,
-        blockNumbers: [114, 115, 116, 216, 217, 218],
-        color: "green",
-      },
-      {
-        name: "3루 오렌지석(응원석)",
-        count: 7,
-        blockNumbers: [219, 220, 221, 222],
-        color: "orange",
-      },
-      {
-        name: "3루 레드석",
-        count: 7,
-        blockNumbers: [117, 118, 119, 120, 121, 122, 226, 225, 224, 223],
-        color: "red",
-      },
-      {
-        name: "3루 네이비석",
-        count: 7,
-        blockNumbers: [318, 319, 320, 321, 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332, 333, 334],
-        color: "navy",
-      },
-      {
-        name: "3루 그린석(외야석)",
-        count: 7,
-        blockNumbers: [412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422],
-        color: "green",
-      },
-    ],
-  },
-];
+const PRICE_TEXT_MAP: Record<string, string> = {
+  익사이팅존: "주중: 28,000원, 주말: 33,000/매",
+  블루석: "주중: 22,000원, 주말: 24,000/매",
+  오렌지석: "주중: 20,000원, 주말: 22,000/매",
+  레드석: "주중: 17,000원, 주말: 19,000/매",
+  네이비석: "주중: 14,000원, 주말: 16,000/매",
+  그린석: "주중: 15,000원, 주말: 17,000/매", //★
+  퍼플석: "주중: 15,000원, 주말: 17,000/매", //★
+  "테라존(중앙 프리미엄석)": "주중: 25,000원, 주말: 27,000/매", //★
+};
+
+function getPriceTextBySeatLabel(seatLabel: string) {
+  return PRICE_TEXT_MAP[seatLabel] ?? "-";
+}
+
+const getSeatColor = (sectionName: string): SeatRecommendItem["color"] => {
+  if (sectionName.includes("익사이팅존")) return "gray";
+  if (sectionName.includes("블루석")) return "blue";
+  if (sectionName.includes("오렌지석")) return "orange";
+  if (sectionName.includes("레드석")) return "red";
+  if (sectionName.includes("네이비석")) return "navy";
+  if (sectionName.includes("그린석")) return "green";
+  if (sectionName.includes("퍼플석")) return "purple";
+  return "orange";
+};
+
+const toSeatSections = (seatGroupsEntry: SeatGroupsEntryResponse): SeatSection[] => {
+  return seatGroupsEntry.seatGroups.map((area) => ({
+    title: area.areaName,
+    items: area.sections.map((section) => ({
+      sectionId: section.sectionId,
+      name: section.displayName,
+      count: section.remainingSeatCount,
+      blockNumbers: section.blockIds,
+      color: getSeatColor(section.sectionName),
+    })),
+  }));
+};
+
+function formatMatchAt(matchAt?: string) {
+  if (!matchAt) return "";
+
+  return new Intl.DateTimeFormat("ko-KR", {
+    timeZone: "Asia/Seoul",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    weekday: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(new Date(matchAt));
+}
+
+function resolveLogoSrc(input: string) {
+  if (/^https?:\/\//i.test(input)) return input;
+  if (!CDN_CLUBS_BASE_URL) return input;
+  return new URL(input.replace(/^\//, ""), CDN_CLUBS_BASE_URL).toString();
+}
+
+function findSeatDetail(
+  blocks: SectionBlock[],
+  seatId: number,
+  sectionName: string,
+): SelectedSeatDetail | null {
+  for (const block of blocks) {
+    for (const row of block.rows) {
+      const seat = row.seats.find((item) => item.seatId === seatId);
+      if (seat) {
+        return {
+          seatId: seat.seatId,
+          seatNo: seat.seatNo,
+          rowNo: row.rowNo,
+          blockId: block.blockId,
+          blockCode: block.blockCode,
+          blockDisplayName: block.displayName,
+          sectionName,
+        };
+      }
+    }
+  }
+
+  return null;
+}
 
 export default function Page() {
-  const searchParams = useSearchParams();
-  const recommendationEnabled =
-    searchParams.get("recommendationEnabled") === "true";
-
-  const nearbySeatEnabled = recommendationEnabled
-    ? searchParams.get("nearbySeatEnabled") === "true"
-    : false;
-
-  const ticketCount = recommendationEnabled
-    ? searchParams.get("ticketCount")
-      ? Number(searchParams.get("ticketCount"))
-      : null
-    : null;
-
-  const initialQueueRank = searchParams.get("queueRank")
-    ? Number(searchParams.get("queueRank"))
-    : null;
-
-  const initialQueueTotalWaitingCount = searchParams.get("queueTotalWaitingCount")
-    ? Number(searchParams.get("queueTotalWaitingCount"))
-    : null;
-
-  const [queueStatus, setQueueStatus] = useState<QueueStatusType | null>(null);
-  const [queueRank, setQueueRank] = useState<number | null>(initialQueueRank);
-  const [totalWaitingCount, setTotalWaitingCount] = useState<number | null>(initialQueueTotalWaitingCount);
-  const [expiresIn, setExpiresIn] = useState<number | null>(null);
-  const [pollingMs, setPollingMs] = useState<number>(3000);
-
-
   const router = useRouter();
   const params = useParams();
+  const searchParams = useSearchParams();
+
   const matchId = useMemo(() => {
     const raw = (params as Record<string, string | string[] | undefined>)?.matchId;
     const value = Array.isArray(raw) ? raw[0] : raw;
@@ -208,20 +154,31 @@ export default function Page() {
     return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
   }, [params]);
 
-  const [loading, setLoading] = useState(false);
+  const recommendationEnabled = searchParams.get("recommendationEnabled") === "true";
+  const initialQueueRank = searchParams.get("queueRank")
+    ? Number(searchParams.get("queueRank"))
+    : null;
+  const initialQueueTotalWaitingCount = searchParams.get("queueTotalWaitingCount")
+    ? Number(searchParams.get("queueTotalWaitingCount"))
+    : null;
 
   const pollingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasHandledQueueEndRef = useRef(false);
-  const clearQueuePolling = () => {
-    if (pollingTimeoutRef.current) {
-      clearTimeout(pollingTimeoutRef.current);
-      pollingTimeoutRef.current = null;
-    }
-  };
-  const scheduleNextPoll = (ms: number, callback: () => void) => {
-    clearQueuePolling();
-    pollingTimeoutRef.current = setTimeout(callback, ms);
-  };
+
+  const [queueStatus, setQueueStatus] = useState<QueueStatusType | null>(null);
+  const [queueRank, setQueueRank] = useState<number | null>(initialQueueRank);
+  const [totalWaitingCount, setTotalWaitingCount] = useState<number | null>(
+    initialQueueTotalWaitingCount,
+  );
+  const [loading, setLoading] = useState(false);
+  const [assigning, setAssigning] = useState(false);
+  const [isFindingSeat, setIsFindingSeat] = useState(true);
+
+  const [seatEntry, setSeatEntry] = useState<SeatEntryResponse | null>(null);
+  const [recommendItems, setRecommendItems] = useState<SeatRecommendItem[]>([]);
+  const [preferredRecommendBlocks, setPreferredRecommendBlocks] = useState<number[]>([]);
+  const [seatGroupsEntry, setSeatGroupsEntry] = useState<SeatGroupsEntryResponse | null>(null);
+  const [seatSections, setSeatSections] = useState<SeatSection[]>([]);
 
   const [isPreferredRecommendOn, setIsPreferredRecommendOn] = useState(recommendationEnabled);
   const [selectedRecommendId, setSelectedRecommendId] = useState<string | null>(null);
@@ -230,37 +187,105 @@ export default function Page() {
   const [hoveredSeatBlocks, setHoveredSeatBlocks] = useState<number[]>([]);
   const [selectedSeatListItem, setSelectedSeatListItem] = useState<SeatListItem | null>(null);
   const [selectedSeatBlocks, setSelectedSeatBlocks] = useState<number[]>([]);
-  const [activeSeatDetailBlock, setActiveSeatDetailBlock] = useState<number | null>(null);
-  const [selectedDetailSeats, setSelectedDetailSeats] = useState<string[]>([]);
+  const [sectionBlocks, setSectionBlocks] = useState<SectionBlock[]>([]);
+  const [sectionBlocksLoading, setSectionBlocksLoading] = useState(false);
+  const [activeBlockId, setActiveBlockId] = useState<number | null>(null);
+  const [selectedSeatIds, setSelectedSeatIds] = useState<number[]>([]);
 
   const [isExitModalOpen, setIsExitModalOpen] = useState(false);
   const [isSoldOutModalOpen, setIsSoldOutModalOpen] = useState(false);
-  const selectedRecommend = recommendItems.find((item) => item.id === selectedRecommendId);
-  const isRecommendEmpty = recommendItems.length === 0;
-  const isSeatDetailOpen = !isPreferredRecommendOn && selectedSeatListItem !== null && selectedSeatBlocks.length > 0 && activeSeatDetailBlock !== null;
   const [isSeatUnavailableModalOpen, setIsSeatUnavailableModalOpen] = useState(false);
-  const [isFindingSeat, setIsFindingSeat] = useState(true);
+
+  const matchInfo = recommendationEnabled ? seatEntry?.match ?? null : seatGroupsEntry?.match ?? null;
+  const homeClub = matchInfo?.homeClub ?? null;
+  const awayClub = matchInfo?.awayClub ?? null;
+  const stadiumName = matchInfo?.stadium?.koName ?? "";
+  const homeLogoImg = homeClub?.logoImg ?? "";
+
+  const formattedMatchAt = useMemo(() => {
+    return formatMatchAt(matchInfo?.matchAt);
+  }, [matchInfo?.matchAt]);
+
+  const selectedRecommend =
+    recommendItems.find((item) => item.id === selectedRecommendId) ?? null;
+  const isRecommendEmpty = recommendItems.length === 0;
+
+  const isSeatDetailOpen =
+    !isPreferredRecommendOn &&
+    selectedSeatListItem !== null &&
+    selectedSeatBlocks.length > 0 &&
+    activeBlockId !== null;
+
+  const stadiumSelectedIndices = useMemo(() => {
+    if (isPreferredRecommendOn) {
+      if (hoveredRecommendBlock) return [hoveredRecommendBlock];
+      if (preferredRecommendBlocks.length > 0) return preferredRecommendBlocks;
+      if (selectedRecommend) return [selectedRecommend.blockNumber];
+      return [];
+    }
+
+    return hoveredSeatBlocks.length > 0 ? hoveredSeatBlocks : selectedSeatBlocks;
+  }, [
+    hoveredRecommendBlock,
+    hoveredSeatBlocks,
+    isPreferredRecommendOn,
+    preferredRecommendBlocks,
+    selectedRecommend,
+    selectedSeatBlocks,
+  ]);
 
   const selectedSeatRows = useMemo(() => {
     if (!selectedSeatListItem) return [];
 
-    return selectedDetailSeats.map((seatKey) => {
-      const [blockNumber, rowLabel, seatNumber] = seatKey.split("-");
+    return selectedSeatIds
+      .map((seatId) => findSeatDetail(sectionBlocks, seatId, selectedSeatListItem.name))
+      .filter((seat): seat is SelectedSeatDetail => seat !== null)
+      .map((seat) => ({
+        key: String(seat.seatId),
+        gradeLabel: seat.sectionName,
+        seatLabel: `${seat.blockDisplayName} ${seat.rowNo}열 ${seat.seatNo}번`,
+      }));
+  }, [sectionBlocks, selectedSeatIds, selectedSeatListItem]);
 
-      return {
-        key: seatKey,
-        gradeLabel: selectedSeatListItem.name,
-        seatLabel: `${blockNumber}블럭 ${rowLabel}열 ${seatNumber}번`,
-      };
-    });
-  }, [selectedDetailSeats, selectedSeatListItem]);
+  const canGoNext = useMemo(() => {
+    if (isPreferredRecommendOn) return selectedRecommendId !== null;
+    return selectedSeatIds.length > 0;
+  }, [isPreferredRecommendOn, selectedRecommendId, selectedSeatIds.length]);
 
-  const handleProceedToPayment = () => {
-    if (!matchId) return;
-    router.push(`/pay/${matchId}`);
+  const clearQueuePolling = () => {
+    if (pollingTimeoutRef.current) {
+      clearTimeout(pollingTimeoutRef.current);
+      pollingTimeoutRef.current = null;
+    }
+  };
+
+  const scheduleNextPoll = (ms: number, callback: () => void) => {
+    clearQueuePolling();
+    pollingTimeoutRef.current = setTimeout(callback, ms);
+  };
+
+  const toRecommendItems = (response: BlockRecommendationResponse): SeatRecommendItem[] =>
+    response.blocks.map((block) => ({
+      id: String(block.blockId),
+      seatLabel: block.sectionName,
+      blockLabel: `${block.blockCode}블럭`,
+      blockNumber: block.blockId,
+      remainCount: block.remainingSeatCount,
+      priceText: getPriceTextBySeatLabel(block.sectionName),
+      color: getSeatColor(block.sectionName),
+    }));
+
+  const resetManualSeatSelection = () => {
+    setHoveredSeatBlocks([]);
+    setSelectedSeatListItem(null);
+    setSelectedSeatBlocks([]);
+    setSectionBlocks([]);
+    setActiveBlockId(null);
+    setSelectedSeatIds([]);
   };
 
   const handleBack = () => setIsExitModalOpen(true);
+
   const handleExit = () => {
     if (!matchId) {
       router.back();
@@ -270,44 +295,68 @@ export default function Page() {
     router.push(`/matches/${matchId}`);
   };
 
-  const handleSelectSeatListItem = (item: SeatListItem) => {
+  const handleSelectSeatListItem = async (item: SeatListItem) => {
+    if (!matchId) return;
+
     setSelectedSeatListItem(item);
     setSelectedSeatBlocks(item.blockNumbers);
-    setActiveSeatDetailBlock(item.blockNumbers[0] ?? null);
-    setSelectedDetailSeats([]);
+    setSectionBlocks([]);
+    setSelectedSeatIds([]);
+    setActiveBlockId(null);
+    setSectionBlocksLoading(true);
+
+    try {
+      const response = await getSectionBlocks(matchId, item.sectionId);
+      console.log("getSectionBlocks:", response);
+      setSectionBlocks(response.blocks);
+      setActiveBlockId(response.blocks[0]?.blockId ?? null);
+    } catch (e) {
+      const error = e as { status?: number };
+
+      if (error.status === 401) {
+        toast.error("유효하지 않은 입장 토큰입니다.");
+        router.push(`/matches/${matchId}`);
+        return;
+      }
+
+      if (error.status === 404) {
+        toast.error("해당 구역의 좌석 정보를 찾을 수 없습니다.");
+        return;
+      }
+
+      if (error.status === 410) {
+        toast.error("좌석 진입 가능 시간이 만료되었습니다.");
+        router.push(`/matches/${matchId}`);
+        return;
+      }
+
+      toast.error("블럭 좌석 정보를 불러오는 중 오류가 발생했습니다.");
+    } finally {
+      setSectionBlocksLoading(false);
+    }
   };
 
-  const handleToggleDetailSeat = (seatKey: string) => {
-    setSelectedDetailSeats((prev) =>
-      prev.includes(seatKey)
-        ? prev.filter((value) => value !== seatKey)
-        : [...prev, seatKey],
+  const handleToggleDetailSeat = (seatId: number) => {
+    const clickedSeat = findSeatDetail(
+      sectionBlocks,
+      seatId,
+      selectedSeatListItem?.name ?? "",
+    );
+
+    if (!clickedSeat) return;
+
+    const targetSeat = sectionBlocks
+      .flatMap((block) => block.rows.flatMap((row) => row.seats))
+      .find((seat) => seat.seatId === seatId);
+
+    if (!targetSeat || targetSeat.saleStatus !== "AVAILABLE") return;
+
+    setSelectedSeatIds((prev) =>
+      prev.includes(seatId)
+        ? prev.filter((id) => id !== seatId)
+        : [...prev, seatId],
     );
   };
-
-  const stadiumSelectedIndices = isPreferredRecommendOn
-    ? hoveredRecommendBlock
-      ? [hoveredRecommendBlock]
-      : selectedRecommend
-        ? [selectedRecommend.blockNumber]
-        : []
-    : hoveredSeatBlocks.length > 0
-      ? hoveredSeatBlocks
-      : selectedSeatBlocks;
-
-  const logoImg = "lg-twins.png";
-
-  const canGoNext = useMemo(() => {
-    if (isPreferredRecommendOn) return selectedRecommendId !== null;
-
-    return selectedSeatListItem !== null && selectedDetailSeats.length > 0;
-  }, [isPreferredRecommendOn, selectedDetailSeats.length, selectedRecommendId, selectedSeatListItem]);
-
-  function resolveLogoSrc(input: string) {
-    if (/^https?:\/\//i.test(input)) return input;
-    if (!CDN_CLUBS_BASE_URL) return input;
-    return new URL(input.replace(/^\//, ""), CDN_CLUBS_BASE_URL).toString();
-  }
 
   const handleQueueEnd = (message: string) => {
     if (hasHandledQueueEndRef.current) return;
@@ -316,9 +365,106 @@ export default function Page() {
     setIsFindingSeat(false);
     clearQueuePolling();
     toast.error(message);
-    router.push(`/matches/${matchId}`);
+
+    if (matchId) {
+      router.push(`/matches/${matchId}`);
+    }
   };
 
+  const handleAssignRecommendedSeats = async () => {
+    if (!matchId || !selectedRecommendId || assigning) return;
+
+    try {
+      setAssigning(true);
+      await assignRecommendedSeats(matchId, selectedRecommendId);
+      router.push(`/pay/${matchId}`);
+    } catch (e) {
+      const error = e as { status?: number };
+
+      if (error.status === 401) {
+        toast.error("유효하지 않은 입장 토큰입니다.");
+        router.push(`/matches/${matchId}`);
+        return;
+      }
+      if (error.status === 404) {
+        toast.error("연석 가능한 좌석을 찾을 수 없습니다.");
+        return;
+      }
+      if (error.status === 409) {
+        toast.error("다른 사용자가 좌석을 선택 중입니다.");
+        return;
+      }
+      if (error.status === 410) {
+        toast.error("입장 가능 시간이 만료되었습니다.");
+        router.push(`/matches/${matchId}`);
+        return;
+      }
+
+      toast.error("좌석 배정 중 오류가 발생했습니다.");
+    } finally {
+      setAssigning(false);
+    }
+  };
+
+  const handleProceed = async () => {
+    if (isPreferredRecommendOn) {
+      await handleAssignRecommendedSeats();
+      return;
+    }
+
+    await handleCreateSeatHold();
+  };
+
+  const handleCreateSeatHold = async () => {
+    if (!matchId || assigning) return;
+
+    try {
+      setAssigning(true);
+
+      console.log("createSeatHoldREQ: ", selectedSeatIds);
+      const response = await createSeatHold(matchId, {
+        seatIds: selectedSeatIds,
+      });
+
+      console.log("createSeatHold:", response);
+
+      router.push(`/pay/${matchId}`);
+    } catch (e) {
+      const error = e as { status?: number };
+
+      if (error.status === 400) {
+        toast.error("좌석 요청 값이 유효하지 않습니다.");
+        return;
+      }
+
+      if (error.status === 401) {
+        toast.error("유효하지 않은 입장 토큰입니다.");
+        router.push(`/matches/${matchId}`);
+        return;
+      }
+
+      if (error.status === 404) {
+        toast.error("좌석 또는 좌석 세션을 찾을 수 없습니다.");
+        return;
+      }
+
+      if (error.status === 409) {
+        toast.error("다른 사용자가 이미 좌석을 선점 중입니다.");
+        return;
+      }
+
+      if (error.status === 410) {
+        toast.error("입장 가능 시간이 만료되었습니다.");
+        router.push(`/matches/${matchId}`);
+        return;
+      }
+
+      toast.error("좌석 Hold 생성 중 오류가 발생했습니다.");
+      setIsSeatUnavailableModalOpen(true);
+    } finally {
+      setAssigning(false);
+    }
+  };
 
   useEffect(() => {
     if (!matchId) return;
@@ -331,36 +477,82 @@ export default function Page() {
     const poll = async () => {
       try {
         const response = await getQueueStatus(matchId);
-
         if (cancelled) return;
 
-        const status = response.status ?? null; // 현재 대기 상태
-        const rank = response.rank ?? null; // 현재 사용자 대기 순번
-        const total = response.totalWaitingCount ?? null; // 전체 대기 인원 수
-        const nextPollingMs = response.pollingMs ?? 3000; // 상태 확인(polling)할 권장 주기
-        const nextExpiresIn = response.expiresIn ?? null; // 토큰 만료까지 남은 시간(초)
+        const status = response.status ?? null;
+        const rank = response.rank ?? null;
+        const total = response.totalWaitingCount ?? null;
+        const nextPollingMs = response.pollingMs ?? 3000;
 
         setQueueStatus(status);
         setQueueRank(rank);
         setTotalWaitingCount(total);
-        setPollingMs(nextPollingMs);
-        setExpiresIn(nextExpiresIn);
 
-        console.log("[recommend] queueStatus", response);
-
-        // stattus 응답에 따른 분기
-        if (status === "WAITING") { // 대기열에서 순번을 기다리는 상태
+        if (status === "WAITING") {
           setIsFindingSeat(true);
           scheduleNextPoll(nextPollingMs, poll);
           return;
         }
 
-        if (status === "READY") { // Seat 서비스에 입장 가능한 상태
+        if (status === "READY") {
           setIsFindingSeat(false);
+          clearQueuePolling();
+          setLoading(true);
+
+          try {
+            if (isPreferredRecommendOn) {
+              const seatEntryResponse = await getRecommendationSeatEntry(matchId);
+              console.log("seatEntryResponse:", seatEntryResponse);
+              if (cancelled) return;
+
+              setSeatEntry(seatEntryResponse);
+
+              const preferredBlockIds = seatEntryResponse.seatSession.preferredBlockIds ?? [];
+              setSelectedSeatBlocks(preferredBlockIds);
+              setPreferredRecommendBlocks(preferredBlockIds);
+
+              const blockRecommendationResponse = await getRecommendationBlocks(matchId);
+              console.log("blockRecommendationResponse:", blockRecommendationResponse);
+              if (cancelled) return;
+
+              setRecommendItems(toRecommendItems(blockRecommendationResponse));
+            } else {
+              const seatGroupsResponse = await getSeatGroupsEntry(matchId);
+              console.log("seatGroupsResponse:", seatGroupsResponse);
+              if (cancelled) return;
+
+              setSeatGroupsEntry(seatGroupsResponse);
+              setSeatSections(toSeatSections(seatGroupsResponse));
+            }
+          } catch (e) {
+            const error = e as { status?: number };
+
+            if (error.status === 401) {
+              toast.error("유효하지 않은 입장 토큰입니다.");
+              router.push(`/matches/${matchId}`);
+              return;
+            }
+            if (error.status === 404) {
+              setIsSoldOutModalOpen(true);
+              return;
+            }
+            if (error.status === 410) {
+              toast.error("입장 가능 시간이 만료되었습니다.");
+              router.push(`/matches/${matchId}`);
+              return;
+            }
+
+            toast.error("좌석 정보를 불러오는 중 오류가 발생했습니다.");
+          } finally {
+            if (!cancelled) {
+              setLoading(false);
+            }
+          }
+
           return;
         }
 
-        if (status === "EXPIRED" || status === "ENTERED") { // 입장 가능 시간이 만료된 상태 (EXPIRED)
+        if (status === "EXPIRED" || status === "ENTERED") {
           if (hasHandledQueueEndRef.current) return;
           hasHandledQueueEndRef.current = true;
 
@@ -368,28 +560,25 @@ export default function Page() {
           clearQueuePolling();
 
           if (status === "EXPIRED") {
-            toast.error("입장 가능 시간이 만료되었습니다. 다시 대기열에 진입해주세요.");
+            toast.error("좌석 진입 가능 시간이 만료되었습니다. 다시 대기열에 진입해 주세요.");
             router.push(`/matches/${matchId}`);
           }
-
-          return;
         }
       } catch (e) {
         if (cancelled || hasHandledQueueEndRef.current) return;
+
         if (e instanceof ApiError) {
           if (e.status === 410) {
-            handleQueueEnd("입장 가능 시간이 만료되었습니다. 다시 대기열에 진입해주세요.");
+            handleQueueEnd("좌석 진입 가능 시간이 만료되었습니다.");
             return;
           }
-
           if (e.status === 404) {
-            handleQueueEnd("해당 경기의 대기열에 등록되어 있지 않습니다.");
+            handleQueueEnd("대기열 정보를 찾을 수 없습니다.");
             return;
           }
         }
 
         setIsFindingSeat(true);
-        console.error("queue polling failed:", e);
         scheduleNextPoll(3000, poll);
       }
     };
@@ -400,23 +589,16 @@ export default function Page() {
       cancelled = true;
       clearQueuePolling();
     };
-  }, [matchId, router]);
-
-
-  useEffect(() => {
-    if (!loading && isRecommendEmpty) {
-      setIsSoldOutModalOpen(true);
-    }
-  }, [isRecommendEmpty, loading]);
+  }, [matchId, queueStatus, isPreferredRecommendOn, router]);
 
   return (
-    <div className="w-full min-h-screen flex flex-col items-center bg-white">
+    <div className="flex min-h-screen w-full flex-col items-center bg-white">
       <div className="w-full border-b border-[var(--foundation-neutral-880)] bg-white">
         <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-4 px-4 py-4 sm:px-6 md:px-8 xl:px-12 lg:flex-row lg:items-center lg:justify-between">
           <div className="min-w-0 flex items-start gap-3 sm:items-center sm:gap-4">
             <button
               type="button"
-              className="cursor-pointer flex h-10 w-10 shrink-0 items-center justify-center rounded-md"
+              className="flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded-md"
               aria-label="뒤로가기"
               onClick={handleBack}
             >
@@ -427,25 +609,27 @@ export default function Page() {
             </button>
 
             <div className="min-w-0 flex flex-wrap items-center gap-x-2 gap-y-1 sm:gap-x-3">
-              <div className="text-sm font-semibold leading-5 text-[var(--foundation-neutral-240)] sm:text-base lg:text-lg sm:leading-6">
-                2026년 3월 29일 (일) 14:00
+              <div className="text-sm font-semibold leading-5 text-[var(--foundation-neutral-240)] sm:text-base sm:leading-6 lg:text-lg">
+                {formattedMatchAt || "-"}
               </div>
-              <div className="text-sm font-semibold leading-5 text-[var(--foundation-neutral-240)] sm:text-base lg:text-lg sm:leading-6">
-                LG vs KT
+              <div className="text-sm font-semibold leading-5 text-[var(--foundation-neutral-240)] sm:text-base sm:leading-6 lg:text-lg">
+                {homeClub && awayClub ? `${homeClub.koName} vs ${awayClub.koName}` : "-"}
               </div>
               <div className="hidden text-sm leading-5 text-[var(--foundation-neutral-600)] sm:block sm:text-base">
                 |
               </div>
               <div className="min-w-0 flex items-center gap-2">
                 <div className="h-7 w-7 overflow-hidden rounded-full bg-white sm:h-8 sm:w-8">
-                  <img
-                    className="h-full w-full object-cover"
-                    src={resolveLogoSrc(logoImg)}
-                    alt={`alt-${logoImg}`}
-                  />
+                  {homeLogoImg ? (
+                    <img
+                      className="h-full w-full object-cover"
+                      src={resolveLogoSrc(homeLogoImg)}
+                      alt={homeClub?.koName ?? "홈 구단 로고"}
+                    />
+                  ) : null}
                 </div>
                 <div className="min-w-0 truncate text-sm font-medium leading-5 text-[var(--foundation-neutral-400)] sm:text-base sm:leading-6">
-                  잠실종합운동장 잠실야구장
+                  {stadiumName || "-"}
                 </div>
               </div>
             </div>
@@ -461,15 +645,21 @@ export default function Page() {
         <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-6 px-4 pb-8 pt-4 sm:px-6 md:px-8 xl:gap-8 xl:px-12 lg:flex-row lg:items-start">
           <div className="min-w-0 flex w-full flex-1 justify-center px-0 lg:px-2 xl:px-4">
             <div className="w-full max-w-none lg:max-w-[calc(100vw-480px)] xl:max-w-[calc(100vw-520px)] 2xl:max-w-[960px]">
-              {isSeatDetailOpen && selectedSeatListItem ? (
-                <BlockSeatDetailView
-                  blockNumbers={selectedSeatListItem.blockNumbers} // 현재 선택한 좌석 리스트 항목에 포함된 블럭 번호들
-                  selectedBlockNumber={activeSeatDetailBlock} // 현재 상세 뷰에서 활성화되어 있는 블럭 번호
-                  selectedSeats={selectedDetailSeats} // 사용자가 상세 뷰에서 선택한 좌석 key 목록
-                  onSelectBlock={setActiveSeatDetailBlock} // 활성 블럭을 바꿀 때 사용하는 setter
-                  onToggleSeat={handleToggleDetailSeat} // 좌석 선택/해제를 처리하는 핸들러
-                  selectedIndices={stadiumSelectedIndices} // StadiumMap에서 강조할 블럭 번호 목록
-                />
+              {isSeatDetailOpen && selectedSeatListItem && activeBlockId ? (
+                sectionBlocksLoading ? (
+                  <div className="flex min-h-[600px] items-center justify-center rounded-2xl bg-[var(--foundation-neutral-960)] text-sm text-[var(--foundation-neutral-400)]">
+                    블럭 좌석 정보를 불러오는 중입니다.
+                  </div>
+                ) : (
+                  <BlockSeatDetailView
+                    blocks={sectionBlocks}
+                    activeBlockId={activeBlockId}
+                    selectedSeatIds={selectedSeatIds}
+                    onSelectBlock={setActiveBlockId}
+                    onToggleSeat={handleToggleDetailSeat}
+                    selectedIndices={stadiumSelectedIndices}
+                  />
+                )
               ) : (
                 <StadiumMap
                   selectedIndices={stadiumSelectedIndices}
@@ -482,16 +672,16 @@ export default function Page() {
           <div className="flex w-full shrink-0 flex-col items-end gap-6 lg:w-[360px] xl:w-[400px] 2xl:w-[460px]">
             <div className="w-full rounded-2xl bg-[var(--foundation-neutral-white)] px-6 py-4 outline outline-1 outline-offset-[-1px] outline-[var(--stroke-interactive-neutral-default)]">
               <div className="flex h-8 w-full items-center justify-between">
-                <div className="text-base font-semibold leading-6 text-black font-['Pretendard_Variable']">
+                <div className="text-base font-semibold leading-6 text-black">
                   사용자 선호 구역 추천
                 </div>
-
                 <Toggle
                   checked={isPreferredRecommendOn}
                   onCheckedChange={(next) => {
                     setIsPreferredRecommendOn(next);
                     setHoveredRecommendBlock(null);
                     setHoveredSeatBlocks([]);
+                    resetManualSeatSelection();
                   }}
                 />
               </div>
@@ -504,42 +694,25 @@ export default function Page() {
                     좌석 추천 리스트
                   </div>
                   <div className="w-full text-xs font-medium leading-5 text-[var(--foundation-neutral-600)] sm:text-sm">
-                    추천 구역을 선택하면 해당 블럭에서 연속 좌석을 확인할 수 있어요.
+                    추천 구역을 선택하면 해당 블럭을 경기장 지도에서 바로 확인할 수 있습니다.
                   </div>
                 </div>
 
                 <div className="w-full overflow-hidden">
                   {loading ? (
-                    <div className="inline-flex w-full flex-col items-start gap-3 self-stretch overflow-hidden">
-                      {Array.from({ length: 5 }).map((_, index) => (
-                        <div
-                          key={index}
-                          className="flex w-full flex-col items-start gap-3 overflow-hidden rounded-lg bg-[var(--background-white)] p-4 shadow-[0px_1px_3px_0px_rgba(0,0,0,0.05)] outline outline-1 outline-offset-[-1px] outline-[var(--stroke-interactive-neutral-default)]"
-                        >
-                          <div className="flex w-full flex-col items-start gap-1">
-                            <div className="h-6 w-24 rounded-[50px] bg-gradient-to-r from-[var(--foundation-neutral-920)] to-[var(--foundation-neutral-880)] animate-pulse" />
-                            <div className="flex w-full flex-col items-end gap-1">
-                              <div className="h-7 w-full rounded-[50px] bg-gradient-to-r from-[var(--foundation-neutral-940)] to-[var(--foundation-neutral-900)] animate-pulse" />
-                              <div className="h-5 w-40 rounded-[50px] bg-gradient-to-r from-[var(--foundation-neutral-960)] to-[var(--foundation-neutral-940)] animate-pulse" />
-                            </div>
-                          </div>
-                        </div>
-                      ))}
+                    <div className="w-full rounded-lg bg-[var(--background-white)] p-6 text-sm text-[var(--foundation-neutral-500)]">
+                      <RecommendSeatSkeleton />
                     </div>
                   ) : isRecommendEmpty ? (
-                    <div className="flex min-h-[240px] w-full items-center justify-center rounded-lg bg-[var(--background-white)] p-6">
-                      <div className="text-center text-base font-medium leading-6 text-[var(--text-info-n600)] font-['Pretendard']">
-                        현재 추천 가능한 좌석이 없어요
-                      </div>
+                    <div className="flex min-h-[160px] w-full items-center justify-center rounded-lg bg-[var(--background-white)] p-6 text-center text-sm text-[var(--foundation-neutral-500)]">
+                      현재 추천 가능한 좌석이 없습니다.
                     </div>
                   ) : (
                     <SeatRecommendSummaryCard
                       items={recommendItems}
                       selectedId={selectedRecommendId}
                       onItemClick={(item) => setSelectedRecommendId(item.id)}
-                      onItemHover={(item) =>
-                        setHoveredRecommendBlock(item.blockNumber)
-                      }
+                      onItemHover={(item) => setHoveredRecommendBlock(item.blockNumber)}
                       onItemLeave={() => setHoveredRecommendBlock(null)}
                     />
                   )}
@@ -547,61 +720,73 @@ export default function Page() {
               </div>
             ) : selectedSeatRows.length > 0 ? (
               <div className="flex w-full flex-col items-end gap-6 self-stretch">
-                <div className="flex w-full flex-col items-start gap-4 rounded-2xl bg-[var(--foundation-neutral-white)] px-6 py-4 outline outline-1 outline-offset-[-1px] outline-[var(--stroke-interactive-neutral-default)]">
-                  <div className="flex w-full items-center justify-between gap-3">
-                    <div className="text-base font-semibold leading-6 text-black font-['Pretendard_Variable']">
-                      선택한 좌석
+                <div className="self-stretch rounded-2xl px-4 py-3">
+                  <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
+                    <div className="inline-flex items-center gap-2.5">
+                      <div
+                        data-seat-status="available"
+                        data-status="default"
+                        className="h-4 w-4 rounded-[4px] border border-[var(--foundation-orange-500)] bg-[var(--foundation-orange-300)] shadow-sm"
+                      />
+                      <span className="text-sm font-medium leading-5 text-[var(--text-normal-n240)]">
+                        예매 가능한 좌석
+                      </span>
                     </div>
-                    <div className="text-right text-sm font-normal leading-5 text-[var(--foundation-secondary-600)] font-['Pretendard']">
-                      총 {selectedSeatRows.length}석 선택되었습니다
+
+                    <div className="inline-flex items-center gap-2.5">
+                      <div
+                        data-seat-status="available"
+                        data-status="focused"
+                        className="flex h-4 w-4 items-center justify-center rounded-[4px] bg-[var(--foundation-orange-600)] text-white outline outline-1 outline-[var(--foundation-orange-800)]"
+                      >
+                        ✓
+                      </div>
+                      <span className="text-sm font-medium leading-5 text-[var(--text-normal-n240)]">
+                        선택된 좌석
+                      </span>
+                    </div>
+                    <div className="inline-flex items-center gap-2.5">
+                      <div
+                        data-seat-status="sold"
+                        data-status="default"
+                        className="h-4 w-4 rounded-[4px] border border-[var(--foundation-neutral-500)] bg-[var(--background-interactive-neutral-default)]"
+                      />
+                      <span className="text-sm font-medium leading-5 text-[var(--text-normal-n240)]">
+                        예매 불가
+                      </span>
                     </div>
                   </div>
-
-                  <div className="flex w-full flex-col items-start gap-3">
-                    <div className="flex w-full items-center">
-                      <div className="flex flex-1 items-center gap-2">
-                        <div className="h-3 w-3 rounded-[3px] border border-[var(--foundation-orange-500)] bg-[var(--foundation-orange-300)]" />
-                        <div className="text-sm font-medium leading-5 text-[var(--foundation-neutral-240)] sm:text-base sm:leading-6">
-                          예매가능한 좌석
-                        </div>
-                      </div>
-                      <div className="flex flex-1 items-center gap-2">
-                        <div className="flex h-3 w-3 items-center justify-center rounded-[3px] bg-[var(--foundation-orange-600)] outline outline-1 outline-[var(--foundation-orange-800)]">
-                          <ChevronDown className="text-[var(--foundation-orange-50)]" />
-                        </div>
-                        <div className="text-sm font-medium leading-5 text-[var(--foundation-neutral-240)] sm:text-base sm:leading-6">
-                          선택된 좌석
-                        </div>
-                      </div>
+                </div>
+                <div className="flex w-full flex-col items-start gap-4 rounded-2xl bg-[var(--foundation-neutral-white)] px-6 py-4 outline outline-1 outline-offset-[-1px] outline-[var(--stroke-interactive-neutral-default)]">
+                  <div className="flex w-full items-center justify-between gap-3">
+                    <div className="text-base font-semibold leading-6 text-black">
+                      선택한 좌석
                     </div>
-
-                    <div className="flex w-full items-center">
-                      <div className="flex flex-1 items-center gap-2">
-                        <div className="h-3 w-3 rounded-[3px] border border-[var(--foundation-neutral-800)] bg-[var(--background-interactive-neutral-default)]" />
-                        <div className="text-sm font-medium leading-5 text-[var(--foundation-neutral-240)] sm:text-base sm:leading-6">
-                          예매 불가
-                        </div>
-                      </div>
+                    <div className="text-right text-sm font-normal leading-5 text-[var(--foundation-secondary-600)]">
+                      총 {selectedSeatRows.length}석 선택되었습니다
                     </div>
                   </div>
 
                   <div className="flex w-full flex-col overflow-hidden outline outline-1 outline-offset-[-1px] outline-[var(--stroke-interactive-neutral-default)]">
                     <div className="inline-flex w-full items-start gap-2">
                       <div className="flex flex-1 items-center gap-3 bg-[var(--foundation-neutral-940)] p-2">
-                        <div className="text-sm font-semibold leading-5 text-[var(--foundation-neutral-240)] font-['Pretendard_Variable']">
+                        <div className="text-sm font-semibold leading-5 text-[var(--foundation-neutral-240)]">
                           좌석 등급
                         </div>
                       </div>
                       <div className="flex flex-1 items-center gap-3 bg-[var(--foundation-neutral-980)] p-2">
-                        <div className="text-sm font-semibold leading-5 text-[var(--foundation-neutral-240)] font-['Pretendard_Variable']">
+                        <div className="text-sm font-semibold leading-5 text-[var(--foundation-neutral-240)]">
                           좌석 번호
                         </div>
                       </div>
                     </div>
 
-                    <div className="flex h-125 w-full flex-col overflow-y-auto items-start bg-[var(--foundation-neutral-white)]">
+                    <div className="flex h-125 w-full flex-col items-start overflow-y-auto bg-[var(--foundation-neutral-white)]">
                       {selectedSeatRows.map((seat) => (
-                        <div key={seat.key} className="inline-flex h-10 min-h-10 w-full items-center gap-2 px-4">
+                        <div
+                          key={seat.key}
+                          className="inline-flex h-10 min-h-10 w-full items-center gap-2 px-4"
+                        >
                           <div className="flex flex-1 items-center gap-2">
                             <div className="text-[14px] font-medium leading-5 text-[var(--foundation-neutral-240)]">
                               {seat.gradeLabel}
@@ -620,7 +805,7 @@ export default function Page() {
               </div>
             ) : (
               <div className="inline-flex w-full flex-col items-start gap-4 self-stretch">
-                <div className="w-full text-lg font-semibold leading-6 text-[var(--foundation-neutral-240)] font-['Pretendard_Variable']">
+                <div className="w-full text-lg font-semibold leading-6 text-[var(--foundation-neutral-240)]">
                   좌석 리스트
                 </div>
 
@@ -629,7 +814,7 @@ export default function Page() {
                     {seatSections.map((section) => (
                       <div key={section.title} className="flex w-full flex-col items-start">
                         <div className="inline-flex w-full items-center justify-start gap-3 bg-[var(--foundation-neutral-980)] p-2">
-                          <div className="text-sm font-semibold leading-5 text-[var(--foundation-neutral-480)] font-['Pretendard_Variable']">
+                          <div className="text-sm font-semibold leading-5 text-[var(--foundation-neutral-480)]">
                             {section.title}
                           </div>
                         </div>
@@ -637,25 +822,25 @@ export default function Page() {
                         <div className="flex w-full flex-col items-start">
                           {section.items.map((item) => (
                             <button
-                              key={item.name}
+                              key={`${section.title}-${item.sectionId}`}
                               type="button"
                               onMouseEnter={() => setHoveredSeatBlocks(item.blockNumbers)}
                               onMouseLeave={() => setHoveredSeatBlocks([])}
-                              onClick={() => handleSelectSeatListItem(item)}
+                              onClick={() => void handleSelectSeatListItem(item)}
                               className={[
                                 "inline-flex w-full items-center justify-start gap-3 px-4 py-2 text-left transition-all",
-                                selectedSeatListItem?.name === item.name
+                                selectedSeatListItem?.sectionId === item.sectionId
                                   ? "bg-[var(--foundation-primary-10)] shadow-[0px_0px_15px_0px_rgba(11,234,178,0.25)] outline outline-1 outline-offset-[-1px] outline-[var(--foundation-primary-500)]"
                                   : "cursor-pointer hover:bg-[var(--background-grey)]",
                               ].join(" ")}
                             >
-                              <div className="text-base font-medium leading-6 text-[var(--foundation-secondary-800)] font-['Pretendard']">
+                              <div className="text-base font-medium leading-6 text-[var(--foundation-secondary-800)]">
                                 {item.name}
                               </div>
-                              <div className="text-sm font-normal leading-5 text-[var(--foundation-neutral-720)] font-['Pretendard']">
+                              <div className="text-sm font-normal leading-5 text-[var(--foundation-neutral-720)]">
                                 |
                               </div>
-                              <div className="text-base font-semibold leading-6 text-[var(--foundation-primary-600)] font-['Pretendard_Variable']">
+                              <div className="text-base font-semibold leading-6 text-[var(--foundation-primary-600)]">
                                 {item.count}석
                               </div>
                             </button>
@@ -675,21 +860,20 @@ export default function Page() {
                   size="lg"
                   tone="base"
                   className="flex-1"
-                  onClick={handleProceedToPayment}
-                  disabled={!canGoNext}
+                  onClick={handleProceed}
+                  disabled={!canGoNext || assigning}
                 >
                   예매하기
                 </PrimaryButton>
               </div>
-              <div className="text-center text-sm font-medium leading-5 text-[var(--text-info-n600)] font-['Pretendard']">
-                예매 진행 후에는 좌석 변경이 어렵습니다.
+              <div className="text-center text-sm font-medium leading-5 text-[var(--text-info-n600)]">
+                예매 진행 중에도 좌석 상황은 변경될 수 있습니다.
               </div>
             </div>
           </div>
         </div>
       </div>
 
-      {/* 추천 좌석 소진 모달 */}
       {isSoldOutModalOpen && (
         <RecommendSoldOutModal
           open={isSoldOutModalOpen}
@@ -700,7 +884,6 @@ export default function Page() {
         />
       )}
 
-      {/* 뒤로가기 확인 모달 */}
       {isExitModalOpen && (
         <RecommendExitModal
           open={isExitModalOpen}
@@ -709,7 +892,6 @@ export default function Page() {
         />
       )}
 
-      {/* 예매할 수 없는 상태 모달 */}
       {isSeatUnavailableModalOpen && (
         <RecommendSeatUnavailableModal
           open={isSeatUnavailableModalOpen}
@@ -717,7 +899,6 @@ export default function Page() {
         />
       )}
 
-      {/* 대기열 모달 */}
       {isFindingSeat && (
         <SeatFindingModal
           open={isFindingSeat && queueStatus === "WAITING"}
@@ -725,7 +906,28 @@ export default function Page() {
           totalWaitingCount={totalWaitingCount}
         />
       )}
+    </div>
+  );
+}
 
+function RecommendSeatSkeleton() {
+  return (
+    <div className="w-full self-stretch inline-flex flex-col justify-start items-start gap-3 overflow-hidden animate-pulse">
+      {Array.from({ length: 5 }).map((_, index) => (
+        <div
+          key={index}
+          data-status="Loading"
+          className="w-full p-4 bg-[var(--background-white)] rounded-lg shadow-[0px_1px_3px_0px_rgba(0,0,0,0.05)] outline outline-1 outline-offset-[-1px] outline-[var(--stroke-interactive-neutral-default)] flex flex-col justify-start items-start gap-3 overflow-hidden"
+        >
+          <div className="self-stretch flex flex-col justify-start items-start gap-1">
+            <div className="w-24 h-6 rounded-[50px] bg-gradient-to-r from-[var(--foundation-neutral-920)] to-[var(--foundation-neutral-880)]" />
+            <div className="self-stretch flex flex-col justify-start items-end gap-1">
+              <div className="self-stretch h-7 rounded-[50px] bg-gradient-to-r from-[var(--foundation-neutral-940)] to-[var(--foundation-neutral-900)]" />
+              <div className="w-40 h-5 rounded-[50px] bg-gradient-to-r from-[var(--foundation-neutral-960)] to-[var(--foundation-neutral-940)]" />
+            </div>
+          </div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/goorm-gongbang/components/common/BlockSeatDetailView.tsx
+++ b/goorm-gongbang/components/common/BlockSeatDetailView.tsx
@@ -1,23 +1,17 @@
 "use client";
 
+import { X } from "lucide-react";
 import { useMemo, useState } from "react";
-import { ChevronDown, X } from "lucide-react";
 import { StadiumMap } from "@/components/my/StadiumMap";
-
-type SeatStatus = "available" | "sold";
-
-type SeatRow = {
-  rowLabel: string;
-  seats: SeatStatus[];
-};
+import type { SectionBlock, SectionBlockSeatStatus } from "@/lib/types";
 
 type Props = {
   selectedIndices: number[];
-  blockNumbers: number[];
-  selectedBlockNumber: number;
-  selectedSeats: string[];
-  onSelectBlock: (blockNumber: number) => void;
-  onToggleSeat: (seatKey: string) => void;
+  blocks: SectionBlock[];
+  activeBlockId: number | null;
+  selectedSeatIds: number[];
+  onSelectBlock: (blockId: number) => void;
+  onToggleSeat: (seatId: number) => void;
 };
 
 const BLOCK_WIDTH = 288;
@@ -26,111 +20,96 @@ const BLOCK_TOP = 200;
 const BLOCK_START_LEFT = 100;
 const CANVAS_HEIGHT = 849;
 
-function getSeatRows(blockNumber: number): SeatRow[] {
-  return [
-    { rowLabel: "1", seats: Array(14).fill("available" as SeatStatus) },
-    { rowLabel: "2", seats: Array(14).fill("available" as SeatStatus) },
-    { rowLabel: "3", seats: Array(14).fill("available" as SeatStatus) },
-    { rowLabel: "4", seats: Array(7).fill("available" as SeatStatus) },
-    { rowLabel: "5", seats: Array(7).fill("available" as SeatStatus) },
-    { rowLabel: "6", seats: Array(7).fill("available" as SeatStatus) },
-    { rowLabel: "7", seats: Array(7).fill("available" as SeatStatus) },
-    { rowLabel: "8", seats: Array(14).fill("available" as SeatStatus) },
-    { rowLabel: "9", seats: Array(14).fill("available" as SeatStatus) },
-    { rowLabel: "10", seats: Array(14).fill("available" as SeatStatus) },
-    { rowLabel: "11", seats: Array(14).fill("available" as SeatStatus) },
-    { rowLabel: "12", seats: Array(14).fill("available" as SeatStatus) },
-    { rowLabel: "13", seats: Array(14).fill("available" as SeatStatus) },
-    { rowLabel: "14", seats: Array(14).fill("available" as SeatStatus) },
-    { rowLabel: "15", seats: Array(14).fill("available" as SeatStatus) },
-    { rowLabel: "16", seats: Array(14).fill("available" as SeatStatus) },
-    { rowLabel: "17", seats: Array(14).fill("available" as SeatStatus) },
-    { rowLabel: "18", seats: Array(14).fill("available" as SeatStatus) },
-    { rowLabel: "19", seats: Array(14).fill("available" as SeatStatus) },
-    { rowLabel: "20", seats: Array(14).fill("available" as SeatStatus) },
-    { rowLabel: "21", seats: Array(14).fill("available" as SeatStatus) },
-    { rowLabel: "22", seats: Array(14).fill("available" as SeatStatus) },
-  ];
+function getSeatClassName(
+  saleStatus: SectionBlockSeatStatus,
+  isSelected: boolean,
+) {
+  if (isSelected) {
+    return "border border-[var(--foundation-orange-800)] bg-[var(--foundation-orange-600)] text-[var(--foundation-orange-50)]";
+  }
+
+  switch (saleStatus) {
+    case "AVAILABLE":
+      return "border border-[var(--foundation-orange-500)] bg-[var(--foundation-orange-300)] text-transparent";
+    case "HELD":
+      return "border border-[var(--foundation-neutral-820)] bg-[var(--foundation-neutral-920)] text-transparent";
+    case "BLOCKED":
+      return "border border-[var(--foundation-neutral-760)] bg-[var(--foundation-neutral-860)] text-transparent";
+    case "SOLD_OUT":
+      return "border border-[var(--foundation-neutral-800)] bg-[var(--background-interactive-neutral-default)] text-transparent";
+    default:
+      return "border border-[var(--foundation-neutral-800)] bg-[var(--background-interactive-neutral-default)] text-transparent";
+  }
 }
 
-function getSeatClassName(status: SeatStatus, isSelected: boolean) {
-  if (isSelected) {
-    return "bg-[var(--foundation-orange-600)] outline outline-1 outline-[var(--foundation-orange-800)]";
-  }
-
-  if (status === "sold") {
-    return "border border-[var(--foundation-neutral-800)] bg-[var(--background-interactive-neutral-default)]";
-  }
-
-  return "border border-[var(--foundation-orange-500)] bg-[var(--foundation-orange-300)]";
+function isSeatDisabled(saleStatus: SectionBlockSeatStatus) {
+  return saleStatus !== "AVAILABLE";
 }
 
 function SeatBlock({
-  blockNumber,
+  block,
   left,
-  selectedSeats,
+  selectedSeatIds,
   onSelectBlock,
   onToggleSeat,
 }: {
-  blockNumber: number;
+  block: SectionBlock;
   left: number;
-  selectedSeats: string[];
-  onSelectBlock: (blockNumber: number) => void;
-  onToggleSeat: (seatKey: string) => void;
+  selectedSeatIds: number[];
+  onSelectBlock: (blockId: number) => void;
+  onToggleSeat: (seatId: number) => void;
 }) {
-  const rows = useMemo(() => getSeatRows(blockNumber), [blockNumber]);
+  const rows = useMemo(() => block.rows, [block.rows]);
 
   return (
     <div
       className="absolute inline-flex w-72 flex-col items-center justify-start"
       style={{ left, top: BLOCK_TOP }}
-      onMouseEnter={() => onSelectBlock(blockNumber)}
+      onMouseEnter={() => onSelectBlock(block.blockId)}
     >
       <div className="text-center text-3xl font-semibold text-[var(--foundation-neutral-240)] font-['Pretendard']">
-        {blockNumber}
+        {block.displayName}
       </div>
 
       <div className="inline-flex items-center justify-start gap-2 overflow-hidden bg-[var(--foundation-neutral-white)] py-4 pl-2.5 pr-5 shadow-[0px_12px_30px_rgba(0,0,0,0.14)]">
-        <div className="inline-flex w-60 flex-col items-start justify-start gap-1">
+        <div className="inline-flex w-63 flex-col items-start justify-start gap-1">
           {rows.map((row) => (
             <div
-              key={`${blockNumber}-${row.rowLabel}`}
+              key={`${block.blockId}-${row.rowNo}`}
               className={[
                 "inline-flex self-stretch items-center gap-2",
-                ["4", "5", "6", "7"].includes(row.rowLabel)
-                  ? "justify-center"
-                  : "justify-start",
+                [4, 5, 6, 7].includes(row.rowNo) ? "justify-center" : "justify-start",
               ].join(" ")}
             >
-              <div className="inline-flex w-4 flex-col items-end justify-center gap-2">
+              <div className="inline-flex w-6 flex-col items-end justify-center gap-2">
                 <div className="text-center text-[10.13px] font-semibold text-[var(--foundation-neutral-240)] font-['Pretendard']">
-                  {row.rowLabel}
+                  {row.rowNo}
                 </div>
               </div>
 
-              <div className="flex items-center justify-start gap-1">
-                {row.seats.map((seatStatus, seatIndex) => {
-                  const seatKey = `${blockNumber}-${row.rowLabel}-${seatIndex + 1}`;
-                  const isSelected = selectedSeats.includes(seatKey);
+              <div className="flex flex-wrap items-center justify-start gap-1">
+                {row.seats.map((seat) => {
+                  const isSelected = selectedSeatIds.includes(seat.seatId);
+                  const disabled = isSeatDisabled(seat.saleStatus);
 
                   return (
                     <button
-                      key={seatKey}
+                      key={seat.seatId}
                       type="button"
-                      disabled={seatStatus === "sold"}
+                      disabled={disabled}
+                      aria-label={`${block.displayName} ${row.rowNo}열 ${seat.seatNo}번`}
                       onClick={() => {
-                        onSelectBlock(blockNumber);
-                        onToggleSeat(seatKey);
+                        onSelectBlock(block.blockId);
+                        onToggleSeat(seat.seatId);
                       }}
                       className={[
-                        "relative flex h-3 w-3 items-center justify-center rounded-[3.04px]",
-                        seatStatus === "sold" ? "cursor-not-allowed" : "cursor-pointer",
-                        getSeatClassName(seatStatus, isSelected),
+                        "relative flex h-3 w-3 items-center justify-center rounded-[3.04px] text-[8px] font-semibold transition-colors",
+                        disabled ? "cursor-not-allowed" : "cursor-pointer",
+                        getSeatClassName(seat.saleStatus, isSelected),
                       ].join(" ")}
+                      title={`${row.rowNo}열 ${seat.seatNo}번 (${seat.saleStatus})`}
                     >
-                      {isSelected ? (
-                        <ChevronDown className="text-[var(--foundation-orange-50)]" />
-                      ) : null}
+                      {isSelected ? "✓" : null}
                     </button>
                   );
                 })}
@@ -145,8 +124,8 @@ function SeatBlock({
 
 export function BlockSeatDetailView({
   selectedIndices,
-  blockNumbers,
-  selectedSeats,
+  blocks,
+  selectedSeatIds,
   onSelectBlock,
   onToggleSeat,
 }: Props) {
@@ -155,21 +134,17 @@ export function BlockSeatDetailView({
   const canvasWidth = Math.max(
     1389,
     BLOCK_START_LEFT * 2 +
-    blockNumbers.length * BLOCK_WIDTH +
-    Math.max(0, blockNumbers.length - 1) * BLOCK_GAP,
+    blocks.length * BLOCK_WIDTH +
+    Math.max(0, blocks.length - 1) * BLOCK_GAP,
   );
 
   return (
     <div className="relative w-full self-stretch overflow-hidden">
       <div className="absolute right-2 top-2 z-30 sm:right-4 sm:top-4">
         <div className="overflow-hidden rounded-2xl bg-[var(--foundation-neutral-white)] shadow-[0px_0px_20px_0px_rgba(0,0,0,0.15)]">
-          <div
-            className={[
-              "flex items-center justify-between gap-3 px-1 py-1"
-            ].join(" ")}
-          >
-            <div className="text-xs font-semibold text-[var(--foundation-neutral-640)] sm:text-sm">
-
+          <div className="flex items-center justify-between gap-3 px-1 py-1">
+            <div className="px-2 text-xs font-semibold text-[var(--foundation-neutral-640)] sm:text-sm">
+              블럭 위치
             </div>
 
             <button
@@ -177,7 +152,7 @@ export function BlockSeatDetailView({
               onClick={() => setIsMapOpen((prev) => !prev)}
               className="cursor-pointer rounded-md px-2 py-1 text-xs font-semibold text-[var(--foundation-neutral-500)] transition-colors hover:bg-[var(--foundation-neutral-50)] hover:text-[var(--foundation-neutral-700)]"
             >
-              {isMapOpen ? <X className="h-4 w-4" /> : "펼치기"}
+              {isMapOpen ? <X className="h-4 w-4" /> : "열기"}
             </button>
           </div>
 
@@ -194,16 +169,24 @@ export function BlockSeatDetailView({
           className="relative overflow-hidden bg-[var(--foundation-neutral-900)]"
           style={{ width: canvasWidth, height: CANVAS_HEIGHT }}
         >
-          {blockNumbers.map((blockNumber, index) => (
+          {blocks.map((block, index) => (
             <SeatBlock
-              key={blockNumber}
-              blockNumber={blockNumber}
+              key={block.blockId}
+              block={block}
               left={BLOCK_START_LEFT + index * (BLOCK_WIDTH + BLOCK_GAP)}
-              selectedSeats={selectedSeats}
+              selectedSeatIds={selectedSeatIds}
               onSelectBlock={onSelectBlock}
               onToggleSeat={onToggleSeat}
             />
           ))}
+
+          {blocks.length === 0 ? (
+            <div className="flex h-full w-full items-center justify-center">
+              <div className="rounded-xl bg-[var(--foundation-neutral-white)] px-6 py-4 text-sm font-medium text-[var(--foundation-neutral-500)] shadow-[0px_12px_30px_rgba(0,0,0,0.14)]">
+                조회 가능한 블럭 좌석이 없습니다.
+              </div>
+            </div>
+          ) : null}
         </div>
       </div>
     </div>

--- a/goorm-gongbang/components/common/RecommendExitModal.tsx
+++ b/goorm-gongbang/components/common/RecommendExitModal.tsx
@@ -23,11 +23,11 @@ export function RecommendExitModal({ open, onExit, onClose }: Props) {
           </div>
         </div>
         <div className="inline-flex w-full items-center gap-2">
-          <SecondaryButton onClick={onExit} className="flex flex-1">
-            나가기
-          </SecondaryButton>
-          <PrimaryButton onClick={onClose} className="flex flex-1">
+          <SecondaryButton onClick={onClose} className="flex flex-1">
             계속 예매하기
+          </SecondaryButton>
+          <PrimaryButton onClick={onExit} className="flex flex-1 bg-[var(--foundation-red-500)] hover:bg-[var(--foundation-red-600)]">
+            화면 나가기
           </PrimaryButton>
         </div>
       </div>

--- a/goorm-gongbang/components/common/SeatRecommendSummaryCard.tsx
+++ b/goorm-gongbang/components/common/SeatRecommendSummaryCard.tsx
@@ -2,7 +2,7 @@
 
 import { cn } from "@/lib/utils";
 
-type SeatColor = "orange" | "red" | "navy" | "green";
+type SeatColor = "orange" | "red" | "navy" | "green" | "gray" | "purple" | "blue";
 
 export type SeatRecommendItem = {
     id: string;
@@ -32,6 +32,13 @@ const badgeClassMap: Record<SeatColor, string> = {
         "bg-indigo-900 outline-slate-600",
     green:
         "bg-lime-600 outline-lime-500",
+    gray:
+        "bg-[var(--foundation-brown-500)] outline-[var(--foundation-brown-400)",
+    purple:
+        "bg-[var(--foundation-purple-500)] outline-[var(--foundation-purple-400)",
+    blue:
+        "bg-[var(--foundation-blue-500)] outline-[var(--foundation-blue-400)",
+    
 };
 
 export function SeatRecommendSummaryCard({

--- a/goorm-gongbang/lib/services/seat.service.ts
+++ b/goorm-gongbang/lib/services/seat.service.ts
@@ -6,26 +6,67 @@
 
 import { API_BASE_URL } from "@/lib/api/config";
 import { auth, pub } from "@/lib/api/fetch";
-import type { SeatStatus, Seat, SeatsData, SeatReservationRequest, BookingOptionsRequest, BookingOptionsResponse } from "@/lib/types";
-
-// Re-export types for convenience
-export type { SeatStatus, Seat, SeatsData, SeatReservationRequest };
-
-/* 좌석 목록 조회 (public) */
-export const getSeats = (matchId: string | number) =>
-  pub.get<SeatsData>(`${API_BASE_URL}/seat?matchId=${matchId}`);
-
-/* 좌석 예약 */
-export const reserveSeats = (body: SeatReservationRequest) =>
-  auth.post<{ reservationId: string }, SeatReservationRequest>(`${API_BASE_URL}/seat/reserve`, body);
-
-/* 좌석 예약 취소 */
-export const cancelReservation = (reservationId: string | number) =>
-  auth.delete<void>(`${API_BASE_URL}/seat/reservations/${reservationId}`);
+import type {
+  BookingOptionsRequest,
+  BookingOptionsResponse,
+  SeatEntryResponse,
+  BlockRecommendationResponse,
+  SeatAssignmentResponse,
+  SeatGroupsEntryResponse,
+  SectionBlocksResponse,
+  SeatHoldCreateRequest,
+  SeatHoldCreateResponse
+} from "@/lib/types";
 
 /* 예매 조건 저장 */
 export const saveBookingOptions = (matchId: string | number, body: BookingOptionsRequest) =>
   auth.post<BookingOptionsResponse, BookingOptionsRequest>(
     `${API_BASE_URL}/seat/matches/${matchId}/booking-options`,
+    body,
+  );
+
+/* 추천 ON - 추천 좌석 초기 진입 */
+export const getRecommendationSeatEntry = (matchId: string | number) =>
+  auth.get<SeatEntryResponse>(
+    `${API_BASE_URL}/seat/matches/${matchId}/recommendations/seat-entry`
+  );
+
+/* 추천 ON - 추천 블럭 리스트 조회 */
+export const getRecommendationBlocks = (matchId: string | number) =>
+  auth.get<BlockRecommendationResponse>(
+    `${API_BASE_URL}/seat/matches/${matchId}/recommendations/blocks`
+  );
+
+/* 추천 ON - 좌석 자동 배정 및 선점 */
+export const assignRecommendedSeats = (
+  matchId: string | number,
+  blockId: string | number
+) =>
+  auth.post<SeatAssignmentResponse>(
+    `${API_BASE_URL}/seat/matches/${matchId}/recommendations/blocks/${blockId}/assign`
+  );
+
+/* 추천 OFF - 구역 리스트 조회 */
+export const getSeatGroupsEntry = (matchId: string | number) =>
+  auth.get<SeatGroupsEntryResponse>(
+    `${API_BASE_URL}/seat/matches/${matchId}/seat-groups`
+  );
+
+/* 구역 클릭 → 블럭별 포도알 조회 */
+export const getSectionBlocks = (
+  matchId: string | number,
+  sectionId: string | number,
+) =>
+  auth.get<SectionBlocksResponse>(
+    `${API_BASE_URL}/seat/matches/${matchId}/sections/${sectionId}/blocks`
+  );
+
+/* 좌석 직접 선택 → Hold 생성 */
+export const createSeatHold = (
+  matchId: string | number,
+  body: SeatHoldCreateRequest,
+) =>
+  auth.post<SeatHoldCreateResponse, SeatHoldCreateRequest>(
+    `${API_BASE_URL}/seat/matches/${matchId}/seat-holds`,
     body,
   );

--- a/goorm-gongbang/lib/types/seat.types.ts
+++ b/goorm-gongbang/lib/types/seat.types.ts
@@ -3,45 +3,6 @@
  * 좌석 관련 타입 정의
  */
 
-/** 좌석 상태 */
-export type SeatStatus = "AVAILABLE" | "RESERVED" | "SOLD" | "BLOCKED";
-
-/** 좌석 정보 */
-export type Seat = {
-  seatId: string;
-  section: string;
-  row: string;
-  seatNumber: string;
-  status: SeatStatus;
-  price: number;
-  seatType?: string;
-};
-
-/** 좌석 목록 응답 데이터 */
-export type SeatsData = {
-  matchId: number;
-  seats: Seat[];
-  updatedAt: string;
-};
-
-/** 좌석 예약 요청 */
-export type SeatReservationRequest = {
-  matchId: number;
-  seatIds: string[];
-  userId: string;
-};
-
-/** 좌석 예약 응답 */
-export type SeatReservationResponse = {
-  code: string;
-  message: string;
-  data: {
-    reservationId: string;
-    expiresAt: string;
-    seats: Seat[];
-  };
-};
-
 /** 좌석 가격 정보 (UI용) */
 export type SeatPriceRow = {
   seatType: string;
@@ -70,4 +31,146 @@ export type BookingOptionsResponse = {
   recommendationEnabled?: boolean,
   nearAdjacentToggle?: boolean,
   ticketCount: number | null;
+};
+
+/* 추천 좌석 초기 진입 응답 */
+export type SeatEntryResponse = {
+  match: {
+    matchId: number;
+    homeClub: {
+      clubId: number;
+      koName: string;
+      logoImg: string;
+    };
+    awayClub: {
+      clubId: number;
+      koName: string;
+      logoImg: string;
+    };
+    matchAt: string;
+    stadium: {
+      stadiumId: number;
+      koName: string;
+    };
+  };
+  seatSession: {
+    recommendationEnabled: boolean;
+    headCount: number;
+    preferredBlockIds: number[];
+  };
+};
+
+/* 추천 블럭 리스트 응답 */
+export type BlockRecommendationResponse = {
+  matchId: number;
+  ticketCount: number;
+  blocks: {
+    blockId: number;
+    blockCode: string;
+    sectionName: string;
+    areaName: string;
+    viewpoint: string;
+    realConsecutiveCount: number;
+    remainingSeatCount: number;
+    rank: number;
+  }[];
+};
+
+/* 좌석 자동 배정 및 선점 */
+export type SeatAssignmentResponse = {
+  matchId: number;
+  blockCode: string;
+  sectionName: string;
+  assignedSeats: {
+    matchSeatId: number;
+    rowNo: number;
+    seatNo: number;
+    templateColNo: number;
+  }[];
+  holdExpiresAt: string;
+  semiConsecutive: boolean;
+};
+
+/* 구역 리스트 조회 */
+export type SeatGroupsEntryResponse = {
+  match: {
+    matchId: number;
+    homeClub: {
+      clubId: number;
+      koName: string;
+      logoImg: string;
+    };
+    awayClub: {
+      clubId: number;
+      koName: string;
+      logoImg: string;
+    };
+    matchAt: string;
+    stadium: {
+      stadiumId: number;
+      koName: string;
+    };
+  };
+  seatSession: {
+    recommendationEnabled: boolean;
+    ticketCount: number;
+    nearAdjacentToggle: boolean;
+  };
+  seatGroups: SeatAreaGroup[];
+};
+
+export type SeatAreaGroup = {
+  areaId: number;
+  areaName: string;
+  sections: SeatGroupSection[];
+};
+
+export type SeatGroupSection = {
+  sectionId: number;
+  sectionName: string;
+  displayName: string;
+  blockIds: number[];
+  remainingSeatCount: number;
+};
+
+/* 구역 클릭 → 블럭별 포도알 조회 */
+export type SectionBlockSeatStatus =
+  | "AVAILABLE"
+  | "HELD"
+  | "BLOCKED"
+  | "SOLD_OUT";
+
+export type SectionBlockSeat = {
+  seatId: number;
+  seatNo: number;
+  saleStatus: SectionBlockSeatStatus;
+};
+
+export type SectionBlockRow = {
+  rowNo: number;
+  remainingSeatCount: number;
+  seats: SectionBlockSeat[];
+};
+
+export type SectionBlock = {
+  blockId: number;
+  blockCode: string;
+  displayName: string;
+  rows: SectionBlockRow[];
+};
+
+export type SectionBlocksResponse = {
+  blocks: SectionBlock[];
+};
+
+/* 좌석 직접 선택 → Hold 생성 */
+export type SeatHoldCreateRequest = {
+  seatIds: number[];
+};
+
+export type SeatHoldCreateResponse = {
+  matchId: number;
+  seatIds: number[];
+  seatCount: number;
+  holdExpiresAt: string;
 };

--- a/goorm-gongbang/package-lock.json
+++ b/goorm-gongbang/package-lock.json
@@ -106,7 +106,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -321,39 +320,6 @@
       "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
       "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
       "license": "MIT"
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -654,443 +620,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
     "node_modules/@img/sharp-win32-x64": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
@@ -1242,9 +771,9 @@
       }
     },
     "node_modules/@javascript-obfuscator/escodegen": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@javascript-obfuscator/escodegen/-/escodegen-2.3.1.tgz",
-      "integrity": "sha512-Z0HEAVwwafOume+6LFXirAVZeuEMKWuPzpFbQhCEU9++BMz0IwEa9bmedJ+rMn/IlXRBID9j3gQ0XYAa6jM10g==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@javascript-obfuscator/escodegen/-/escodegen-2.4.1.tgz",
+      "integrity": "sha512-YrEJJDr4cb+pIQKWzHFoDlDkQzatcrNB6OhAD6iTSwiKwzZUMVdobwbOuLpF4EiLxUj0qP28Xl1saTHYzIPCLg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -1402,19 +931,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.4.3",
-        "@emnapi/runtime": "^1.4.3",
-        "@tybys/wasm-util": "^0.10.0"
-      }
-    },
     "node_modules/@next/env": {
       "version": "16.1.4",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.4.tgz",
@@ -1429,111 +945,6 @@
       "license": "MIT",
       "dependencies": {
         "fast-glob": "3.3.1"
-      }
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.4.tgz",
-      "integrity": "sha512-T8atLKuvk13XQUdVLCv1ZzMPgLPW0+DWWbHSQXs0/3TjPrKNxTmUIhOEaoEyl3Z82k8h/gEtqyuoZGv6+Ugawg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.4.tgz",
-      "integrity": "sha512-AKC/qVjUGUQDSPI6gESTx0xOnOPQ5gttogNS3o6bA83yiaSZJek0Am5yXy82F1KcZCx3DdOwdGPZpQCluonuxg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.4.tgz",
-      "integrity": "sha512-POQ65+pnYOkZNdngWfMEt7r53bzWiKkVNbjpmCt1Zb3V6lxJNXSsjwRuTQ8P/kguxDC8LRkqaL3vvsFrce4dMQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.4.tgz",
-      "integrity": "sha512-3Wm0zGYVCs6qDFAiSSDL+Z+r46EdtCv/2l+UlIdMbAq9hPJBvGu/rZOeuvCaIUjbArkmXac8HnTyQPJFzFWA0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.4.tgz",
-      "integrity": "sha512-lWAYAezFinaJiD5Gv8HDidtsZdT3CDaCeqoPoJjeB57OqzvMajpIhlZFce5sCAH6VuX4mdkxCRqecCJFwfm2nQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.4.tgz",
-      "integrity": "sha512-fHaIpT7x4gA6VQbdEpYUXRGyge/YbRrkG6DXM60XiBqDM2g2NcrsQaIuj375egnGFkJow4RHacgBOEsHfGbiUw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.4.tgz",
-      "integrity": "sha512-MCrXxrTSE7jPN1NyXJr39E+aNFBrQZtO154LoCz7n99FuKqJDekgxipoodLNWdQP7/DZ5tKMc/efybx1l159hw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
@@ -1630,7 +1041,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1640,7 +1050,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.211.0.tgz",
       "integrity": "sha512-swFdZq8MCdmdR22jTVGQDhwqDzcI4M10nhjXkLr1EsIzXgZBqm4ZlmmcWsg3TSNf+3mzgOiqveXmBLZuDi2Lgg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
       },
@@ -1771,7 +1180,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.0.tgz",
       "integrity": "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2002,7 +1410,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.211.0.tgz",
       "integrity": "sha512-h0nrZEC/zvI994nhg7EgQ8URIHt0uDTwN90r3qQUdZORS455bbx+YebnGeEuFghUT0HlJSrLF4iHw67f+odY+Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.211.0",
         "import-in-the-middle": "^2.0.0",
@@ -2910,7 +2317,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.0.tgz",
       "integrity": "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2927,7 +2333,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.211.0.tgz",
       "integrity": "sha512-O5nPwzgg2JHzo59kpQTPUOTzFi0Nv5LxryG27QoXBciX3zWM3z83g+SNOHhiQVYRWFSxoWn1JM2TGD5iNjOwdA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.211.0",
         "@opentelemetry/core": "2.5.0",
@@ -2945,7 +2350,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.5.0.tgz",
       "integrity": "sha512-BeJLtU+f5Gf905cJX9vXFQorAr6TAfK3SPvTFqP+scfIpDQEJfRaGJWta7sJgP+m4dNtBf9y3yvBKVAZZtJQVA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/resources": "2.5.0"
@@ -3000,7 +2404,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.5.0.tgz",
       "integrity": "sha512-VzRf8LzotASEyNDUxTdaJ9IRJ1/h692WyArDBInf5puLCjxbICD6XkHgpuudis56EndyS7LYFmtTMny6UABNdQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/resources": "2.5.0",
@@ -4939,206 +4342,6 @@
         "@tailwindcss/oxide-win32-x64-msvc": "4.1.18"
       }
     },
-    "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.18.tgz",
-      "integrity": "sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.18.tgz",
-      "integrity": "sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.18.tgz",
-      "integrity": "sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.18.tgz",
-      "integrity": "sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.18.tgz",
-      "integrity": "sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.18.tgz",
-      "integrity": "sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.18.tgz",
-      "integrity": "sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.18.tgz",
-      "integrity": "sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.18.tgz",
-      "integrity": "sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.18.tgz",
-      "integrity": "sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==",
-      "bundleDependencies": [
-        "@napi-rs/wasm-runtime",
-        "@emnapi/core",
-        "@emnapi/runtime",
-        "@tybys/wasm-util",
-        "@emnapi/wasi-threads",
-        "tslib"
-      ],
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@emnapi/wasi-threads": "^1.1.0",
-        "@napi-rs/wasm-runtime": "^1.1.0",
-        "@tybys/wasm-util": "^0.10.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
-      "integrity": "sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.18.tgz",
@@ -5168,17 +4371,6 @@
         "@tailwindcss/oxide": "4.1.18",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.18"
-      }
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/aws-lambda": {
@@ -5295,7 +4487,6 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5306,7 +4497,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5379,7 +4569,6 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -5604,261 +4793,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
-      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-android-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
-      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-darwin-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
-      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-darwin-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
-      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-freebsd-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
-      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
-      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
-      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
-      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
-      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
-      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
-      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
-      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
-      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
-      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
-      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
-      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@napi-rs/wasm-runtime": "^0.2.11"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
-      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
-      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
@@ -5913,7 +4847,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5965,48 +4898,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -6301,17 +5192,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/atomically": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
-      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "stubborn-fs": "^2.0.0",
-        "when-exit": "^2.1.4"
-      }
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -6423,7 +5303,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6437,13 +5316,6 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -6673,67 +5545,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/conf": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/conf/-/conf-15.0.2.tgz",
-      "integrity": "sha512-JBSrutapCafTrddF9dH3lc7+T2tBycGF4uPkI4Js+g4vLLEhG6RZcFi3aJd5zntdf5tQxAejJt8dihkoQ/eSJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "atomically": "^2.0.3",
-        "debounce-fn": "^6.0.0",
-        "dot-prop": "^10.0.0",
-        "env-paths": "^3.0.0",
-        "json-schema-typed": "^8.0.1",
-        "semver": "^7.7.2",
-        "uint8array-extras": "^1.5.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/conf/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/conf/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/conf/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -6864,22 +5675,6 @@
       "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
       "license": "MIT"
     },
-    "node_modules/debounce-fn": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-6.0.0.tgz",
-      "integrity": "sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-function": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -6969,22 +5764,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/dot-prop": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-10.1.0.tgz",
-      "integrity": "sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -7029,13 +5808,16 @@
       }
     },
     "node_modules/env-paths": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
-      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-4.0.0.tgz",
+      "integrity": "sha512-pxP8eL2SwwaTRi/KHYwLYXinDs7gL3jxFcBYmEdYfZmZXbaVDvdppd0XBU8qVz03rDfKZMXg1omHCbsJjZrMsw==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "is-safe-filename": "^0.1.0"
+      },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7246,7 +6028,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7432,7 +6213,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7736,23 +6516,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -8687,6 +7450,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-safe-filename": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-safe-filename/-/is-safe-filename-0.1.1.tgz",
+      "integrity": "sha512-4SrR7AdnY11LHfDKTZY1u6Ga3RuxZdl3YKWWShO5iyuG5h8QS4GD2tOb04peBJ5I7pXbR+CGBNEhTcwK+FzN3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-set": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
@@ -8858,33 +7634,32 @@
       }
     },
     "node_modules/javascript-obfuscator": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/javascript-obfuscator/-/javascript-obfuscator-5.3.0.tgz",
-      "integrity": "sha512-EKKLTeKgzmY/foePpuNWhlKnrSqWMt1IHvIp0FEWzXODFqY2ZB6Mr0s2Q0uIOFCYbdYHeJNdPs6wpPb9NoUxMA==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/javascript-obfuscator/-/javascript-obfuscator-5.4.1.tgz",
+      "integrity": "sha512-HoG2vdmo0xM37YQtcjYXNBTlRvypW5G6gtTMFrCBzLkVMLWQy97+XISDNL1DUMfKQQ6Njp8SddfPJix1h2FhVg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@javascript-obfuscator/escodegen": "2.3.1",
+        "@javascript-obfuscator/escodegen": "2.4.1",
         "@javascript-obfuscator/estraverse": "5.4.0",
         "@vercel/blob": ">=0.23.0",
         "acorn": "8.15.0",
+        "acorn-import-attributes": "^1.9.5",
         "assert": "2.1.0",
         "chalk": "4.1.2",
         "chance": "1.1.13",
         "class-validator": "0.14.3",
         "commander": "12.1.0",
-        "conf": "15.0.2",
+        "env-paths": "4.0.0",
         "eslint-scope": "8.4.0",
         "eslint-visitor-keys": "4.2.1",
         "fast-deep-equal": "3.1.3",
         "inversify": "6.1.4",
         "js-string-escape": "1.0.1",
         "md5": "2.3.0",
-        "mkdirp": "3.0.1",
         "multimatch": "5.0.0",
         "process": "0.11.10",
         "reflect-metadata": "0.2.2",
-        "source-map-support": "0.5.21",
         "string-template": "1.0.0",
         "stringz": "2.1.0",
         "tslib": "2.8.1"
@@ -8972,13 +7747,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -9060,9 +7828,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.12.38",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.38.tgz",
-      "integrity": "sha512-vwzxmasAy9hZigxtqTbFEwp8ZdZ975TiqVDwj5bKx5sR+zi5ucUQy9mbVTkKM9GzqdLdxux/hTw2nmN5J7POMA==",
+      "version": "1.12.40",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.40.tgz",
+      "integrity": "sha512-HKGs7GowShNls3Zh+7DTr6wYpPk5jC78l508yQQY3e8ZgJChM3A9JZghmMJZuK+5bogSfuTafpjksGSR3aMIEg==",
       "dev": true,
       "license": "MIT"
     },
@@ -9094,216 +7862,6 @@
         "lightningcss-linux-x64-musl": "1.30.2",
         "lightningcss-win32-arm64-msvc": "1.30.2",
         "lightningcss-win32-x64-msvc": "1.30.2"
-      }
-    },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
-      "integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz",
-      "integrity": "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
-      "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
-      "integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
-      "integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
-      "integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
-      "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
-      "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
-      "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
-      "integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
@@ -9457,19 +8015,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mimic-function": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -9491,22 +8036,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/module-details-from-path": {
@@ -10471,7 +9000,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10502,7 +9030,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10600,8 +9127,7 @@
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -10651,16 +9177,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11096,6 +9612,7 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11107,17 +9624,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
       }
     },
     "node_modules/split2": {
@@ -11352,23 +9858,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/stubborn-fs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
-      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "stubborn-utils": "^1.0.1"
-      }
-    },
-    "node_modules/stubborn-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
-      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -11537,7 +10026,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11765,7 +10253,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11798,19 +10285,6 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/uint8array-extras": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
-      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -11831,9 +10305,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12036,13 +10510,6 @@
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
-    },
-    "node_modules/when-exit": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
-      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -12275,7 +10742,6 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -12297,8 +10763,7 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.0.tgz",
       "integrity": "sha512-LqLPpIQANebrlxY6jKcYKdgN5DTXyyHAKnnWWjE5pPfEQ4n7j5zn7mOEEpwNZVKGqx3kKKmvplEmoBrvpgROTA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/zustand": {
       "version": "5.0.10",
@@ -12327,6 +10792,111 @@
         "use-sync-external-store": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.4.tgz",
+      "integrity": "sha512-T8atLKuvk13XQUdVLCv1ZzMPgLPW0+DWWbHSQXs0/3TjPrKNxTmUIhOEaoEyl3Z82k8h/gEtqyuoZGv6+Ugawg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.4.tgz",
+      "integrity": "sha512-AKC/qVjUGUQDSPI6gESTx0xOnOPQ5gttogNS3o6bA83yiaSZJek0Am5yXy82F1KcZCx3DdOwdGPZpQCluonuxg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.4.tgz",
+      "integrity": "sha512-POQ65+pnYOkZNdngWfMEt7r53bzWiKkVNbjpmCt1Zb3V6lxJNXSsjwRuTQ8P/kguxDC8LRkqaL3vvsFrce4dMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.4.tgz",
+      "integrity": "sha512-3Wm0zGYVCs6qDFAiSSDL+Z+r46EdtCv/2l+UlIdMbAq9hPJBvGu/rZOeuvCaIUjbArkmXac8HnTyQPJFzFWA0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.4.tgz",
+      "integrity": "sha512-lWAYAezFinaJiD5Gv8HDidtsZdT3CDaCeqoPoJjeB57OqzvMajpIhlZFce5sCAH6VuX4mdkxCRqecCJFwfm2nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.4.tgz",
+      "integrity": "sha512-fHaIpT7x4gA6VQbdEpYUXRGyge/YbRrkG6DXM60XiBqDM2g2NcrsQaIuj375egnGFkJow4RHacgBOEsHfGbiUw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.4.tgz",
+      "integrity": "sha512-MCrXxrTSE7jPN1NyXJr39E+aNFBrQZtO154LoCz7n99FuKqJDekgxipoodLNWdQP7/DZ5tKMc/efybx1l159hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     }
   }


### PR DESCRIPTION
feat(GBGB-280-fe-seat-api): SEAT API 연동 완료

🔧 작업 내용
- 좌석 예매 관련 SEAT API 연동을 완료했습니다.
- 추천 좌석 조회, 구역/블럭 좌석 조회, 좌석 Hold 생성 흐름을 프론트와 연결했습니다.
- 좌석 선택/추천 좌석 예매 시 API 응답에 맞춰 화면이 동작하도록 처리했습니다.

🧩 구현 상세 (선택)
- `booking-options` 저장 후 대기열 진입 및 좌석 선택 화면 이동 로직을 연결했습니다.
- 추천 좌석 조회 API, 구역별 블럭 좌석 조회 API를 연동했습니다.
- 직접 선택 시 `seat-holds` API를 호출할 수 있도록 구조를 반영했습니다.
- 추천 좌석/직접 선택 각각의 로딩, 예외, 만료 케이스를 프론트에서 분기 처리했습니다.

📌 관련 Jira Issue
- GBGB-280-fe-seat-api

🧪 테스트 방법(선택)
- 경기 상세에서 예매하기 클릭 후 대기열 진입이 정상 동작하는지 확인
- 추천 좌석 모드에서 추천 좌석 목록이 정상 조회되는지 확인
- 직접 선택 모드에서 구역/블럭 진입 후 좌석 조회가 정상 동작하는지 확인
- 좌석 선택 완료 시 Hold 생성 API가 정상 호출되는지 확인
- 만료/충돌/잘못된 요청 등 에러 케이스에서 토스트 및 화면 이동이 정상 동작하는지 확인

❗ 참고 사항
- 백엔드 응답 스펙 기준으로 상태 코드별 예외 처리를 반영했습니다.
- 직접 선택 좌석 Hold 이후 결제 화면 연계는 후속 플로우와 함께 최종 점검이 필요할 수 있습니다.

Fixes:
- GBGB-280