### PR TITLE
feat(faro): Faro SDK 보완 - 민감정보 필터링, 트래킹 훅 추가

### DIFF
--- a/goorm-gongbang/app/page.tsx
+++ b/goorm-gongbang/app/page.tsx
@@ -8,6 +8,7 @@ import { TeamInfoCard } from "@/components/common/TeamInfoCard";
 import { cn } from "@/lib/utils";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useRouter } from "next/navigation";
+import { useMatchTracking } from "@/hooks/useAnalytics";
 import { getMatches, getClubs } from "@/lib/services";
 import { SaleStatus, Club, MatchesData, ClubsData } from "@/lib/types";
 import { ApiError } from "@/lib/api";
@@ -125,6 +126,7 @@ function TeamCardSkeleton() {
 
 export default function Home() {
   const router = useRouter();
+  const { onMatchClick } = useMatchTracking();
   const todayISO = useMemo(() => {
     const d = new Date();
     const yyyy = d.getFullYear();
@@ -292,7 +294,10 @@ export default function Home() {
                         key={m.matchId}
                         type="button"
                         disabled={!isClickable}
-                        onClick={() => router.push(`/matches/${m.matchId}`)}
+                        onClick={() => {
+                          onMatchClick({ match_slug: String(m.matchId) });
+                          router.push(`/matches/${m.matchId}`);
+                        }}
                         className="w-full max-w-[1074px] text-left cursor-pointer"
                       >
                         <MatchCard

--- a/goorm-gongbang/app/providers.tsx
+++ b/goorm-gongbang/app/providers.tsx
@@ -9,15 +9,36 @@
 
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
 import { useAuthStore } from "@/stores/authStore";
 import { refreshAccessToken, getMe } from "@/lib/services";
+import { initFaro } from "@/lib/client/faro";
+import { trackPageView } from "@/lib/client/analytics";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const setAccessToken = useAuthStore((s) => s.setAccessToken);
   const setUser = useAuthStore((s) => s.setUser);
   const bootstrapped = useAuthStore((s) => s.bootstrapped); // 초기 인증 복구 절차 플래그
   const setBootstrapped = useAuthStore((s) => s.setBootstrapped);
+
+  const pathname = usePathname();
+  const faroInitialized = useRef(false);
+
+  // [Faro] 초기화 (1회만)
+  useEffect(() => {
+    if (!faroInitialized.current) {
+      initFaro();
+      faroInitialized.current = true;
+    }
+  }, []);
+
+  // [Faro] 페이지 뷰 추적
+  useEffect(() => {
+    if (bootstrapped && pathname) {
+      trackPageView(pathname);
+    }
+  }, [bootstrapped, pathname]);
 
   useEffect(() => {
     let mounted = true;

--- a/goorm-gongbang/hooks/useAnalytics.ts
+++ b/goorm-gongbang/hooks/useAnalytics.ts
@@ -1,0 +1,237 @@
+"use client";
+
+import { useEffect, useCallback, useRef } from "react";
+import { useAuthStore } from "@/stores/authStore";
+import { trackAction, trackError, trackPageView } from "@/lib/client/analytics";
+
+type EventProps = Record<string, string | number | boolean | undefined>;
+
+/**
+ * 로그인 상태를 자동으로 주입하는 헬퍼
+ */
+function useWithAuth() {
+  const user = useAuthStore((s) => s.user);
+  const isLoggedIn = !!user;
+
+  const withAuth = useCallback(
+    (props?: EventProps): EventProps => ({
+      ...props,
+      is_logged_in: isLoggedIn,
+    }),
+    [isLoggedIn]
+  );
+
+  return { isLoggedIn, withAuth };
+}
+
+/**
+ * 페이지 뷰 자동 트래킹 훅
+ * - 컴포넌트 마운트 시 page_view 이벤트 전송
+ * - 로그인 상태 자동 주입
+ */
+export function useTrackPageView(pageName: string, props?: EventProps) {
+  const tracked = useRef(false);
+  const { withAuth } = useWithAuth();
+
+  useEffect(() => {
+    if (tracked.current) return;
+    tracked.current = true;
+    trackPageView(pageName, withAuth(props));
+  }, [pageName, props, withAuth]);
+}
+
+/**
+ * 이벤트 트래킹 훅
+ * - trackEvent: 수동 이벤트 전송 (로그인 상태 자동 주입)
+ */
+export function useTrackEvent() {
+  const { withAuth } = useWithAuth();
+
+  const trackEvent = useCallback(
+    (name: string, props?: EventProps) => {
+      trackAction(name, withAuth(props));
+    },
+    [withAuth]
+  );
+
+  return { trackEvent };
+}
+
+/**
+ * 에러 트래킹 훅 (로그인 상태 자동 주입)
+ */
+export function useTrackError() {
+  const { withAuth } = useWithAuth();
+
+  const track = useCallback(
+    (name: string, error?: Error | string, props?: EventProps) => {
+      trackError(name, error, withAuth(props));
+    },
+    [withAuth]
+  );
+
+  return { trackError: track };
+}
+
+// ============================================
+// 도메인별 특화 훅
+// ============================================
+
+/**
+ * 로그인 트래킹 훅
+ * @example
+ * const { onLoginSuccess, onLoginFail } = useLoginTracking("kakao");
+ *
+ * try {
+ *   await login();
+ *   onLoginSuccess();
+ * } catch (e) {
+ *   onLoginFail(e);
+ * }
+ */
+export function useLoginTracking(method: "kakao" | "google") {
+  const onLoginSuccess = useCallback(() => {
+    trackAction("login_success", { method });
+  }, [method]);
+
+  const onLoginFail = useCallback(
+    (error?: Error | string) => {
+      trackError("login_fail", error, { method });
+    },
+    [method]
+  );
+
+  return { onLoginSuccess, onLoginFail };
+}
+
+/**
+ * 결제 트래킹 훅 (로그인 상태 자동 주입)
+ * @example
+ * const { onPaymentSuccess, onPaymentFail, onCheckoutStart } = usePaymentTracking();
+ *
+ * // 주문서 진입 시
+ * onCheckoutStart({ ticket_count: 2 });
+ *
+ * // 결제 완료 시
+ * onPaymentSuccess({ payment_method: "toss" });
+ */
+export function usePaymentTracking() {
+  const { withAuth } = useWithAuth();
+
+  const onCheckoutStart = useCallback(
+    (props?: EventProps) => {
+      trackAction("checkout_start", withAuth(props));
+    },
+    [withAuth]
+  );
+
+  const onPaymentStart = useCallback(
+    (props?: EventProps) => {
+      trackAction("payment_start", withAuth(props));
+    },
+    [withAuth]
+  );
+
+  const onPaymentSuccess = useCallback(
+    (props?: EventProps) => {
+      trackAction("payment_success", withAuth(props));
+    },
+    [withAuth]
+  );
+
+  const onPaymentFail = useCallback(
+    (error?: Error | string, props?: EventProps) => {
+      trackError("payment_fail", error, withAuth(props));
+    },
+    [withAuth]
+  );
+
+  return { onCheckoutStart, onPaymentStart, onPaymentSuccess, onPaymentFail };
+}
+
+/**
+ * 좌석 트래킹 훅 (로그인 상태 자동 주입)
+ * @example
+ * const { onSeatRecommendClick, onSeatSelectClick } = useSeatTracking();
+ *
+ * // 추천 좌석 선택 시
+ * onSeatRecommendClick({ seat_count: 2 });
+ */
+export function useSeatTracking() {
+  const { withAuth } = useWithAuth();
+
+  const onSeatRecommendClick = useCallback(
+    (props?: EventProps) => {
+      trackAction("seat_recommend_click", withAuth(props));
+    },
+    [withAuth]
+  );
+
+  const onSeatSelectClick = useCallback(
+    (props?: EventProps) => {
+      trackAction("seat_select_click", withAuth(props));
+    },
+    [withAuth]
+  );
+
+  const onSeatFetchFail = useCallback(
+    (error?: Error | string, props?: EventProps) => {
+      trackError("seat_fetch_fail", error, withAuth(props));
+    },
+    [withAuth]
+  );
+
+  return { onSeatRecommendClick, onSeatSelectClick, onSeatFetchFail };
+}
+
+/**
+ * 매치 트래킹 훅 (로그인 상태 자동 주입)
+ * @example
+ * const { onMatchClick } = useMatchTracking();
+ *
+ * // 매치 카드 클릭 시
+ * onMatchClick({ match_slug: "lg-vs-samsung-20260401" });
+ */
+export function useMatchTracking() {
+  const { withAuth } = useWithAuth();
+
+  const onMatchClick = useCallback(
+    (props?: EventProps) => {
+      trackAction("match_click", withAuth(props));
+    },
+    [withAuth]
+  );
+
+  const onMatchDetailView = useCallback(
+    (props?: EventProps) => {
+      trackAction("match_detail_view", withAuth(props));
+    },
+    [withAuth]
+  );
+
+  return { onMatchClick, onMatchDetailView };
+}
+
+/**
+ * API 에러 트래킹 훅 (로그인 상태 자동 주입)
+ * @example
+ * const { onApiFail } = useApiTracking();
+ *
+ * try {
+ *   await fetchData();
+ * } catch (e) {
+ *   onApiFail("seat_api", e);
+ * }
+ */
+export function useApiTracking() {
+  const { withAuth } = useWithAuth();
+
+  const onApiFail = useCallback(
+    (apiName: string, error?: Error | string, props?: EventProps) => {
+      trackError(`${apiName}_fail`, error, withAuth(props));
+    },
+    [withAuth]
+  );
+
+  return { onApiFail };
+}

--- a/goorm-gongbang/hooks/useAnalytics.ts
+++ b/goorm-gongbang/hooks/useAnalytics.ts
@@ -28,16 +28,20 @@ function useWithAuth() {
  * 페이지 뷰 자동 트래킹 훅
  * - 컴포넌트 마운트 시 page_view 이벤트 전송
  * - 로그인 상태 자동 주입
+ * - props는 JSON.stringify로 안정적 의존성 처리
  */
 export function useTrackPageView(pageName: string, props?: EventProps) {
   const tracked = useRef(false);
   const { withAuth } = useWithAuth();
+  // props 객체를 안정적으로 비교하기 위해 JSON 문자열로 변환
+  const propsKey = props ? JSON.stringify(props) : "";
 
   useEffect(() => {
     if (tracked.current) return;
     tracked.current = true;
-    trackPageView(pageName, withAuth(props));
-  }, [pageName, props, withAuth]);
+    const parsedProps = propsKey ? JSON.parse(propsKey) : undefined;
+    trackPageView(pageName, withAuth(parsedProps));
+  }, [pageName, propsKey, withAuth]);
 }
 
 /**
@@ -78,7 +82,7 @@ export function useTrackError() {
 // ============================================
 
 /**
- * 로그인 트래킹 훅
+ * 로그인 트래킹 훅 (로그인 상태 자동 주입)
  * @example
  * const { onLoginSuccess, onLoginFail } = useLoginTracking("kakao");
  *
@@ -90,15 +94,17 @@ export function useTrackError() {
  * }
  */
 export function useLoginTracking(method: "kakao" | "google") {
+  const { withAuth } = useWithAuth();
+
   const onLoginSuccess = useCallback(() => {
-    trackAction("login_success", { method });
-  }, [method]);
+    trackAction("login_success", withAuth({ method }));
+  }, [method, withAuth]);
 
   const onLoginFail = useCallback(
     (error?: Error | string) => {
-      trackError("login_fail", error, { method });
+      trackError("login_fail", error, withAuth({ method }));
     },
-    [method]
+    [method, withAuth]
   );
 
   return { onLoginSuccess, onLoginFail };

--- a/goorm-gongbang/lib/client/analytics.ts
+++ b/goorm-gongbang/lib/client/analytics.ts
@@ -1,4 +1,99 @@
 /* ===========================
-   -용도
    브라우저 전용 관측/분석 유틸
+   - Grafana Faro 이벤트 래퍼
+   - 공통 필드 자동 포함
 =========================== */
+
+import { getFaro } from "./faro";
+
+type EventProps = Record<string, string | number | boolean | undefined>;
+
+/**
+ * 디바이스 타입 감지
+ */
+function getDeviceType(): "mobile" | "desktop" {
+  if (typeof window === "undefined") return "desktop";
+  return /Mobile|Android|iPhone|iPad/i.test(navigator.userAgent)
+    ? "mobile"
+    : "desktop";
+}
+
+/**
+ * 로그인 상태 확인 (zustand 직접 import 방지 - 순환참조)
+ */
+function getIsLoggedIn(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const stored = localStorage.getItem("auth-storage");
+    if (!stored) return false;
+    const parsed = JSON.parse(stored);
+    return !!parsed?.state?.user;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 공통 필드 생성
+ */
+function getCommonProps(
+  route: string,
+  extra?: EventProps
+): Record<string, string | number | boolean> {
+  const props: Record<string, string | number | boolean> = {
+    route,
+    device_type: getDeviceType(),
+    is_logged_in: getIsLoggedIn(),
+  };
+
+  // 추가 필드 병합 (undefined 제외)
+  if (extra) {
+    Object.entries(extra).forEach(([key, value]) => {
+      if (value !== undefined) {
+        props[key] = value;
+      }
+    });
+  }
+
+  return props;
+}
+
+/**
+ * 페이지 뷰 전송
+ */
+export function trackPageView(route: string, props?: EventProps): void {
+  if (typeof window === "undefined") return;
+
+  const faro = getFaro();
+  if (!faro) return;
+
+  faro.api?.pushEvent("page_view", getCommonProps(route, props));
+}
+
+/**
+ * 액션 이벤트 전송
+ */
+export function trackAction(name: string, props?: EventProps): void {
+  if (typeof window === "undefined") return;
+
+  const faro = getFaro();
+  if (!faro) return;
+
+  const route =
+    typeof window !== "undefined" ? window.location.pathname : "unknown";
+  faro.api?.pushEvent(name, getCommonProps(route, props));
+}
+
+/**
+ * 에러 이벤트 전송
+ */
+export function trackError(name: string, props?: EventProps): void {
+  if (typeof window === "undefined") return;
+
+  const faro = getFaro();
+  if (!faro) return;
+
+  const route =
+    typeof window !== "undefined" ? window.location.pathname : "unknown";
+  faro.api?.pushEvent(name, getCommonProps(route, props));
+}

--- a/goorm-gongbang/lib/client/analytics.ts
+++ b/goorm-gongbang/lib/client/analytics.ts
@@ -39,12 +39,10 @@ const DENIED_PATTERNS = [
 ];
 
 /**
- * 민감정보 필터링
+ * 민감정보 필터링 + string 변환 (Faro EventAttributes 호환)
  */
-function sanitizeProps(
-  props: EventProps
-): Record<string, string | number | boolean> {
-  const sanitized: Record<string, string | number | boolean> = {};
+function sanitizeProps(props: EventProps): Record<string, string> {
+  const sanitized: Record<string, string> = {};
 
   Object.entries(props).forEach(([key, value]) => {
     if (value === undefined) return;
@@ -52,7 +50,8 @@ function sanitizeProps(
     if (!ALLOWED_FIELDS.has(key)) return;
     // 금지 패턴 2차 체크
     if (DENIED_PATTERNS.some((pattern) => pattern.test(key))) return;
-    sanitized[key] = value;
+    // Faro는 string만 허용
+    sanitized[key] = String(value);
   });
 
   return sanitized;
@@ -84,16 +83,16 @@ function getIsLoggedIn(): boolean {
 }
 
 /**
- * 공통 필드 생성
+ * 공통 필드 생성 (Faro EventAttributes 호환 - string only)
  */
 function getCommonProps(
   route: string,
   extra?: EventProps
-): Record<string, string | number | boolean> {
-  const base: Record<string, string | number | boolean> = {
+): Record<string, string> {
+  const base: Record<string, string> = {
     route,
     device_type: getDeviceType(),
-    is_logged_in: getIsLoggedIn(),
+    is_logged_in: String(getIsLoggedIn()),
   };
 
   if (extra) {
@@ -142,7 +141,7 @@ export function trackError(
   if (!faro) return;
 
   const route = window.location.pathname;
-  const errorProps = {
+  const errorProps: Record<string, string> = {
     ...getCommonProps(route, props),
     error_type: error instanceof Error ? error.name : "Error",
     error_code: typeof error === "string" ? error : error?.message || "unknown",

--- a/goorm-gongbang/lib/client/analytics.ts
+++ b/goorm-gongbang/lib/client/analytics.ts
@@ -2,11 +2,61 @@
    브라우저 전용 관측/분석 유틸
    - Grafana Faro 이벤트 래퍼
    - 공통 필드 자동 포함
+   - 민감정보 필터링
 =========================== */
 
 import { getFaro } from "./faro";
 
 type EventProps = Record<string, string | number | boolean | undefined>;
+
+// 허용된 필드만 전송 (화이트리스트)
+const ALLOWED_FIELDS = new Set([
+  "route",
+  "device_type",
+  "is_logged_in",
+  "payment_method",
+  "seat_count",
+  "ticket_count",
+  "flow_step",
+  "match_slug",
+  "error_code",
+  "error_type",
+  "step",
+  "method",
+]);
+
+// 금지 필드 패턴 (2차 방어)
+const DENIED_PATTERNS = [
+  /token/i,
+  /password/i,
+  /email/i,
+  /phone/i,
+  /secret/i,
+  /credential/i,
+  /user_id/i,
+  /order_id/i,
+  /session_id/i,
+];
+
+/**
+ * 민감정보 필터링
+ */
+function sanitizeProps(
+  props: EventProps
+): Record<string, string | number | boolean> {
+  const sanitized: Record<string, string | number | boolean> = {};
+
+  Object.entries(props).forEach(([key, value]) => {
+    if (value === undefined) return;
+    // 허용 필드만 통과
+    if (!ALLOWED_FIELDS.has(key)) return;
+    // 금지 패턴 2차 체크
+    if (DENIED_PATTERNS.some((pattern) => pattern.test(key))) return;
+    sanitized[key] = value;
+  });
+
+  return sanitized;
+}
 
 /**
  * 디바이스 타입 감지
@@ -40,22 +90,17 @@ function getCommonProps(
   route: string,
   extra?: EventProps
 ): Record<string, string | number | boolean> {
-  const props: Record<string, string | number | boolean> = {
+  const base: Record<string, string | number | boolean> = {
     route,
     device_type: getDeviceType(),
     is_logged_in: getIsLoggedIn(),
   };
 
-  // 추가 필드 병합 (undefined 제외)
   if (extra) {
-    Object.entries(extra).forEach(([key, value]) => {
-      if (value !== undefined) {
-        props[key] = value;
-      }
-    });
+    return { ...base, ...sanitizeProps(extra) };
   }
 
-  return props;
+  return base;
 }
 
 /**
@@ -79,21 +124,29 @@ export function trackAction(name: string, props?: EventProps): void {
   const faro = getFaro();
   if (!faro) return;
 
-  const route =
-    typeof window !== "undefined" ? window.location.pathname : "unknown";
+  const route = window.location.pathname;
   faro.api?.pushEvent(name, getCommonProps(route, props));
 }
 
 /**
  * 에러 이벤트 전송
  */
-export function trackError(name: string, props?: EventProps): void {
+export function trackError(
+  name: string,
+  error?: Error | string,
+  props?: EventProps
+): void {
   if (typeof window === "undefined") return;
 
   const faro = getFaro();
   if (!faro) return;
 
-  const route =
-    typeof window !== "undefined" ? window.location.pathname : "unknown";
-  faro.api?.pushEvent(name, getCommonProps(route, props));
+  const route = window.location.pathname;
+  const errorProps = {
+    ...getCommonProps(route, props),
+    error_type: error instanceof Error ? error.name : "Error",
+    error_code: typeof error === "string" ? error : error?.message || "unknown",
+  };
+
+  faro.api?.pushEvent(name, errorProps);
 }

--- a/goorm-gongbang/lib/client/analytics.ts
+++ b/goorm-gongbang/lib/client/analytics.ts
@@ -68,22 +68,8 @@ function getDeviceType(): "mobile" | "desktop" {
 }
 
 /**
- * 로그인 상태 확인 (zustand 직접 import 방지 - 순환참조)
- */
-function getIsLoggedIn(): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    const stored = localStorage.getItem("auth-storage");
-    if (!stored) return false;
-    const parsed = JSON.parse(stored);
-    return !!parsed?.state?.user;
-  } catch {
-    return false;
-  }
-}
-
-/**
  * 공통 필드 생성 (Faro EventAttributes 호환 - string only)
+ * - is_logged_in은 훅(useAnalytics)에서 주입됨
  */
 function getCommonProps(
   route: string,
@@ -92,7 +78,6 @@ function getCommonProps(
   const base: Record<string, string> = {
     route,
     device_type: getDeviceType(),
-    is_logged_in: String(getIsLoggedIn()),
   };
 
   if (extra) {

--- a/goorm-gongbang/lib/client/faro.ts
+++ b/goorm-gongbang/lib/client/faro.ts
@@ -1,0 +1,58 @@
+/* ===========================
+   Grafana Faro 초기화
+   - 프론트엔드 관측성 (RUM, Tracing)
+   - 중복 초기화 방지
+=========================== */
+
+import { initializeFaro, getWebInstrumentations } from "@grafana/faro-web-sdk";
+import { TracingInstrumentation } from "@grafana/faro-web-tracing";
+
+type FaroInstance = ReturnType<typeof initializeFaro>;
+
+let faroInstance: FaroInstance | null = null;
+
+/**
+ * Faro 초기화 (클라이언트 전용)
+ * - 서버에서 호출 시 null 반환
+ * - 중복 호출 시 기존 인스턴스 반환
+ */
+export function initFaro(): FaroInstance | null {
+  // 서버 사이드 실행 방지
+  if (typeof window === "undefined") return null;
+
+  // 이미 초기화되었으면 기존 인스턴스 반환
+  if (faroInstance) return faroInstance;
+
+  const faroUrl = process.env.NEXT_PUBLIC_FARO_URL;
+
+  // URL이 없으면 초기화하지 않음
+  if (!faroUrl) {
+    console.warn("[Faro] NEXT_PUBLIC_FARO_URL is not set. Faro disabled.");
+    return null;
+  }
+
+  faroInstance = initializeFaro({
+    url: faroUrl,
+    app: {
+      name: "goormgb-frontend",
+      version: process.env.NEXT_PUBLIC_RELEASE || "1.0.0",
+      environment: process.env.NEXT_PUBLIC_ENV || "development",
+    },
+    instrumentations: [
+      // 기본 웹 계측 (console, errors, web vitals 등)
+      ...getWebInstrumentations(),
+      // 분산 추적 (traceparent 전파)
+      new TracingInstrumentation(),
+    ],
+  });
+
+  console.info("[Faro] Initialized successfully");
+  return faroInstance;
+}
+
+/**
+ * Faro 인스턴스 가져오기
+ */
+export function getFaro(): FaroInstance | null {
+  return faroInstance;
+}

--- a/goorm-gongbang/lib/client/faro.ts
+++ b/goorm-gongbang/lib/client/faro.ts
@@ -50,7 +50,9 @@ export function initFaro(): FaroInstance | null {
       ...getWebInstrumentations(),
       // 분산 추적 - 내부 API만 추적 (외부/정적 파일 제외)
       new TracingInstrumentation({
-        propagateTraceHeaderCorsUrls: TRACE_TARGET_URLS,
+        instrumentationOptions: {
+          propagateTraceHeaderCorsUrls: TRACE_TARGET_URLS,
+        },
       }),
     ],
   });

--- a/goorm-gongbang/lib/client/faro.ts
+++ b/goorm-gongbang/lib/client/faro.ts
@@ -1,7 +1,7 @@
 /* ===========================
    Grafana Faro 초기화
    - 프론트엔드 관측성 (RUM, Tracing)
-   - 중복 초기화 방지
+   - API 호출만 추적 (범위 제한)
 =========================== */
 
 import { initializeFaro, getWebInstrumentations } from "@grafana/faro-web-sdk";
@@ -10,6 +10,13 @@ import { TracingInstrumentation } from "@grafana/faro-web-tracing";
 type FaroInstance = ReturnType<typeof initializeFaro>;
 
 let faroInstance: FaroInstance | null = null;
+
+// Tracing 대상 API (내부 API만 - 정적 파일/외부 요청 제외)
+const TRACE_TARGET_URLS = [
+  /api\.staging\.playball\.one/,
+  /api\.playball\.one/,
+  /api\.dev\.goormgb\.space/,
+];
 
 /**
  * Faro 초기화 (클라이언트 전용)
@@ -41,8 +48,10 @@ export function initFaro(): FaroInstance | null {
     instrumentations: [
       // 기본 웹 계측 (console, errors, web vitals 등)
       ...getWebInstrumentations(),
-      // 분산 추적 (traceparent 전파)
-      new TracingInstrumentation(),
+      // 분산 추적 - 내부 API만 추적 (외부/정적 파일 제외)
+      new TracingInstrumentation({
+        propagateTraceHeaderCorsUrls: TRACE_TARGET_URLS,
+      }),
     ],
   });
 

--- a/goorm-gongbang/next.config.ts
+++ b/goorm-gongbang/next.config.ts
@@ -25,7 +25,8 @@ const nextConfig = {
   // 기존 OTel 및 권장 설정 유지
   compress: true,
   poweredByHeader: false,
-  productionBrowserSourceMaps: false,
+  // staging에서만 sourcemap 활성화 (디버깅용)
+  productionBrowserSourceMaps: process.env.NEXT_PUBLIC_ENV === "staging",
 
   // 보안 헤더 유지
   async headers() {

--- a/goorm-gongbang/next.config.ts
+++ b/goorm-gongbang/next.config.ts
@@ -52,6 +52,9 @@ const nextConfig = {
     OTEL_EXPORTER_OTLP_ENDPOINT:
       process.env.OTEL_EXPORTER_OTLP_ENDPOINT ||
       "http://otel-collector:4318/v1/traces",
+    // Grafana Faro (프론트엔드 관측성)
+    NEXT_PUBLIC_FARO_URL: process.env.NEXT_PUBLIC_FARO_URL || "",
+    NEXT_PUBLIC_RELEASE: process.env.NEXT_PUBLIC_RELEASE || "1.0.0",
   },
 };
 

--- a/goorm-gongbang/package.json
+++ b/goorm-gongbang/package.json
@@ -11,6 +11,8 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@grafana/faro-web-sdk": "^1.13.1",
+    "@grafana/faro-web-tracing": "^1.13.1",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.211.0",
     "@opentelemetry/auto-instrumentations-node": "^0.69.0",


### PR DESCRIPTION
🔧 작업 내용

  - Grafana Faro SDK 보완 (클라우드팀 요청 반영)
  - 민감정보 수집 방지 로직 추가
  - 이벤트 트래킹 훅 모듈화
  - Tracing 범위를 내부 API로 제한

  🧩 구현 상세

  민감정보 필터링
  - 화이트리스트 기반 필드 필터링 (ALLOWED_FIELDS)
  - 블랙리스트 패턴 2차 방어 (DENIED_PATTERNS)

  트래킹 훅 (hooks/useAnalytics.ts)
  - useAuthStore 통해 로그인 상태 주입 (localStorage 직접 접근 제거)
  - 도메인별 훅: useLoginTracking, usePaymentTracking, useSeatTracking 등

  Tracing 범위 제한
  - api.staging.playball.one, api.playball.one 만 추적
  - 외부 요청/정적 파일 제외 → Tempo 노이즈 감소

  📌 관련 Jira Issue

  - GRGB-XX

  🧪 테스트 방법

  1. 브라우저 DevTools > Network > /faro 요청 확인
  2. Request Payload에 민감정보(token, email 등) 없는지 확인
  3. Grafana > Loki > {service_name="goormgb-frontend"} 쿼리

  ❗ 참고 사항

  - Vercel 환경변수 설정 완료 (NEXT_PUBLIC_FARO_URL, NEXT_PUBLIC_ENV, NEXT_PUBLIC_RELEASE)
   - 후속 작업: 주요 플로우에 트래킹 훅 연결 (match_click, payment_success 등)
  + match_click 이벤트 연결 (홈페이지 매치 카드 클릭)
