### PR TITLE
Feat.faro

### DIFF
--- a/goorm-gongbang/app/providers.tsx
+++ b/goorm-gongbang/app/providers.tsx
@@ -9,15 +9,36 @@
 
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
 import { useAuthStore } from "@/stores/authStore";
 import { refreshAccessToken, getMe } from "@/lib/services";
+import { initFaro } from "@/lib/client/faro";
+import { trackPageView } from "@/lib/client/analytics";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const setAccessToken = useAuthStore((s) => s.setAccessToken);
   const setUser = useAuthStore((s) => s.setUser);
   const bootstrapped = useAuthStore((s) => s.bootstrapped); // 초기 인증 복구 절차 플래그
   const setBootstrapped = useAuthStore((s) => s.setBootstrapped);
+
+  const pathname = usePathname();
+  const faroInitialized = useRef(false);
+
+  // [Faro] 초기화 (1회만)
+  useEffect(() => {
+    if (!faroInitialized.current) {
+      initFaro();
+      faroInitialized.current = true;
+    }
+  }, []);
+
+  // [Faro] 페이지 뷰 추적
+  useEffect(() => {
+    if (bootstrapped && pathname) {
+      trackPageView(pathname);
+    }
+  }, [bootstrapped, pathname]);
 
   useEffect(() => {
     let mounted = true;

--- a/goorm-gongbang/lib/client/analytics.ts
+++ b/goorm-gongbang/lib/client/analytics.ts
@@ -1,4 +1,99 @@
 /* ===========================
-   -용도
    브라우저 전용 관측/분석 유틸
+   - Grafana Faro 이벤트 래퍼
+   - 공통 필드 자동 포함
 =========================== */
+
+import { getFaro } from "./faro";
+
+type EventProps = Record<string, string | number | boolean | undefined>;
+
+/**
+ * 디바이스 타입 감지
+ */
+function getDeviceType(): "mobile" | "desktop" {
+  if (typeof window === "undefined") return "desktop";
+  return /Mobile|Android|iPhone|iPad/i.test(navigator.userAgent)
+    ? "mobile"
+    : "desktop";
+}
+
+/**
+ * 로그인 상태 확인 (zustand 직접 import 방지 - 순환참조)
+ */
+function getIsLoggedIn(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const stored = localStorage.getItem("auth-storage");
+    if (!stored) return false;
+    const parsed = JSON.parse(stored);
+    return !!parsed?.state?.user;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 공통 필드 생성
+ */
+function getCommonProps(
+  route: string,
+  extra?: EventProps
+): Record<string, string | number | boolean> {
+  const props: Record<string, string | number | boolean> = {
+    route,
+    device_type: getDeviceType(),
+    is_logged_in: getIsLoggedIn(),
+  };
+
+  // 추가 필드 병합 (undefined 제외)
+  if (extra) {
+    Object.entries(extra).forEach(([key, value]) => {
+      if (value !== undefined) {
+        props[key] = value;
+      }
+    });
+  }
+
+  return props;
+}
+
+/**
+ * 페이지 뷰 전송
+ */
+export function trackPageView(route: string, props?: EventProps): void {
+  if (typeof window === "undefined") return;
+
+  const faro = getFaro();
+  if (!faro) return;
+
+  faro.api?.pushEvent("page_view", getCommonProps(route, props));
+}
+
+/**
+ * 액션 이벤트 전송
+ */
+export function trackAction(name: string, props?: EventProps): void {
+  if (typeof window === "undefined") return;
+
+  const faro = getFaro();
+  if (!faro) return;
+
+  const route =
+    typeof window !== "undefined" ? window.location.pathname : "unknown";
+  faro.api?.pushEvent(name, getCommonProps(route, props));
+}
+
+/**
+ * 에러 이벤트 전송
+ */
+export function trackError(name: string, props?: EventProps): void {
+  if (typeof window === "undefined") return;
+
+  const faro = getFaro();
+  if (!faro) return;
+
+  const route =
+    typeof window !== "undefined" ? window.location.pathname : "unknown";
+  faro.api?.pushEvent(name, getCommonProps(route, props));
+}

--- a/goorm-gongbang/lib/client/analytics.ts
+++ b/goorm-gongbang/lib/client/analytics.ts
@@ -39,12 +39,10 @@ const DENIED_PATTERNS = [
 ];
 
 /**
- * 민감정보 필터링
+ * 민감정보 필터링 + string 변환 (Faro EventAttributes 호환)
  */
-function sanitizeProps(
-  props: EventProps
-): Record<string, string | number | boolean> {
-  const sanitized: Record<string, string | number | boolean> = {};
+function sanitizeProps(props: EventProps): Record<string, string> {
+  const sanitized: Record<string, string> = {};
 
   Object.entries(props).forEach(([key, value]) => {
     if (value === undefined) return;
@@ -52,7 +50,8 @@ function sanitizeProps(
     if (!ALLOWED_FIELDS.has(key)) return;
     // 금지 패턴 2차 체크
     if (DENIED_PATTERNS.some((pattern) => pattern.test(key))) return;
-    sanitized[key] = value;
+    // Faro는 string만 허용
+    sanitized[key] = String(value);
   });
 
   return sanitized;
@@ -84,16 +83,16 @@ function getIsLoggedIn(): boolean {
 }
 
 /**
- * 공통 필드 생성
+ * 공통 필드 생성 (Faro EventAttributes 호환 - string only)
  */
 function getCommonProps(
   route: string,
   extra?: EventProps
-): Record<string, string | number | boolean> {
-  const base: Record<string, string | number | boolean> = {
+): Record<string, string> {
+  const base: Record<string, string> = {
     route,
     device_type: getDeviceType(),
-    is_logged_in: getIsLoggedIn(),
+    is_logged_in: String(getIsLoggedIn()),
   };
 
   if (extra) {
@@ -142,7 +141,7 @@ export function trackError(
   if (!faro) return;
 
   const route = window.location.pathname;
-  const errorProps = {
+  const errorProps: Record<string, string> = {
     ...getCommonProps(route, props),
     error_type: error instanceof Error ? error.name : "Error",
     error_code: typeof error === "string" ? error : error?.message || "unknown",

--- a/goorm-gongbang/lib/client/analytics.ts
+++ b/goorm-gongbang/lib/client/analytics.ts
@@ -2,11 +2,61 @@
    브라우저 전용 관측/분석 유틸
    - Grafana Faro 이벤트 래퍼
    - 공통 필드 자동 포함
+   - 민감정보 필터링
 =========================== */
 
 import { getFaro } from "./faro";
 
 type EventProps = Record<string, string | number | boolean | undefined>;
+
+// 허용된 필드만 전송 (화이트리스트)
+const ALLOWED_FIELDS = new Set([
+  "route",
+  "device_type",
+  "is_logged_in",
+  "payment_method",
+  "seat_count",
+  "ticket_count",
+  "flow_step",
+  "match_slug",
+  "error_code",
+  "error_type",
+  "step",
+  "method",
+]);
+
+// 금지 필드 패턴 (2차 방어)
+const DENIED_PATTERNS = [
+  /token/i,
+  /password/i,
+  /email/i,
+  /phone/i,
+  /secret/i,
+  /credential/i,
+  /user_id/i,
+  /order_id/i,
+  /session_id/i,
+];
+
+/**
+ * 민감정보 필터링
+ */
+function sanitizeProps(
+  props: EventProps
+): Record<string, string | number | boolean> {
+  const sanitized: Record<string, string | number | boolean> = {};
+
+  Object.entries(props).forEach(([key, value]) => {
+    if (value === undefined) return;
+    // 허용 필드만 통과
+    if (!ALLOWED_FIELDS.has(key)) return;
+    // 금지 패턴 2차 체크
+    if (DENIED_PATTERNS.some((pattern) => pattern.test(key))) return;
+    sanitized[key] = value;
+  });
+
+  return sanitized;
+}
 
 /**
  * 디바이스 타입 감지
@@ -40,22 +90,17 @@ function getCommonProps(
   route: string,
   extra?: EventProps
 ): Record<string, string | number | boolean> {
-  const props: Record<string, string | number | boolean> = {
+  const base: Record<string, string | number | boolean> = {
     route,
     device_type: getDeviceType(),
     is_logged_in: getIsLoggedIn(),
   };
 
-  // 추가 필드 병합 (undefined 제외)
   if (extra) {
-    Object.entries(extra).forEach(([key, value]) => {
-      if (value !== undefined) {
-        props[key] = value;
-      }
-    });
+    return { ...base, ...sanitizeProps(extra) };
   }
 
-  return props;
+  return base;
 }
 
 /**
@@ -79,21 +124,29 @@ export function trackAction(name: string, props?: EventProps): void {
   const faro = getFaro();
   if (!faro) return;
 
-  const route =
-    typeof window !== "undefined" ? window.location.pathname : "unknown";
+  const route = window.location.pathname;
   faro.api?.pushEvent(name, getCommonProps(route, props));
 }
 
 /**
  * 에러 이벤트 전송
  */
-export function trackError(name: string, props?: EventProps): void {
+export function trackError(
+  name: string,
+  error?: Error | string,
+  props?: EventProps
+): void {
   if (typeof window === "undefined") return;
 
   const faro = getFaro();
   if (!faro) return;
 
-  const route =
-    typeof window !== "undefined" ? window.location.pathname : "unknown";
-  faro.api?.pushEvent(name, getCommonProps(route, props));
+  const route = window.location.pathname;
+  const errorProps = {
+    ...getCommonProps(route, props),
+    error_type: error instanceof Error ? error.name : "Error",
+    error_code: typeof error === "string" ? error : error?.message || "unknown",
+  };
+
+  faro.api?.pushEvent(name, errorProps);
 }

--- a/goorm-gongbang/lib/client/faro.ts
+++ b/goorm-gongbang/lib/client/faro.ts
@@ -1,0 +1,58 @@
+/* ===========================
+   Grafana Faro 초기화
+   - 프론트엔드 관측성 (RUM, Tracing)
+   - 중복 초기화 방지
+=========================== */
+
+import { initializeFaro, getWebInstrumentations } from "@grafana/faro-web-sdk";
+import { TracingInstrumentation } from "@grafana/faro-web-tracing";
+
+type FaroInstance = ReturnType<typeof initializeFaro>;
+
+let faroInstance: FaroInstance | null = null;
+
+/**
+ * Faro 초기화 (클라이언트 전용)
+ * - 서버에서 호출 시 null 반환
+ * - 중복 호출 시 기존 인스턴스 반환
+ */
+export function initFaro(): FaroInstance | null {
+  // 서버 사이드 실행 방지
+  if (typeof window === "undefined") return null;
+
+  // 이미 초기화되었으면 기존 인스턴스 반환
+  if (faroInstance) return faroInstance;
+
+  const faroUrl = process.env.NEXT_PUBLIC_FARO_URL;
+
+  // URL이 없으면 초기화하지 않음
+  if (!faroUrl) {
+    console.warn("[Faro] NEXT_PUBLIC_FARO_URL is not set. Faro disabled.");
+    return null;
+  }
+
+  faroInstance = initializeFaro({
+    url: faroUrl,
+    app: {
+      name: "goormgb-frontend",
+      version: process.env.NEXT_PUBLIC_RELEASE || "1.0.0",
+      environment: process.env.NEXT_PUBLIC_ENV || "development",
+    },
+    instrumentations: [
+      // 기본 웹 계측 (console, errors, web vitals 등)
+      ...getWebInstrumentations(),
+      // 분산 추적 (traceparent 전파)
+      new TracingInstrumentation(),
+    ],
+  });
+
+  console.info("[Faro] Initialized successfully");
+  return faroInstance;
+}
+
+/**
+ * Faro 인스턴스 가져오기
+ */
+export function getFaro(): FaroInstance | null {
+  return faroInstance;
+}

--- a/goorm-gongbang/lib/client/faro.ts
+++ b/goorm-gongbang/lib/client/faro.ts
@@ -1,7 +1,7 @@
 /* ===========================
    Grafana Faro 초기화
    - 프론트엔드 관측성 (RUM, Tracing)
-   - 중복 초기화 방지
+   - API 호출만 추적 (범위 제한)
 =========================== */
 
 import { initializeFaro, getWebInstrumentations } from "@grafana/faro-web-sdk";
@@ -10,6 +10,13 @@ import { TracingInstrumentation } from "@grafana/faro-web-tracing";
 type FaroInstance = ReturnType<typeof initializeFaro>;
 
 let faroInstance: FaroInstance | null = null;
+
+// Tracing 대상 API (내부 API만 - 정적 파일/외부 요청 제외)
+const TRACE_TARGET_URLS = [
+  /api\.staging\.playball\.one/,
+  /api\.playball\.one/,
+  /api\.dev\.goormgb\.space/,
+];
 
 /**
  * Faro 초기화 (클라이언트 전용)
@@ -41,8 +48,10 @@ export function initFaro(): FaroInstance | null {
     instrumentations: [
       // 기본 웹 계측 (console, errors, web vitals 등)
       ...getWebInstrumentations(),
-      // 분산 추적 (traceparent 전파)
-      new TracingInstrumentation(),
+      // 분산 추적 - 내부 API만 추적 (외부/정적 파일 제외)
+      new TracingInstrumentation({
+        propagateTraceHeaderCorsUrls: TRACE_TARGET_URLS,
+      }),
     ],
   });
 

--- a/goorm-gongbang/next.config.ts
+++ b/goorm-gongbang/next.config.ts
@@ -25,7 +25,8 @@ const nextConfig = {
   // 기존 OTel 및 권장 설정 유지
   compress: true,
   poweredByHeader: false,
-  productionBrowserSourceMaps: false,
+  // staging에서만 sourcemap 활성화 (디버깅용)
+  productionBrowserSourceMaps: process.env.NEXT_PUBLIC_ENV === "staging",
 
   // 보안 헤더 유지
   async headers() {

--- a/goorm-gongbang/next.config.ts
+++ b/goorm-gongbang/next.config.ts
@@ -52,6 +52,9 @@ const nextConfig = {
     OTEL_EXPORTER_OTLP_ENDPOINT:
       process.env.OTEL_EXPORTER_OTLP_ENDPOINT ||
       "http://otel-collector:4318/v1/traces",
+    // Grafana Faro (프론트엔드 관측성)
+    NEXT_PUBLIC_FARO_URL: process.env.NEXT_PUBLIC_FARO_URL || "",
+    NEXT_PUBLIC_RELEASE: process.env.NEXT_PUBLIC_RELEASE || "1.0.0",
   },
 };
 

--- a/goorm-gongbang/package.json
+++ b/goorm-gongbang/package.json
@@ -11,6 +11,8 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@grafana/faro-web-sdk": "^1.13.1",
+    "@grafana/faro-web-tracing": "^1.13.1",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.211.0",
     "@opentelemetry/auto-instrumentations-node": "^0.69.0",


### PR DESCRIPTION
[🔧 작업 내용]
 - Grafana Faro SDK 보완 (PM용 대시보드 기획)

  1.민감정보 수집 방지
  - analytics.ts에 화이트리스트 기반 필드 필터링 추가
  - ALLOWED_FIELDS: route, device_type, payment_method, seat_count 등 허용 필드만 전송
  - DENIED_PATTERNS: token, email, phone, user_id 등 민감 패턴 2차 차단

  2.Tracing 범위 제한
  - faro.ts에서 TracingInstrumentation에 propagateTraceHeaderCorsUrls 설정
  - 내부 API만 추적 (api.staging.playball.one, api.playball.one, api.dev.goormgb.space)
  - 외부 요청, 정적 파일, 이미지 등 불필요한 추적 제외 → Tempo 노이즈 감소

  3.Staging Sourcemap 활성화
  - next.config.ts에서 staging 환경에서만 sourcemap 활성화
  - 프론트 오류 stack trace 분석 가능

  ---
[🧩 구현 상세]

  1.민감정보 필터링 전략

  이벤트 props → sanitizeProps() → ALLOWED_FIELDS 체크 → DENIED_PATTERNS 체크 → 전송
  - 화이트리스트 우선: 허용 필드만 명시적으로 정의
  - 블랙리스트 2차 방어: 실수로 허용 필드에 민감 패턴이 포함되더라도 차단

  2.Tracing 범위 제한 이유

  - 기본 TracingInstrumentation()은 모든 fetch/XHR 요청을 추적
  - CDN 이미지, 외부 스크립트, 폰트 등까지 추적 시 오버헤드 발생
  - 내부 API만 추적하여 의미 있는 분산 추적 데이터만 수집

  ---
  [🧪 테스트 방법]

  1. Faro 초기화 확인
  - 브라우저 콘솔에서 [Faro] Initialized successfully 로그 확인

  2. 이벤트 전송 확인
  - DevTools > Network > /faro 요청 확인
  - Request Payload에 민감정보(token, email 등) 없는지 확인

  3. Grafana 수집 확인
  - Grafana > Explore > Loki
  - {service_name="goormgb-frontend"} 쿼리로 로그 확인

  ---
  ❗ 참고 사항

  Vercel 환경변수 설정 완료
  | 변수                 | 값                                    |
  |----------------------|---------------------------------------|
  | NEXT_PUBLIC_FARO_URL | https://api.staging.playball.one/faro |
  | NEXT_PUBLIC_ENV      | staging                               |
  | NEXT_PUBLIC_RELEASE  | $VERCEL_GIT_COMMIT_SHA                |

  후속 작업 
  - 주요 플로우에 trackAction() 호출 연결 필요
    - match_click, checkout_start, payment_success/fail, login_success/fail 등
  - API 에러 분기에 trackError() 호출 연결 필요

  관련 문서
  - 클라우드팀 Faro 보완 요청서 (2026-03-25, 정지혜)