### PR TITLE
feat(GBGB-289-fe-pay-api): PAY API 연동 완료

### DIFF
--- a/goorm-gongbang/app/(protected)/pay/[matchId]/bank-account/page.tsx
+++ b/goorm-gongbang/app/(protected)/pay/[matchId]/bank-account/page.tsx
@@ -4,13 +4,86 @@ import Link from "next/link";
 import { Check, ExternalLink } from "lucide-react";
 import { PrimaryButton, SecondaryButton } from "@/components/common/Button";
 import { RefundPolicyModal } from "@/components/common/RefundPolicyModal";
-
-const stadiumAddress = "서울 송파구 올림픽로 19-2 서울종합운동장";
+import { useSearchParams } from "next/navigation";
 
 
 export default function BankAccountPage() {
     const [isRefundModalOpen, setIsRefundModalOpen] = useState(false);
+    const searchParams = useSearchParams();
+
+    const stadiumName = searchParams.get("stadiumName") ?? "";
+    const stadiumAddress = searchParams.get("stadiumAddress") ?? "";
+    const matchAt = searchParams.get("matchAt") ?? "";
+    const totalAmount = Number(searchParams.get("totalAmount") ?? "0");
+    const fee = Number(searchParams.get("fee") ?? "0");
+
+    const seatRows = JSON.parse(searchParams.get("seatLabels") ?? "[]") as Array<{
+        label: string;
+        price: number;
+    }>;
+
+
     const naverMapUrl = `https://map.naver.com/p/search/${encodeURIComponent(stadiumAddress)}`;
+
+    const formatMatchAt = (value?: string) => {
+        if (!value) return "-";
+        const date = new Date(value);
+        return new Intl.DateTimeFormat("ko-KR", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+            weekday: "short",
+            hour: "2-digit",
+            minute: "2-digit",
+            hour12: false,
+        }).format(date);
+    };
+
+    const formatCancelDeadline = (value?: string) => {
+        if (!value) return "-";
+
+        const matchDate = new Date(value);
+        if (Number.isNaN(matchDate.getTime())) return "-";
+
+        const cancelDeadline = new Date(matchDate);
+        cancelDeadline.setDate(cancelDeadline.getDate() - 1);
+        cancelDeadline.setHours(23, 59, 0, 0);
+
+        return new Intl.DateTimeFormat("ko-KR", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+            weekday: "short",
+            hour: "2-digit",
+            minute: "2-digit",
+            hour12: false,
+            timeZone: "Asia/Seoul",
+        }).format(cancelDeadline);
+    };
+
+    const formatDepositDeadline = (value?: string) => {
+        if (!value) return "-";
+
+        const matchDate = new Date(value);
+        if (Number.isNaN(matchDate.getTime())) return "-";
+
+        const cancelDeadline = new Date(matchDate);
+        cancelDeadline.setDate(cancelDeadline.getDate() + 1);
+        cancelDeadline.setHours(23, 59, 0, 0);
+
+        return new Intl.DateTimeFormat("ko-KR", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+            weekday: "short",
+            hour: "2-digit",
+            minute: "2-digit",
+            hour12: false,
+            timeZone: "Asia/Seoul",
+        }).format(cancelDeadline);
+    };
+
+    const won = (n: number) => `${n.toLocaleString("ko-KR")} 원`;
 
     return (
         <div className="min-h-screen bg-[var(--foundation-neutral-980)] px-4 py-8">
@@ -44,7 +117,7 @@ export default function BankAccountPage() {
                                     입금 기한
                                 </div>
                                 <div className="flex-1 text-lg font-semibold leading-6 text-[var(--foundation-neutral-240)]">
-                                    2026년 3월 24일 (화) 23:59
+                                    {formatDepositDeadline(matchAt)}
                                 </div>
                             </div>
 
@@ -81,7 +154,7 @@ export default function BankAccountPage() {
 
                                 <div className="flex-1">
                                     <div className="text-base font-semibold leading-6 text-[var(--foundation-neutral-240)]">
-                                        잠실종합운동장 잠실야구장
+                                        {stadiumName || "-"}
                                     </div>
 
                                     <a
@@ -90,7 +163,7 @@ export default function BankAccountPage() {
                                         rel="noopener noreferrer"
                                         className="mt-0.5 inline-flex items-center gap-1 text-xs leading-4 text-[var(--foundation-neutral-600)]"
                                     >
-                                        <span className="underline">{stadiumAddress}</span>
+                                        <span className="underline">{stadiumAddress || "-"}</span>
                                         <ExternalLink className="h-4 w-4" strokeWidth={1.5} />
                                     </a>
                                 </div>
@@ -101,7 +174,7 @@ export default function BankAccountPage() {
                                     경기 시간
                                 </div>
                                 <div className="flex-1 text-base font-semibold leading-6 text-[var(--foundation-neutral-240)]">
-                                    2026년 3월 29일 (일) 14:00
+                                    {formatMatchAt(matchAt)}
                                 </div>
                             </div>
 
@@ -110,12 +183,14 @@ export default function BankAccountPage() {
                                     선택 좌석
                                 </div>
                                 <div className="flex-1">
-                                    <div className="text-base font-semibold leading-6 text-[var(--foundation-blue-600)]">
-                                        오렌지석 206블럭 3열 13번
-                                    </div>
-                                    <div className="text-base font-semibold leading-6 text-[var(--foundation-blue-600)]">
-                                        오렌지석 206블럭 3열 14번
-                                    </div>
+                                    {seatRows.map((seat) => (
+                                        <div
+                                            key={seat.label}
+                                            className="text-base font-semibold text-[var(--foundation-blue-600)]"
+                                        >
+                                            {seat.label}
+                                        </div>
+                                    ))}
                                 </div>
                             </div>
                         </div>
@@ -133,28 +208,30 @@ export default function BankAccountPage() {
                                         총 결제 금액
                                     </div>
                                     <div className="text-lg font-semibold leading-6 text-[var(--foundation-primary-600)]">
-                                        42,000 원
+                                        {won(totalAmount) || 0}
                                     </div>
                                 </div>
 
                                 <div className="h-px bg-[var(--stroke-interactive-neutral-default)]" />
 
                                 <div className="flex flex-col gap-0.5">
-                                    <div className="flex justify-between">
-                                        <div className="text-sm font-medium leading-5 text-[var(--foundation-neutral-240)]">
-                                            티켓 금액
+                                    {seatRows.map((seat) => (
+                                        <div key={seat.label} className="flex justify-between gap-4">
+                                            <div className="text-sm font-medium text-[var(--foundation-neutral-240)]">
+                                                {seat.label || "-"}
+                                            </div>
+                                            <div className="text-sm font-medium text-[var(--foundation-neutral-240)]">
+                                                1개
+                                            </div>
                                         </div>
-                                        <div className="text-sm font-medium leading-5 text-[var(--foundation-neutral-240)]">
-                                            40,000 원
-                                        </div>
-                                    </div>
+                                    ))}
 
                                     <div className="flex justify-between">
                                         <div className="text-sm font-medium leading-5 text-[var(--foundation-neutral-240)]">
                                             수수료
                                         </div>
                                         <div className="text-sm font-medium leading-5 text-[var(--foundation-neutral-240)]">
-                                            2,000 원
+                                            {fee.toLocaleString() || "0"} 원
                                         </div>
                                     </div>
                                 </div>
@@ -164,7 +241,7 @@ export default function BankAccountPage() {
                                 <div className="flex items-center gap-6">
                                     <div className="w-20 text-sm font-medium text-[var(--foundation-neutral-600)]">취소 기한</div>
                                     <div className="flex-1 text-sm font-medium text-[var(--foundation-neutral-240)]">
-                                        2026년 2월 11일 (수) 23:59
+                                        {formatCancelDeadline(matchAt)}
                                     </div>
                                 </div>
 

--- a/goorm-gongbang/app/(protected)/pay/[matchId]/bank-account/page.tsx
+++ b/goorm-gongbang/app/(protected)/pay/[matchId]/bank-account/page.tsx
@@ -17,10 +17,17 @@ export default function BankAccountPage() {
     const totalAmount = Number(searchParams.get("totalAmount") ?? "0");
     const fee = Number(searchParams.get("fee") ?? "0");
 
-    const seatRows = JSON.parse(searchParams.get("seatLabels") ?? "[]") as Array<{
-        label: string;
-        price: number;
-    }>;
+    const seatRows = (() => {
+        try {
+            return JSON.parse(searchParams.get("seatLabels") ?? "[]") as Array<{
+                label: string;
+                price: number;
+            }>;
+        } catch (e) {
+            console.error("seatLabels 파싱 오류:", e);
+            return [];
+        }
+    })();
 
 
     const naverMapUrl = `https://map.naver.com/p/search/${encodeURIComponent(stadiumAddress)}`;

--- a/goorm-gongbang/app/(protected)/pay/[matchId]/complete/page.tsx
+++ b/goorm-gongbang/app/(protected)/pay/[matchId]/complete/page.tsx
@@ -32,10 +32,17 @@ export default function PaymentCompletePage() {
     const totalAmount = Number(searchParams.get("totalAmount") ?? "0");
     const fee = Number(searchParams.get("fee") ?? "0");
 
-    const seatRows = JSON.parse(searchParams.get("seatLabels") ?? "[]") as Array<{
-        label: string;
-        price: number;
-    }>;
+    const seatRows = (() => {
+        try {
+            return JSON.parse(searchParams.get("seatLabels") ?? "[]") as Array<{
+                label: string;
+                price: number;
+            }>;
+        } catch (e) {
+            console.error("seatLabels 파싱 오류:", e);
+            return [];
+        }
+    })();
 
     const naverMapUrl = `https://map.naver.com/p/search/${encodeURIComponent(stadiumAddress)}`;
 

--- a/goorm-gongbang/app/(protected)/pay/[matchId]/complete/page.tsx
+++ b/goorm-gongbang/app/(protected)/pay/[matchId]/complete/page.tsx
@@ -7,26 +7,75 @@ import { RefundPolicyModal } from "@/components/common/RefundPolicyModal";
 import { PrimaryButton, SecondaryButton } from "@/components/common/Button";
 
 const paymentMethodLabel: Record<string, string> = {
-    toss: "토스페이 사용",
-    kakao: "카카오페이 사용",
-    bank: "무통장 입금",
+    BANK_TRANSFER: "무통장 입금 사용",
+    TOSS_PAY: "토스페이 사용",
+    KAKAO_PAY: "카카오페이 사용",
 };
-
-const seatRows = [
-    { label: "오렌지석 206블럭 3열 13번", price: "20,000 원" },
-    { label: "오렌지석 206블럭 3열 14번", price: "20,000 원" },
-];
-
-const stadiumAddress = "서울 송파구 올림픽로 19-2 서울종합운동장";
-
 
 export default function PaymentCompletePage() {
     const [isRefundModalOpen, setIsRefundModalOpen] = useState(false);
 
     const searchParams = useSearchParams();
-    const method = searchParams.get("method") ?? "toss";
-    const methodLabel = paymentMethodLabel[method] ?? "토스페이 사용";
+
+    const paymentMethod = searchParams.get("paymentMethod") ?? "TOSS_PAY";
+    const paymentStatus = searchParams.get("paymentStatus") ?? "";
+    const paidAt = searchParams.get("paidAt") ?? "";
+
+    const bank = searchParams.get("bank") ?? "";
+    const accountNumber = searchParams.get("accountNumber") ?? "";
+    const holder = searchParams.get("holder") ?? "";
+    const depositDeadline = searchParams.get("depositDeadline") ?? "";
+
+    const stadiumName = searchParams.get("stadiumName") ?? "";
+    const stadiumAddress = searchParams.get("stadiumAddress") ?? "";
+    const matchAt = searchParams.get("matchAt") ?? "";
+    const totalAmount = Number(searchParams.get("totalAmount") ?? "0");
+    const fee = Number(searchParams.get("fee") ?? "0");
+
+    const seatRows = JSON.parse(searchParams.get("seatLabels") ?? "[]") as Array<{
+        label: string;
+        price: number;
+    }>;
+
     const naverMapUrl = `https://map.naver.com/p/search/${encodeURIComponent(stadiumAddress)}`;
+
+    const formatMatchAt = (value?: string) => {
+        if (!value) return "-";
+        const date = new Date(value);
+        return new Intl.DateTimeFormat("ko-KR", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+            weekday: "short",
+            hour: "2-digit",
+            minute: "2-digit",
+            hour12: false,
+        }).format(date);
+    };
+
+    const formatCancelDeadline = (value?: string) => {
+        if (!value) return "-";
+
+        const matchDate = new Date(value);
+        if (Number.isNaN(matchDate.getTime())) return "-";
+
+        const cancelDeadline = new Date(matchDate);
+        cancelDeadline.setDate(cancelDeadline.getDate() - 1);
+        cancelDeadline.setHours(23, 59, 0, 0);
+
+        return new Intl.DateTimeFormat("ko-KR", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+            weekday: "short",
+            hour: "2-digit",
+            minute: "2-digit",
+            hour12: false,
+            timeZone: "Asia/Seoul",
+        }).format(cancelDeadline);
+    };
+
+    const won = (n: number) => `${n.toLocaleString("ko-KR")} 원`;
 
     return (
         <div className="min-h-screen bg-[var(--foundation-neutral-980)] px-4 py-8 md:px-10">
@@ -57,13 +106,13 @@ export default function PaymentCompletePage() {
                             <div className="flex items-center gap-6">
                                 <div className="w-20 text-base font-medium text-[var(--foundation-neutral-600)]">결제 일시</div>
                                 <div className="flex-1 text-base font-medium text-[var(--foundation-neutral-240)]">
-                                    2026년 3월 22일 (일) 14:39
+                                    {formatMatchAt(paidAt)}
                                 </div>
                             </div>
                             <div className="flex items-center gap-6">
                                 <div className="w-20 text-base font-medium text-[var(--foundation-neutral-600)]">결제 수단</div>
                                 <div className="flex-1 text-base font-medium text-[var(--foundation-neutral-240)]">
-                                    {methodLabel}
+                                    {paymentMethodLabel[paymentMethod] ?? "토스페이 사용"}
                                 </div>
                             </div>
                         </div>
@@ -78,15 +127,15 @@ export default function PaymentCompletePage() {
                                 <div className="w-20 text-base font-medium text-[var(--foundation-neutral-600)]">경기 장소</div>
                                 <div className="flex-1">
                                     <div className="text-base font-semibold text-[var(--foundation-neutral-240)]">
-                                        잠실종합운동장 잠실야구장
+                                        {stadiumName || "-"}
                                     </div>
                                     <a
                                         href={naverMapUrl}
                                         target="_blank"
                                         rel="noopener noreferrer"
                                         className="mt-0.5 inline-flex items-center gap-1 text-xs text-[var(--foundation-neutral-600)]"
-                                        >
-                                        <span className="underline">{stadiumAddress}</span>
+                                    >
+                                        <span className="underline">{stadiumAddress || "-"}</span>
                                         <ExternalLink className="h-4 w-4" strokeWidth={1.5} />
                                     </a>
                                 </div>
@@ -95,7 +144,7 @@ export default function PaymentCompletePage() {
                             <div className="flex items-center gap-6">
                                 <div className="w-20 text-base font-medium text-[var(--foundation-neutral-600)]">경기 시간</div>
                                 <div className="flex-1 text-base font-semibold text-[var(--foundation-neutral-240)]">
-                                    2026년 3월 29일 (일) 14:00
+                                    {formatMatchAt(matchAt)}
                                 </div>
                             </div>
 
@@ -126,7 +175,7 @@ export default function PaymentCompletePage() {
                                         총 결제 금액
                                     </div>
                                     <div className="text-lg font-semibold text-[var(--foundation-primary-600)]">
-                                        42,000 원
+                                        {won(totalAmount) || 0}
                                     </div>
                                 </div>
 
@@ -136,17 +185,17 @@ export default function PaymentCompletePage() {
                                     {seatRows.map((seat) => (
                                         <div key={seat.label} className="flex justify-between gap-4">
                                             <div className="text-sm font-medium text-[var(--foundation-neutral-240)]">
-                                                {seat.label}
+                                                {seat.label || "-"}
                                             </div>
                                             <div className="text-sm font-medium text-[var(--foundation-neutral-240)]">
-                                                {seat.price}
+                                                1개
                                             </div>
                                         </div>
                                     ))}
 
                                     <div className="flex justify-between gap-4">
                                         <div className="text-sm font-medium text-[var(--foundation-neutral-240)]">수수료</div>
-                                        <div className="text-sm font-medium text-[var(--foundation-neutral-240)]">2,000 원</div>
+                                        <div className="text-sm font-medium text-[var(--foundation-neutral-240)]">{fee.toLocaleString() || "0"} 원</div>
                                     </div>
                                 </div>
                             </div>
@@ -155,7 +204,7 @@ export default function PaymentCompletePage() {
                                 <div className="flex items-center gap-6">
                                     <div className="w-20 text-sm font-medium text-[var(--foundation-neutral-600)]">취소 기한</div>
                                     <div className="flex-1 text-sm font-medium text-[var(--foundation-neutral-240)]">
-                                        2026년 2월 11일 (수) 23:59
+                                        {formatCancelDeadline(matchAt)}
                                     </div>
                                 </div>
 
@@ -182,9 +231,9 @@ export default function PaymentCompletePage() {
 
                     <div className="flex flex-col gap-2 md:flex-row">
                         <Link className="flex flex-1 h-10" href="/">
-                            <SecondaryButton 
-                                size="md" 
-                                tone="base" 
+                            <SecondaryButton
+                                size="md"
+                                tone="base"
                                 className="flex flex-1 h-10"
                             >
                                 홈으로
@@ -192,7 +241,7 @@ export default function PaymentCompletePage() {
                         </Link>
 
                         <Link className="flex flex-1 h-10" href="/my/tickets">
-                            <PrimaryButton 
+                            <PrimaryButton
                                 size="lg"
                                 tone="base"
                                 className="flex flex-1 h-10"

--- a/goorm-gongbang/app/(protected)/pay/[matchId]/page.tsx
+++ b/goorm-gongbang/app/(protected)/pay/[matchId]/page.tsx
@@ -339,31 +339,12 @@ export default function Page() {
             });
 
             if (paymentResult.paymentMethod === "BANK_TRANSFER") {
-
-                const params = new URLSearchParams({
-
-                    stadiumName: orderSheet?.match.stadium.koName ?? "",
-                    stadiumAddress: orderSheet?.match.stadium.address ?? "",
-                    matchAt: orderSheet?.match.matchAt ?? "",
-                    totalAmount: String(totalAmount),
-                    fee: String(fee),
-                    seatLabels: JSON.stringify(
-                        seats.map((seat) => ({
-                            label: `${seat.sectionName} ${seat.blockCode}블럭 ${seat.rowNo}열 ${seat.seatNo}번`,
-                            price: seat.adultPrice,
-                        }))
-                    ),
-
-                    cashReceiptApplied: cashReceiptResult ? "true" : "false",
-                    cashReceiptPurpose: cashReceiptResult?.purpose ?? "",
-                    cashReceiptNumber: cashReceiptResult?.number ?? "",
-                });
-
                 router.push(`/pay/${matchId}/bank-account?${params.toString()}`);
                 return;
             }
 
             router.push(`/pay/${matchId}/complete?${params.toString()}`);
+
         } catch (e) {
             const error = e as { status?: number };
 

--- a/goorm-gongbang/app/(protected)/pay/[matchId]/page.tsx
+++ b/goorm-gongbang/app/(protected)/pay/[matchId]/page.tsx
@@ -1,78 +1,225 @@
 ﻿"use client";
-import { useState, useEffect } from "react";
+import { toast } from "sonner";
+import { useState, useEffect, useMemo } from "react";
 import { ChevronLeft, Minus, Plus } from "lucide-react";
+import { CDN_CLUBS_BASE_URL } from "@/lib/api/config";
 import { TicketingNavigator } from "@/components/common/TicketingNavigator";
 import { CancelOrderModal } from "@/components/common/CancelOrderModal";
 import { RefundPolicyModal } from "@/components/common/RefundPolicyModal";
-import { useRouter, useParams } from "next/navigation";
+import { useRouter, useParams, useSearchParams } from "next/navigation";
 import { ChevronRight } from "lucide-react";
 import { PaymentTimeoutModal } from "@/components/common/PaymentTimeoutModal";
 import { PrimaryButton, SecondaryButton } from "@/components/common/Button";
+import { PaymentFailureModal } from "@/components/common/PaymentFailureModal";
+import {
+    getOrderSheet,
+    createOrder,
+    processPayment,
+    createCashReceipt
+} from "@/lib/services";
+import type {
+    OrderSheetResponse,
+    CreateOrderRequest,
+} from "@/lib/types";
+
+type TicketKey =
+    | "normal"
+    | "disabled"
+    | "veteran"
+    | "child"
+    | "infant"
+    | "senior"
+    | "youth";
+
+type TicketOption = {
+    key: TicketKey;
+    title: string;
+    description?: string;
+    note?: string;
+    tone?: "default" | "muted";
+};
+
+const INITIAL_TICKET_COUNTS: Record<TicketKey, number> = {
+    normal: 0,
+    disabled: 0,
+    veteran: 0,
+    child: 0,
+    infant: 0,
+    senior: 0,
+    youth: 0,
+};
+
+const TICKET_OPTIONS_BY_SECTION: Array<{ sectionLabel: string; options: TicketOption[]; }> =
+    [
+        {
+            sectionLabel: "기본가",
+            options: [{ key: "normal", title: "일반" }],
+        },
+        {
+            sectionLabel: "기본 할인",
+            options: [
+                { key: "disabled", title: "장애인", description: "1급 ~ 3급" },
+                { key: "veteran", title: "국가유공자", description: "국가유공자 & 병역명문가" },
+                { key: "child", title: "어린이", description: "36개월 ~ 초등학생" },
+                { key: "infant", title: "미취학 아동", description: "36개월 미만, 보호자 좌석 미점유 시" },
+                { key: "senior", title: "경로자", description: "만 65세 이상", note: "외야 그린석 한정", tone: "muted" },
+                { key: "youth", title: "청소년/군경", description: "중·고생, 일반 사병", note: "외야 그린석 한정", tone: "muted" },
+            ],
+        },
+    ];
 
 export default function Page() {
     const router = useRouter();
     const params = useParams<{ matchId: string }>();
+    const searchParams = useSearchParams();
     const matchId = Array.isArray(params.matchId) ? params.matchId[0] : params.matchId;
+    const seatIds = useMemo(() => searchParams.get("seatIds")?.split(",").map((v) => Number(v)).filter((v) => Number.isFinite(v)) ?? [], [searchParams]);
 
-    const [step, setStep] = useState<"ticket" | "payment">("ticket");
+    const [orderSheet, setOrderSheet] = useState<OrderSheetResponse | null>(null);
+    const [isLoadingOrderSheet, setIsLoadingOrderSheet] = useState(true);
 
-    const handleNextStep = () => {
-        if (!canProceed) return;
-        setStep("payment");
+    const match = orderSheet?.match;
+    const seats = orderSheet?.seats ?? [];
+    const summary = orderSheet?.summary;
+    const maxSelectableTicketCount = seats.length;
+    const normalTicketPrice = seats[0]?.adultPrice ?? 0;
+    const [ticketCounts, setTicketCounts] = useState<Record<TicketKey, number>>(INITIAL_TICKET_COUNTS);
+    const ticketPrices = useMemo<Record<TicketKey, number>>( // 티켓 가격 정책
+        () => ({
+            normal: normalTicketPrice,
+            disabled: normalTicketPrice * 0.5,
+            veteran: normalTicketPrice * 0.5,
+            child: normalTicketPrice * 0.5,
+            infant: 0,
+            senior: normalTicketPrice * 0.5,
+            youth: Math.max(normalTicketPrice - 2000, 0),
+        }),
+        [normalTicketPrice]
+    );
+    const selectedTicketCount = useMemo(
+        () => Object.values(ticketCounts).reduce((sum, count) => sum + count, 0),
+        [ticketCounts]
+    );
+    const remainingSelectableTicketCount = Math.max(maxSelectableTicketCount - selectedTicketCount, 0);
+    const ticketAmount = useMemo(
+        () => (Object.keys(ticketCounts) as TicketKey[]).reduce(
+            (sum, key) => sum + ticketCounts[key] * ticketPrices[key],
+            0
+        ),
+        [ticketCounts, ticketPrices]
+    );
+    const fee = summary?.bookingFee ?? 0;
+    const discount = 0;
+    const totalAmount = ticketAmount + fee - discount;
+    const seatLabels = seats.map((seat) => `${seat.sectionName} ${seat.blockCode}블럭 ${seat.rowNo}열 ${seat.seatNo}번`);
+    const matchTitle = match ? `${match.homeClub.koName} vs ${match.awayClub.koName}` : "-";
+
+    const formatMatchAt = (value?: string) => {
+        if (!value) return "-";
+        const date = new Date(value);
+        return new Intl.DateTimeFormat("ko-KR", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+            weekday: "short",
+            hour: "2-digit",
+            minute: "2-digit",
+            hour12: false,
+        }).format(date);
     };
 
-    const handleSubmitPayment = () => {
-        if (!canSubmitPayment || !matchId) return;
+    const formatCancelDeadline = (value?: string) => {
+        if (!value) return "-";
 
-        if (paymentMethod === "toss" || paymentMethod === "kakao") {
-            router.push(`/pay/${matchId}/complete?method=${paymentMethod}`);
-            return;
-        }
+        const matchDate = new Date(value);
+        if (Number.isNaN(matchDate.getTime())) return "-";
 
-        if (paymentMethod === "bank") {
-            router.push(`/pay/${matchId}/bank-account`);
+        const cancelDeadline = new Date(matchDate);
+        cancelDeadline.setDate(cancelDeadline.getDate() - 1);
+        cancelDeadline.setHours(23, 59, 0, 0);
+
+        return new Intl.DateTimeFormat("ko-KR", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+            weekday: "short",
+            hour: "2-digit",
+            minute: "2-digit",
+            hour12: false,
+            timeZone: "Asia/Seoul",
+        }).format(cancelDeadline);
+    };
+
+    const won = (n: number) => `${n.toLocaleString("ko-KR")} 원`;
+    const getTicketPriceLabel = (key: TicketKey) => ticketPrices[key] === 0 ? "무료" : won(ticketPrices[key]);
+    const canIncreaseTicket = !isLoadingOrderSheet && selectedTicketCount < maxSelectableTicketCount;
+    const canDecreaseTicket = (key: TicketKey) => !isLoadingOrderSheet && ticketCounts[key] > 0;
+
+    const changeCount = (key: TicketKey, diff: number) => {
+        setTicketCounts((prev) => {
+            const nextValue = Math.max(0, prev[key] + diff);
+            const currentTotal = Object.values(prev).reduce((sum, count) => sum + count, 0);
+            const nextTotal = currentTotal - prev[key] + nextValue;
+
+            if (nextTotal > maxSelectableTicketCount) { return prev; }
+            return { ...prev, [key]: nextValue };
+        });
+    };
+
+
+    const [step, setStep] = useState<"ticket" | "payment">("ticket");
+    const [createdOrderId, setCreatedOrderId] = useState<number | null>(null);
+    const [isCreatingOrder, setIsCreatingOrder] = useState(false);
+
+    const handleNextStep = async () => {
+        if (!canProceed || !matchId || !orderSheet || isCreatingOrder) return;
+
+        try {
+            setIsCreatingOrder(true);
+
+            const body: CreateOrderRequest = {
+                matchId: Number(matchId),
+                matchSeatIds: seats.map((seat) => seat.matchSeatId),
+                totalPrice: totalAmount,
+                ordererName: name.trim(),
+                ordererEmail: email.trim(),
+                ordererPhone: phoneDigits,
+                ordererBirthDate: birthDigits,
+            };
+
+            console.log("CreateOrderRequest:", body);
+            const createdOrder = await createOrder(body);
+            console.log("CreateOrderResponse:", createdOrder);
+
+            setCreatedOrderId(createdOrder.orderId);
+            setStep("payment");
+        } catch (e) {
+            const error = e as { status?: number };
+
+            if (error.status === 400) {
+                toast.error("요청 값 오류 또는 좌석 선점 만료");
+                return;
+            }
+            if (error.status === 401) {
+                toast.error("인증 필요");
+                return;
+            }
+            if (error.status === 403) {
+                toast.error("선점 소유권 없음");
+                return;
+            }
+            if (error.status === 404) {
+                toast.error("경기 또는 좌석 선점 없음");
+                return;
+            }
+
+            toast.error("주문 생성 중 오류가 발생했습니다.");
+        } finally {
+            setIsCreatingOrder(false);
         }
     };
 
     const [remainingSeconds, setRemainingSeconds] = useState(5 * 60);
-
-    const PRICE = {
-        normal: 20000,   // 일반
-        disabled: 10000, // 장애인
-        veteran: 10000,  // 국가유공자
-        child: 10000,    // 어린이
-        infant: 0,       // 미취학 아동
-        senior: 4500,    // 경로자
-        youth: 7000,     // 청소년/군경
-    } as const;
-
-    type TicketKey = keyof typeof PRICE;
-
-    const [ticketCounts, setTicketCounts] = useState<Record<TicketKey, number>>({
-        normal: 2,
-        disabled: 0,
-        veteran: 0,
-        child: 0,
-        infant: 0,
-        senior: 0,
-        youth: 0,
-    });
-
-    const changeCount = (key: keyof typeof ticketCounts, diff: number) => {
-        setTicketCounts((prev) => ({
-            ...prev,
-            [key]: Math.max(0, prev[key] + diff), // 0 미만 방지
-        }));
-    };
-
-    const ticketAmount = (Object.keys(PRICE) as TicketKey[]).reduce(
-        (sum, key) => sum + PRICE[key] * ticketCounts[key], 0
-    );
-
-    const fee = ticketAmount > 0 ? 2000 : 0;
-    const discount = 0;
-    const totalAmount = ticketAmount + fee - discount;
-    const won = (n: number) => `${n.toLocaleString("ko-KR")} 원`;
 
     const [name, setName] = useState("");
     const [email, setEmail] = useState("");
@@ -82,6 +229,7 @@ export default function Page() {
     const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
     const [isRefundModalOpen, setIsRefundModalOpen] = useState(false);
     const [isPaymentTimeoutModalOpen, setIsPaymentTimeoutModalOpen] = useState(false);
+    const [isPaymentFailureModalOpen, setIsPaymentFailureModalOpen] = useState(false);
 
     const formatPhone = (value: string) => {
         const digits = value.replace(/\D/g, "").slice(0, 11); // 숫자만, 최대 11자리
@@ -98,7 +246,8 @@ export default function Page() {
     const isPhoneValid = /^01[0-9]\d{7,8}$/.test(phoneDigits) && phoneDigits.length === 11;
     const birthDigits = onlyDigits(birth);
     const isBirthValid = /^\d{6}$/.test(birthDigits);
-    const canProceed = isNameValid && isEmailValid && isPhoneValid && isBirthValid;
+    const hasAssignedAllTickets = !isLoadingOrderSheet && maxSelectableTicketCount > 0 && selectedTicketCount === maxSelectableTicketCount;
+    const canProceed = isNameValid && isEmailValid && isPhoneValid && isBirthValid && hasAssignedAllTickets;
 
     const [paymentMethod, setPaymentMethod] = useState<"toss" | "kakao" | "bank">("toss");
     const [cashReceipt, setCashReceipt] = useState<"apply" | "none">("none");
@@ -120,19 +269,140 @@ export default function Page() {
 
     const [receiptPurpose, setReceiptPurpose] = useState<"personal" | "business">("personal");
 
-    const handleBack = () => {
-        if (step === "payment") {
-            setStep("ticket");
-            return;
-        }
-
-        if (!matchId) {
-            router.back();
-            return;
-        }
-
-        router.push(`/recommend/${matchId}`);
+    const toPaymentMethod = (method: "toss" | "kakao" | "bank"): "TOSS_PAY" | "KAKAO_PAY" | "BANK_TRANSFER" => {
+        if (method === "bank") return "BANK_TRANSFER";
+        if (method === "kakao") return "KAKAO_PAY";
+        return "TOSS_PAY";
     };
+
+    const toCashReceiptPurpose = (purpose: "personal" | "business"): "PERSONAL_DEDUCTION" | "BUSINESS_EXPENSE" => {
+        return purpose === "business"
+            ? "BUSINESS_EXPENSE"
+            : "PERSONAL_DEDUCTION";
+    };
+
+
+    const handleSubmitPayment = async () => {
+        if (!canSubmitPayment || !matchId || !createdOrderId || isCreatingOrder) return;
+
+        try {
+            setIsCreatingOrder(true);
+
+            const paymentBody = {
+                paymentMethod: toPaymentMethod(paymentMethod),
+            };
+
+            let cashReceiptResult = null;
+
+            console.log("processPaymentReq:", paymentBody);
+            const paymentResult = await processPayment(createdOrderId, paymentBody);
+            console.log("processPaymentRes:", paymentResult);
+
+            // 현금 영수증
+            if (cashReceipt === "apply") {
+                console.log("cashReceiptResultcreatedOrderIdREQ:", createdOrderId);
+                console.log("cashReceiptResultreceiptPurposeREQ:", toCashReceiptPurpose(receiptPurpose));
+                console.log("cashReceiptResultcashReceiptPhoneREQ:", cashReceiptPhone.replace(/\D/g, ""));
+                cashReceiptResult = await createCashReceipt(createdOrderId, {
+                    purpose: toCashReceiptPurpose(receiptPurpose),
+                    number: cashReceiptPhone.replace(/\D/g, ""),
+                });
+                console.log("cashReceiptResult:", cashReceiptResult);
+            }
+
+            const params = new URLSearchParams({
+                orderId: String(paymentResult.orderId),
+                paymentMethod: paymentResult.paymentMethod,
+                paymentStatus: paymentResult.paymentStatus,
+                paidAt: paymentResult.paidAt ?? "",
+
+                bank: paymentResult.account?.bank ?? "",
+                accountNumber: paymentResult.account?.accountNumber ?? "",
+                holder: paymentResult.account?.holder ?? "",
+                depositDeadline: paymentResult.account?.depositDeadline ?? "",
+
+                stadiumName: orderSheet?.match.stadium.koName ?? "",
+                stadiumAddress: orderSheet?.match.stadium.address ?? "",
+                matchAt: orderSheet?.match.matchAt ?? "",
+                totalAmount: String(totalAmount),
+                fee: String(fee),
+                seatLabels: JSON.stringify(
+                    seats.map((seat) => ({
+                        label: `${seat.sectionName} ${seat.blockCode}블럭 ${seat.rowNo}열 ${seat.seatNo}번`,
+                        price: seat.adultPrice,
+                    }))
+                ),
+
+                cashReceiptApplied: cashReceiptResult ? "true" : "false",
+                cashReceiptPurpose: cashReceiptResult?.purpose ?? "",
+                cashReceiptNumber: cashReceiptResult?.number ?? "",
+            });
+
+            if (paymentResult.paymentMethod === "BANK_TRANSFER") {
+
+                const params = new URLSearchParams({
+
+                    stadiumName: orderSheet?.match.stadium.koName ?? "",
+                    stadiumAddress: orderSheet?.match.stadium.address ?? "",
+                    matchAt: orderSheet?.match.matchAt ?? "",
+                    totalAmount: String(totalAmount),
+                    fee: String(fee),
+                    seatLabels: JSON.stringify(
+                        seats.map((seat) => ({
+                            label: `${seat.sectionName} ${seat.blockCode}블럭 ${seat.rowNo}열 ${seat.seatNo}번`,
+                            price: seat.adultPrice,
+                        }))
+                    ),
+
+                    cashReceiptApplied: cashReceiptResult ? "true" : "false",
+                    cashReceiptPurpose: cashReceiptResult?.purpose ?? "",
+                    cashReceiptNumber: cashReceiptResult?.number ?? "",
+                });
+
+                router.push(`/pay/${matchId}/bank-account?${params.toString()}`);
+                return;
+            }
+
+            router.push(`/pay/${matchId}/complete?${params.toString()}`);
+        } catch (e) {
+            const error = e as { status?: number };
+
+            if (error.status === 400) {
+                toast.error("이미 결제 완료 또는 잘못된 요청");
+                return;
+            }
+            if (error.status === 401) {
+                toast.error("인증 필요");
+                return;
+            }
+            if (error.status === 403) {
+                toast.error("주문 소유권 없음");
+                return;
+            }
+            if (error.status === 404) {
+                toast.error("주문 없음");
+                return;
+            }
+
+            toast.error("결제 처리 중 오류가 발생했습니다.");
+            setIsPaymentFailureModalOpen(true);
+        } finally {
+            setIsCreatingOrder(false);
+        }
+    };
+
+
+    useEffect(() => {
+        if (maxSelectableTicketCount === 0) {
+            setTicketCounts(INITIAL_TICKET_COUNTS);
+            return;
+        }
+
+        setTicketCounts({
+            ...INITIAL_TICKET_COUNTS,
+            normal: maxSelectableTicketCount,
+        });
+    }, [maxSelectableTicketCount]);
 
     useEffect(() => {
         if (isPaymentTimeoutModalOpen) return;
@@ -151,6 +421,53 @@ export default function Page() {
         return () => clearInterval(timer);
     }, [isPaymentTimeoutModalOpen]);
 
+    useEffect(() => {
+        if (!matchId || seatIds.length === 0) {
+            toast.error("좌석 정보가 없습니다.");
+            setIsLoadingOrderSheet(false);
+            return;
+        }
+
+        const fetchOrderSheet = async () => {
+            try {
+                setIsLoadingOrderSheet(true);
+                console.log("getOrderSheetREQ matchId:", matchId);
+                console.log("getOrderSheetREQ seatIds:", seatIds);
+
+                const response = await getOrderSheet(matchId, seatIds);
+
+                console.log("getOrderSheet:", response);
+                setOrderSheet(response);
+            } catch (e) {
+                const error = e as { status?: number };
+
+                if (error.status === 400) {
+                    toast.error("요청 파라미터 오류 또는 선점 만료");
+                    return;
+                }
+                if (error.status === 401) {
+                    toast.error("인증 필요");
+                    return;
+                }
+                if (error.status === 403) {
+                    toast.error("선점 소유권 없음");
+                    return;
+                }
+                if (error.status === 404) {
+                    toast.error("경기 또는 좌석 선점 없음");
+                    return;
+                }
+
+                toast.error("주문서 조회 중 오류가 발생했습니다.");
+            } finally {
+                setIsLoadingOrderSheet(false);
+            }
+        };
+
+        fetchOrderSheet();
+    }, [matchId, seatIds]);
+
+
     return (
         <div className="w-full min-h-screen flex flex-col items-center bg-[var(--foundation-neutral-980)] ">
             <div className="w-full border-b border-[var(--foundation-neutral-880)] bg-white">
@@ -164,7 +481,7 @@ export default function Page() {
                             data-stroke="False"
                             className="cursor-pointer w-10 h-10 rounded-md flex shrink-0 justify-center items-center"
                             aria-label="뒤로가기"
-                            onClick={handleBack}
+                            onClick={() => setIsCancelModalOpen(true)}
                         >
                             <ChevronLeft
                                 className="w-6 h-6 text-[var(--foundation-neutral-160)]"
@@ -174,11 +491,11 @@ export default function Page() {
 
                         <div className="min-w-0 flex flex-wrap items-center gap-x-2 gap-y-1 sm:gap-x-3">
                             <div className="text-[var(--foundation-neutral-240)] text-sm sm:text-base lg:text-lg font-semibold leading-5 sm:leading-6">
-                                2026년 3월 29일 (일) 14:00
+                                {formatMatchAt(match?.matchAt)}
                             </div>
 
                             <div className="text-[var(--foundation-neutral-240)] text-sm sm:text-base lg:text-lg font-semibold leading-5 sm:leading-6">
-                                LG vs KT
+                                {matchTitle}
                             </div>
 
                             <div className="hidden sm:block text-[var(--foundation-neutral-600)] text-sm sm:text-base leading-5">
@@ -193,14 +510,15 @@ export default function Page() {
                                     className="w-7 h-7 sm:w-8 sm:h-8 bg-white inline-flex flex-col justify-center items-center overflow-hidden shrink-0"
                                 >
                                     <img
-                                        className="w-7 h-7 sm:w-8 sm:h-8 rounded-full bg-white object-cover"
-                                        src="https://goormgb-assets.s3.ap-northeast-2.amazonaws.com/static/clubs/hanwha-eagles.png"
-                                        alt="logo"
+                                        className="h-full w-full object-cover"
+                                        src={resolveLogoSrc("lg-twins.png")}
+                                        alt={"홈 구단 로고"}
                                     />
+
                                 </div>
 
                                 <div className="min-w-0 text-[var(--foundation-neutral-400)] text-sm sm:text-base font-medium leading-5 sm:leading-6 truncate">
-                                    잠실종합운동장 잠실야구장
+                                    {match?.stadium.koName ?? "-"}
                                 </div>
                             </div>
                         </div>
@@ -222,139 +540,76 @@ export default function Page() {
                                         <div className="self-stretch justify-center text-[var(--foundation-neutral-240)] text-lg sm:text-xl font-bold font-['Pretendard'] leading-7">티켓 선택</div>
                                     </div>
                                     <div className="self-stretch p-4 bg-[var(--foundation-neutral-white)] rounded-[10px] outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-940)] flex flex-col justify-start items-start gap-4">
-                                        <div className="self-stretch inline-flex justify-start items-start gap-2">
-                                            <div className="w-20 justify-center text-[var(--foundation-neutral-600)] text-sm sm:text-base font-medium font-['Pretendard'] leading-6">기본가</div>
-                                            <div className="flex-1 inline-flex flex-col justify-start items-start gap-2">
-                                                <div className="self-stretch inline-flex justify-start items-start gap-2 sm:gap-10">
-                                                    <div className="flex-1 min-w-0 flex items-start gap-2">
-                                                        <div className="flex-1 min-w-0 break-keep text-[var(--foundation-neutral-240)] text-sm sm:text-base font-semibold font-['Pretendard'] leading-6">일반</div>
-                                                        <div className="shrink-0 min-w-[76px] text-right text-[var(--foundation-neutral-240)] text-sm sm:text-base font-semibold font-['Pretendard'] leading-6">20,000 원</div>
+                                        {TICKET_OPTIONS_BY_SECTION.map((section, sectionIndex) => (
+                                            <div key={section.sectionLabel} className="self-stretch flex flex-col gap-4">
+                                                {sectionIndex > 0 && (
+                                                    <div className="self-stretch h-0 outline outline-1 outline-offset-[-0.50px] outline-[var(--foundation-neutral-900)]" />
+                                                )}
+                                                <div className="self-stretch inline-flex justify-start items-start gap-2">
+                                                    <div className="w-20 justify-center text-[var(--foundation-neutral-600)] text-sm sm:text-base font-medium font-['Pretendard'] leading-6">
+                                                        {section.sectionLabel}
                                                     </div>
-                                                    <div className="rounded-xl flex justify-center items-center gap-2">
-                                                        <div className="flex justify-start items-center gap-0.5">
-                                                            <div onClick={() => changeCount("normal", -1)} data-rounded="Medium" data-size="small" data-status="Default" data-stroke="True" className="cursor-pointer w-7 h-7 px-4 py-2 bg-[var(--foundation-neutral-960)] rounded-md flex justify-center items-center">
-                                                                <Minus className="w-4 h-4 shrink-0 text-[var(--foundation-neutral-440)]" strokeWidth={1.75} />
-                                                            </div>
-                                                            <div className="w-8 h-8 px-4 py-2 rounded-md flex justify-center items-center">
-                                                                <div className="justify-center text-[var(--foundation-neutral-240)] text-base font-medium font-['Pretendard'] leading-6">{ticketCounts.normal}</div>
-                                                            </div>
-                                                            <div onClick={() => changeCount("normal", +1)} data-rounded="Medium" data-size="small" data-status="Default" data-stroke="True" className="cursor-pointer w-7 h-7 px-4 py-2 bg-[var(--foundation-neutral-960)] rounded-md flex justify-center items-center">
-                                                                <Plus className="w-4 h-4 shrink-0 text-[var(--foundation-neutral-440)]" strokeWidth={1.75} />
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div className="self-stretch h-0 outline outline-1 outline-offset-[-0.50px] outline-[var(--foundation-neutral-900)]" />
-                                        <div className="self-stretch inline-flex justify-start items-start gap-2">
-                                            <div className="w-20 justify-center text-[var(--foundation-neutral-600)] text-sm sm:text-base font-medium font-['Pretendard'] leading-6">기본 할인</div>
-                                            <div className="flex-1 inline-flex flex-col justify-start items-start gap-2">
-                                                <div className="self-stretch inline-flex justify-start items-start gap-2 sm:gap-10">
-                                                    <div className="flex-1 min-w-0 flex items-start gap-2">
-                                                        <div className="flex-1 min-w-0 break-keep text-[var(--foundation-neutral-240)] text-sm sm:text-base font-semibold font-['Pretendard'] leading-6"><span>장애인</span><span className="block lg:inline">(1급 ~ 3급)</span></div>
-                                                        <div className="shrink-0 min-w-[76px] text-right text-[var(--foundation-neutral-240)] text-sm sm:text-base font-semibold font-['Pretendard'] leading-6">10,000 원</div>
-                                                    </div>
-                                                    <div className="flex justify-start items-center gap-0.5">
-                                                        <div onClick={() => changeCount("disabled", -1)} data-rounded="Medium" data-size="small" data-status="Default" data-stroke="True" className="cursor-pointer w-7 h-7 px-4 py-2 bg-[var(--foundation-neutral-960)] rounded-md flex justify-center items-center">
-                                                            <Minus className="w-4 h-4 shrink-0 text-[var(--foundation-neutral-440)]" strokeWidth={1.75} />
-                                                        </div>
-                                                        <div className="w-8 h-8 px-4 py-2 rounded-md flex justify-center items-center">
-                                                            <div className="justify-center text-[var(--foundation-neutral-600)] text-base font-medium font-['Pretendard'] leading-6">{ticketCounts.disabled}</div>
-                                                        </div>
-                                                        <div onClick={() => changeCount("disabled", +1)} data-rounded="Medium" data-size="small" data-status="Default" data-stroke="True" className="cursor-pointer w-7 h-7 px-4 py-2 bg-[var(--foundation-neutral-960)] rounded-md flex justify-center items-center">
-                                                            <Plus className="w-4 h-4 shrink-0 text-[var(--foundation-neutral-440)]" strokeWidth={1.75} />
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <div className="self-stretch inline-flex justify-start items-start gap-2 sm:gap-10">
-                                                    <div className="flex-1 min-w-0 flex items-start gap-2">
-                                                        <div className="flex-1 min-w-0 break-keep text-[var(--foundation-neutral-240)] text-sm sm:text-base font-semibold font-['Pretendard'] leading-6"><span>국가유공자</span><span className="block lg:inline">(국가유공자 & 병역명문가)</span></div>
-                                                        <div className="shrink-0 min-w-[76px] text-right text-[var(--foundation-neutral-240)] text-sm sm:text-base font-semibold font-['Pretendard'] leading-6">10,000 원</div>
-                                                    </div>
-                                                    <div className="flex justify-start items-center gap-0.5">
-                                                        <div onClick={() => changeCount("veteran", -1)} data-rounded="Medium" data-size="small" data-status="Default" data-stroke="True" className="cursor-pointer w-7 h-7 px-4 py-2 bg-[var(--foundation-neutral-960)] rounded-md flex justify-center items-center">
-                                                            <Minus className="w-4 h-4 shrink-0 text-[var(--foundation-neutral-440)]" strokeWidth={1.75} />
-                                                        </div>
-                                                        <div className="w-8 h-8 px-4 py-2 rounded-md flex justify-center items-center">
-                                                            <div className="justify-center text-[var(--foundation-neutral-600)] text-base font-medium font-['Pretendard'] leading-6">{ticketCounts.veteran}</div>
-                                                        </div>
-                                                        <div onClick={() => changeCount("veteran", +1)} data-rounded="Medium" data-size="small" data-status="Default" data-stroke="True" className="cursor-pointer w-7 h-7 px-4 py-2 bg-[var(--foundation-neutral-960)] rounded-md flex justify-center items-center">
-                                                            <Plus className="w-4 h-4 shrink-0 text-[var(--foundation-neutral-440)]" strokeWidth={1.75} />
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <div className="self-stretch inline-flex justify-start items-start gap-2 sm:gap-10">
-                                                    <div className="flex-1 min-w-0 flex items-start gap-2">
-                                                        <div className="flex-1 min-w-0 break-keep text-[var(--foundation-neutral-240)] text-sm sm:text-base font-semibold font-['Pretendard'] leading-6"><span>어린이</span><span className="block lg:inline">(36개월 ~ 초등학생)</span></div>
-                                                        <div className="shrink-0 min-w-[76px] text-right text-[var(--foundation-neutral-240)] text-sm sm:text-base font-semibold font-['Pretendard'] leading-6">10,000 원</div>
-                                                    </div>
-                                                    <div className="flex justify-start items-center gap-0.5">
-                                                        <div onClick={() => changeCount("child", -1)} data-rounded="Medium" data-size="small" data-status="Default" data-stroke="True" className="cursor-pointer w-7 h-7 px-4 py-2 bg-[var(--foundation-neutral-960)] rounded-md flex justify-center items-center">
-                                                            <Minus className="w-4 h-4 shrink-0 text-[var(--foundation-neutral-440)]" strokeWidth={1.75} />
-                                                        </div>
-                                                        <div className="w-8 h-8 px-4 py-2 rounded-md flex justify-center items-center">
-                                                            <div className="justify-center text-[var(--foundation-neutral-600)] text-base font-medium font-['Pretendard'] leading-6">{ticketCounts.child}</div>
-                                                        </div>
-                                                        <div onClick={() => changeCount("child", +1)} data-rounded="Medium" data-size="small" data-status="Default" data-stroke="True" className="cursor-pointer w-7 h-7 px-4 py-2 bg-[var(--foundation-neutral-960)] rounded-md flex justify-center items-center">
-                                                            <Plus className="w-4 h-4 shrink-0 text-[var(--foundation-neutral-440)]" strokeWidth={1.75} />
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <div className="self-stretch inline-flex justify-start items-start gap-2 sm:gap-10">
-                                                    <div className="flex-1 min-w-0 flex items-start gap-2">
-                                                        <div className="flex-1 min-w-0 break-keep text-[var(--foundation-neutral-240)] text-sm sm:text-base font-semibold font-['Pretendard'] leading-6"><span>미취학 아동</span><span className="block lg:inline">(36개월 미만, 보호자 좌석 미점유 시)</span></div>
-                                                        <div className="shrink-0 min-w-[76px] text-right text-[var(--foundation-neutral-240)] text-sm sm:text-base font-semibold font-['Pretendard'] leading-6">무료</div>
-                                                    </div>
-                                                    <div className="flex justify-start items-center gap-0.5">
-                                                        <div onClick={() => changeCount("infant", -1)} data-rounded="Medium" data-size="small" data-status="Default" data-stroke="True" className="cursor-pointer w-7 h-7 px-4 py-2 bg-[var(--foundation-neutral-960)] rounded-md flex justify-center items-center">
-                                                            <Minus className="w-4 h-4 shrink-0 text-[var(--foundation-neutral-440)]" strokeWidth={1.75} />
-                                                        </div>
-                                                        <div className="w-8 h-8 px-4 py-2 rounded-md flex justify-center items-center">
-                                                            <div className="justify-center text-[var(--foundation-neutral-600)] text-base font-medium font-['Pretendard'] leading-6">{ticketCounts.infant}</div>
-                                                        </div>
-                                                        <div onClick={() => changeCount("infant", +1)} data-rounded="Medium" data-size="small" data-status="Default" data-stroke="True" className="cursor-pointer w-7 h-7 px-4 py-2 bg-[var(--foundation-neutral-960)] rounded-md flex justify-center items-center">
-                                                            <Plus className="w-4 h-4 shrink-0 text-[var(--foundation-neutral-440)]" strokeWidth={1.75} />
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <div className="self-stretch inline-flex justify-start items-start gap-2 sm:gap-10">
-                                                    <div className="flex-1 min-w-0 flex items-start gap-2">
-                                                        <div className="flex-1 min-w-0 break-keep text-[var(--foundation-neutral-800)] text-sm sm:text-base font-semibold font-['Pretendard'] leading-6"><span>경로자</span><span className="block lg:inline">(만 65세 이상)</span></div>
-                                                        <div className="hidden lg:block shrink-0 text-[var(--foundation-neutral-800)] text-xs font-medium font-['Pretendard'] leading-4">외야 그린석 한정</div>
-                                                        <div className="shrink-0 min-w-[76px] text-right text-[var(--foundation-neutral-800)] text-sm sm:text-base font-semibold font-['Pretendard'] leading-6">4,500 원</div>
-                                                    </div>
-                                                    <div className="flex justify-start items-center gap-0.5">
-                                                        <div onClick={() => changeCount("senior", -1)} data-rounded="Medium" data-size="small" data-status="Default" data-stroke="True" className="cursor-pointer w-7 h-7 px-4 py-2 bg-[var(--foundation-neutral-960)] rounded-md flex justify-center items-center">
-                                                            <Minus className="w-4 h-4 shrink-0 text-[var(--foundation-neutral-440)]" strokeWidth={1.75} />
-                                                        </div>
-                                                        <div className="w-8 h-8 px-4 py-2 rounded-md flex justify-center items-center">
-                                                            <div className="justify-center text-[var(--foundation-neutral-800)] text-base font-medium font-['Pretendard'] leading-6">{ticketCounts.senior}</div>
-                                                        </div>
-                                                        <div onClick={() => changeCount("senior", +1)} data-rounded="Medium" data-size="small" data-status="Default" data-stroke="True" className="cursor-pointer w-7 h-7 px-4 py-2 bg-[var(--foundation-neutral-960)] rounded-md flex justify-center items-center">
-                                                            <Plus className="w-4 h-4 shrink-0 text-[var(--foundation-neutral-440)]" strokeWidth={1.75} />
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <div className="self-stretch inline-flex justify-start items-start gap-2 sm:gap-10">
-                                                    <div className="flex-1 min-w-0 flex items-start gap-2">
-                                                        <div className="flex-1 min-w-0 break-keep text-[var(--foundation-neutral-800)] text-sm sm:text-base font-semibold font-['Pretendard'] leading-6"><span>청소년/군경</span><span className="block lg:inline">(중·고생, 일반 사병)</span></div>
-                                                        <div className="hidden lg:block shrink-0 text-[var(--foundation-neutral-800)] text-xs font-medium font-['Pretendard'] leading-4">외야 그린석 한정</div>
-                                                        <div className="shrink-0 min-w-[76px] text-right text-[var(--foundation-neutral-800)] text-sm sm:text-base font-semibold font-['Pretendard'] leading-6">7,000 원</div>
-                                                    </div>
-                                                    <div className="flex justify-start items-center gap-0.5">
-                                                        <div onClick={() => changeCount("youth", -1)} data-rounded="Medium" data-size="small" data-status="Default" data-stroke="True" className="cursor-pointer w-7 h-7 px-4 py-2 bg-[var(--foundation-neutral-960)] rounded-md flex justify-center items-center">
-                                                            <Minus className="w-4 h-4 shrink-0 text-[var(--foundation-neutral-440)]" strokeWidth={1.75} />
-                                                        </div>
-                                                        <div className="w-8 h-8 px-4 py-2 rounded-md flex justify-center items-center">
-                                                            <div className="justify-center text-[var(--foundation-neutral-800)] text-base font-medium font-['Pretendard'] leading-6">{ticketCounts.youth}</div>
-                                                        </div>
-                                                        <div onClick={() => changeCount("youth", +1)} data-rounded="Medium" data-size="small" data-status="Default" data-stroke="True" className="cursor-pointer w-7 h-7 px-4 py-2 bg-[var(--foundation-neutral-960)] rounded-md flex justify-center items-center">
-                                                            <Plus className="w-4 h-4 shrink-0 text-[var(--foundation-neutral-440)]" strokeWidth={1.75} />
-                                                        </div>
+                                                    <div className="flex-1 inline-flex flex-col justify-start items-start gap-2">
+                                                        {section.options.map((option) => {
+                                                            const isMuted = option.tone === "muted";
+                                                            const textTone = isMuted
+                                                                ? "text-[var(--foundation-neutral-800)]"
+                                                                : "text-[var(--foundation-neutral-240)]";
+                                                            const countTone = isMuted
+                                                                ? "text-[var(--foundation-neutral-800)]"
+                                                                : "text-[var(--foundation-neutral-600)]";
+
+                                                            return (
+                                                                <div key={option.key} className="self-stretch inline-flex justify-start items-start gap-2 sm:gap-10">
+                                                                    <div className="flex-1 min-w-0 flex items-start gap-2">
+                                                                        <div className={`flex-1 min-w-0 break-keep text-sm sm:text-base font-semibold font-['Pretendard'] leading-6 ${textTone}`}>
+                                                                            <span>{option.title}</span>
+                                                                            {option.description && (
+                                                                                <span className="block lg:inline">({option.description})</span>
+                                                                            )}
+                                                                        </div>
+                                                                        {option.note && (
+                                                                            <div className={`hidden lg:block shrink-0 text-xs font-medium font-['Pretendard'] leading-4 ${textTone}`}>
+                                                                                {option.note}
+                                                                            </div>
+                                                                        )}
+                                                                        <div className={`shrink-0 min-w-[76px] text-right text-sm sm:text-base font-semibold font-['Pretendard'] leading-6 ${textTone}`}>
+                                                                            {getTicketPriceLabel(option.key)}
+                                                                        </div>
+                                                                    </div>
+                                                                    <div className="flex justify-start items-center gap-0.5">
+                                                                        <button
+                                                                            type="button"
+                                                                            onClick={() => changeCount(option.key, -1)}
+                                                                            disabled={!canDecreaseTicket(option.key)}
+                                                                            className="cursor-pointer w-7 h-7 px-4 py-2 bg-[var(--foundation-neutral-960)] rounded-md flex justify-center items-center disabled:opacity-40 disabled:cursor-not-allowed"
+                                                                        >
+                                                                            <Minus className="w-4 h-4 shrink-0 text-[var(--foundation-neutral-440)]" strokeWidth={1.75} />
+                                                                        </button>
+                                                                        <div className="w-8 h-8 px-4 py-2 rounded-md flex justify-center items-center">
+                                                                            <div className={`justify-center text-base font-medium font-['Pretendard'] leading-6 ${countTone}`}>
+                                                                                {ticketCounts[option.key]}
+                                                                            </div>
+                                                                        </div>
+                                                                        <button
+                                                                            type="button"
+                                                                            onClick={() => changeCount(option.key, +1)}
+                                                                            disabled={!canIncreaseTicket}
+                                                                            className="cursor-pointer w-7 h-7 px-4 py-2 bg-[var(--foundation-neutral-960)] rounded-md flex justify-center items-center disabled:opacity-40 disabled:cursor-not-allowed"
+                                                                        >
+                                                                            <Plus className="w-4 h-4 shrink-0 text-[var(--foundation-neutral-440)]" strokeWidth={1.75} />
+                                                                        </button>
+                                                                    </div>
+                                                                </div>
+                                                            );
+                                                        })}
                                                     </div>
                                                 </div>
                                             </div>
+                                        ))}
+                                        <div className="self-stretch text-right text-sm font-medium font-['Pretendard'] leading-5 text-[var(--foundation-neutral-600)]">
+                                            {maxSelectableTicketCount}좌석 중 {selectedTicketCount}좌석 선택
+                                            {remainingSelectableTicketCount > 0 && ` · ${remainingSelectableTicketCount}좌석 남음`}
                                         </div>
                                     </div>
                                 </div>
@@ -748,7 +1003,7 @@ export default function Page() {
                                                                     setIsCashReceiptEditing(false);
                                                                 }}
                                                                 className="flex-1 min-w-20"
-                                                                >
+                                                            >
                                                                 확인
                                                             </PrimaryButton>
                                                         </div>
@@ -925,17 +1180,23 @@ export default function Page() {
                                     <div className="self-stretch flex flex-col justify-start items-start gap-2">
                                         <div className="self-stretch inline-flex justify-center items-start gap-2">
                                             <div className="justify-center text-[var(--foundation-neutral-600)] text-sm font-medium font-['Pretendard'] leading-5">경기 장소</div>
-                                            <div className="flex-1 text-right justify-center text-[var(--foundation-neutral-240)] text-sm font-medium font-['Pretendard'] leading-5">서울 송파구 올림픽로 19-2 서울종합운동장</div>
+                                            <div className="flex-1 text-right justify-center text-[var(--foundation-neutral-240)] text-sm font-medium font-['Pretendard'] leading-5">{match?.stadium.address ?? "-"}</div>
                                         </div>
                                         <div className="self-stretch inline-flex justify-center items-center gap-2">
                                             <div className="justify-center text-[var(--foundation-neutral-600)] text-sm font-medium font-['Pretendard'] leading-5">경기 시간</div>
-                                            <div className="flex-1 text-right justify-center text-[var(--foundation-neutral-240)] text-sm font-medium font-['Pretendard'] leading-5">2026년 3월 29일 (일) 14:00 </div>
+                                            <div className="flex-1 text-right justify-center text-[var(--foundation-neutral-240)] text-sm font-medium font-['Pretendard'] leading-5">{formatMatchAt(match?.matchAt)}</div>
                                         </div>
                                         <div className="self-stretch inline-flex justify-start items-start gap-2">
                                             <div className="justify-center text-[var(--foundation-neutral-600)] text-sm font-medium font-['Pretendard'] leading-5">선택 좌석</div>
                                             <div className="flex-1 inline-flex flex-col justify-center items-start gap-0.5">
-                                                <div className="self-stretch text-right justify-center text-[var(--foundation-blue-600)] text-sm font-medium font-['Pretendard'] leading-5">오렌지석 206블럭 3열 13번</div>
-                                                <div className="self-stretch text-right justify-center text-[var(--foundation-blue-600)] text-sm font-medium font-['Pretendard'] leading-5">오렌지석 206블럭 3열 14번</div>
+                                                {seatLabels.map((label) => (
+                                                    <div
+                                                        key={label}
+                                                        className="self-stretch text-right justify-center text-[var(--foundation-blue-600)] text-sm font-medium font-['Pretendard'] leading-5"
+                                                    >
+                                                        {label}
+                                                    </div>
+                                                ))}
                                             </div>
                                         </div>
                                     </div>
@@ -966,7 +1227,7 @@ export default function Page() {
                                 <div className="self-stretch flex flex-col justify-start items-start gap-2">
                                     <div className="self-stretch inline-flex justify-start items-center gap-2">
                                         <div className="w-20 justify-center text-[var(--foundation-neutral-600)] text-sm font-medium font-['Pretendard'] leading-5">취소 기한</div>
-                                        <div className="flex-1 justify-center text-[var(--foundation-neutral-240)] text-sm font-medium font-['Pretendard'] leading-5">2026년 2월 11일 (수) 23:59</div>
+                                        <div className="flex-1 justify-center text-[var(--foundation-neutral-240)] text-sm font-medium font-['Pretendard'] leading-5">{formatCancelDeadline(match?.matchAt)}</div>
                                     </div>
                                     <div className="self-stretch inline-flex justify-start items-center gap-2">
                                         <div className="w-20 justify-center text-[var(--foundation-neutral-600)] text-sm font-medium font-['Pretendard'] leading-5">취소 수수료</div>
@@ -1023,6 +1284,11 @@ export default function Page() {
                                     >
                                         다음 단계
                                     </PrimaryButton>
+
+                                    <PaymentFailureModal
+                                        open={isPaymentFailureModalOpen}
+                                        onClose={() => setIsPaymentFailureModalOpen(false)}
+                                    />
                                 </div>
                             </div>
                         </div>
@@ -1031,4 +1297,10 @@ export default function Page() {
             </div>
         </div>
     );
+}
+
+function resolveLogoSrc(input: string) {
+    if (/^https?:\/\//i.test(input)) return input;
+    if (!CDN_CLUBS_BASE_URL) return input;
+    return new URL(input.replace(/^\//, ""), CDN_CLUBS_BASE_URL).toString();
 }

--- a/goorm-gongbang/app/(protected)/recommend/[matchId]/page.tsx
+++ b/goorm-gongbang/app/(protected)/recommend/[matchId]/page.tsx
@@ -32,6 +32,7 @@ import type {
   SeatGroupsEntryResponse,
   SectionBlock,
   SectionBlockSeat,
+  SeatAssignmentResponse,
 } from "@/lib/types";
 
 type SeatListItem = {
@@ -95,52 +96,6 @@ const toSeatSections = (seatGroupsEntry: SeatGroupsEntryResponse): SeatSection[]
     })),
   }));
 };
-
-function formatMatchAt(matchAt?: string) {
-  if (!matchAt) return "";
-
-  return new Intl.DateTimeFormat("ko-KR", {
-    timeZone: "Asia/Seoul",
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    weekday: "short",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  }).format(new Date(matchAt));
-}
-
-function resolveLogoSrc(input: string) {
-  if (/^https?:\/\//i.test(input)) return input;
-  if (!CDN_CLUBS_BASE_URL) return input;
-  return new URL(input.replace(/^\//, ""), CDN_CLUBS_BASE_URL).toString();
-}
-
-function findSeatDetail(
-  blocks: SectionBlock[],
-  seatId: number,
-  sectionName: string,
-): SelectedSeatDetail | null {
-  for (const block of blocks) {
-    for (const row of block.rows) {
-      const seat = row.seats.find((item) => item.seatId === seatId);
-      if (seat) {
-        return {
-          seatId: seat.seatId,
-          seatNo: seat.seatNo,
-          rowNo: row.rowNo,
-          blockId: block.blockId,
-          blockCode: block.blockCode,
-          blockDisplayName: block.displayName,
-          sectionName,
-        };
-      }
-    }
-  }
-
-  return null;
-}
 
 export default function Page() {
   const router = useRouter();
@@ -376,8 +331,15 @@ export default function Page() {
 
     try {
       setAssigning(true);
-      await assignRecommendedSeats(matchId, selectedRecommendId);
-      router.push(`/pay/${matchId}`);
+      const response = await assignRecommendedSeats(matchId, selectedRecommendId);
+      console.log("SeatAssignmentResponse:", response);
+
+      const params = new URLSearchParams({
+        matchId: String(response.matchId),
+        seatIds: response.assignedSeats.map((seat) => seat.matchSeatId).join(","),
+      });
+
+      router.push(`/pay/${matchId}?${params.toString()}`);
     } catch (e) {
       const error = e as { status?: number };
 
@@ -421,14 +383,18 @@ export default function Page() {
     try {
       setAssigning(true);
 
-      console.log("createSeatHoldREQ: ", selectedSeatIds);
-      const response = await createSeatHold(matchId, {
-        seatIds: selectedSeatIds,
-      });
+      console.log("createSeatHold-matchId-REQ: ", matchId);
+      console.log("createSeatHold-selectedSeatIds-REQ: ", selectedSeatIds);
+      const response = await createSeatHold(matchId, { seatIds: selectedSeatIds });
 
       console.log("createSeatHold:", response);
 
-      router.push(`/pay/${matchId}`);
+      const params = new URLSearchParams({
+        matchId: String(response.matchId),
+        seatIds: response.matchSeatIds.join(","),
+      });
+
+      router.push(`/pay/${matchId}?${params.toString()}`);
     } catch (e) {
       const error = e as { status?: number };
 
@@ -570,6 +536,7 @@ export default function Page() {
         if (e instanceof ApiError) {
           if (e.status === 410) {
             handleQueueEnd("좌석 진입 가능 시간이 만료되었습니다.");
+            router.push(`/matches/${matchId}`);
             return;
           }
           if (e.status === 404) {
@@ -623,8 +590,8 @@ export default function Page() {
                   {homeLogoImg ? (
                     <img
                       className="h-full w-full object-cover"
-                      src={resolveLogoSrc(homeLogoImg)}
-                      alt={homeClub?.koName ?? "홈 구단 로고"}
+                      src={resolveLogoSrc("lg-twins.png")}
+                      alt={"홈 구단 로고"}
                     />
                   ) : null}
                 </div>
@@ -930,4 +897,50 @@ function RecommendSeatSkeleton() {
       ))}
     </div>
   );
+}
+
+function formatMatchAt(matchAt?: string) {
+  if (!matchAt) return "";
+
+  return new Intl.DateTimeFormat("ko-KR", {
+    timeZone: "Asia/Seoul",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    weekday: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(new Date(matchAt));
+}
+
+function resolveLogoSrc(input: string) {
+  if (/^https?:\/\//i.test(input)) return input;
+  if (!CDN_CLUBS_BASE_URL) return input;
+  return new URL(input.replace(/^\//, ""), CDN_CLUBS_BASE_URL).toString();
+}
+
+function findSeatDetail(
+  blocks: SectionBlock[],
+  seatId: number,
+  sectionName: string,
+): SelectedSeatDetail | null {
+  for (const block of blocks) {
+    for (const row of block.rows) {
+      const seat = row.seats.find((item) => item.seatId === seatId);
+      if (seat) {
+        return {
+          seatId: seat.seatId,
+          seatNo: seat.seatNo,
+          rowNo: row.rowNo,
+          blockId: block.blockId,
+          blockCode: block.blockCode,
+          blockDisplayName: block.displayName,
+          sectionName,
+        };
+      }
+    }
+  }
+
+  return null;
 }

--- a/goorm-gongbang/components/common/PaymentFailureModal.tsx
+++ b/goorm-gongbang/components/common/PaymentFailureModal.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { AlertCircle } from "lucide-react";
+
+type PaymentFailureModalProps = {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  description?: string;
+};
+
+const DEFAULT_TITLE = "결제를 완료하지 못했어요";
+const DEFAULT_DESCRIPTION =
+  "선택하신 결제 수단으로 결제가 진행되지 않았어요.\n다른 결제 수단을 선택해 다시 시도해 주세요.";
+
+export function PaymentFailureModal({
+  open,
+  onClose,
+  title = DEFAULT_TITLE,
+  description = DEFAULT_DESCRIPTION,
+}: PaymentFailureModalProps) {
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 px-4 pt-10"
+      onClick={onClose}
+    >
+      <div
+        data-button="off"
+        data-icon="on"
+        className="w-full max-w-md rounded-2xl bg-gradient-to-b from-[var(--foundation-red-50)] to-[var(--foundation-neutral-white)] shadow-[0px_1px_3px_0px_rgba(0,0,0,0.05)] outline outline-1 outline-offset-[-1px] outline-[var(--foundation-red-400)]"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="payment-failure-modal-title"
+      >
+        <div className="flex flex-col gap-4 p-8">
+          <div className="flex flex-col gap-6">
+            <div className="inline-flex items-center gap-2">
+              <AlertCircle
+                className="h-4 w-4 text-[var(--foundation-red-500)]"
+                strokeWidth={2}
+              />
+              <div
+                id="payment-failure-modal-title"
+                className="text-lg font-semibold leading-6 text-[var(--foundation-neutral-240)]"
+              >
+                {title}
+              </div>
+            </div>
+
+            <div className="text-base font-medium leading-6 whitespace-pre-line text-[var(--foundation-neutral-240)]">
+              {description}
+            </div>
+          </div>
+
+          <button
+            type="button"
+            onClick={onClose}
+            className="cursor-pointer w-fit px-1 text-sm font-medium leading-5 underline text-[var(--foundation-neutral-600)]"
+          >
+            닫기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/goorm-gongbang/lib/services/order-core.service.ts
+++ b/goorm-gongbang/lib/services/order-core.service.ts
@@ -96,7 +96,7 @@ export const saveOnboardingPreferencesBlocks = (body: PreferredBlockUpdateReques
 
 /* 주문서 조회 */
 export const getOrderSheet = (
-  matchId: number,
+  matchId: string | number,
   seatIds: number[],
 ) =>
   auth.get<OrderSheetResponse>(

--- a/goorm-gongbang/lib/services/order-core.service.ts
+++ b/goorm-gongbang/lib/services/order-core.service.ts
@@ -21,6 +21,13 @@ import type {
   ClubMonthMatches,
   OnboardingPreferencesResponse,
   PreferredBlockUpdateRequest,
+  OrderSheetResponse,
+  CreateOrderRequest,
+  CreateOrderResponse,
+  ProcessPaymentRequest,
+  ProcessPaymentResponse,
+  CreateCashReceiptRequest,
+  CreateCashReceiptResponse
 } from "@/lib/types";
 
 // Re-export types for convenience
@@ -86,3 +93,39 @@ export const getOnboardingPreferences = () =>
 /* 선호 구역 수정 */
 export const saveOnboardingPreferencesBlocks = (body: PreferredBlockUpdateRequest) =>
   auth.put(`${API_BASE_URL}/order/onboarding/preferred-blocks`, body);
+
+/* 주문서 조회 */
+export const getOrderSheet = (
+  matchId: number,
+  seatIds: number[],
+) =>
+  auth.get<OrderSheetResponse>(
+    `${API_BASE_URL}/order/mypage/orders/sheet?matchId=${matchId}&seatIds=${seatIds.join(",")}`
+  );
+
+/* 주문 생성 */
+export const createOrder = (body: CreateOrderRequest) =>
+  auth.post<CreateOrderResponse, CreateOrderRequest>(
+    `${API_BASE_URL}/order/mypage/orders`,
+    body,
+  );
+
+/* 결제 처리 */
+export const processPayment = (
+  orderId: number,
+  body: ProcessPaymentRequest,
+) =>
+  auth.post<ProcessPaymentResponse, ProcessPaymentRequest>(
+    `${API_BASE_URL}/order/mypage/orders/${orderId}/payment`,
+    body,
+  );
+
+/* 현금 영수증 신청 */
+export const createCashReceipt = (
+  orderId: number,
+  body: CreateCashReceiptRequest,
+) =>
+  auth.post<CreateCashReceiptResponse, CreateCashReceiptRequest>(
+    `${API_BASE_URL}/order/mypage/orders/${orderId}/cash-receipt`,
+    body,
+  );

--- a/goorm-gongbang/lib/types/order-core.types.ts
+++ b/goorm-gongbang/lib/types/order-core.types.ts
@@ -235,3 +235,103 @@ export interface CalendarMatch {
   saleStatus: SaleStatus;
   isHomeMatch: boolean;
 }
+
+/* 주문서 조회 */
+export type OrderSheetResponse = {
+  match: {
+    matchId: number;
+    matchAt: string;
+    homeClub: { clubId: number; koName: string };
+    awayClub: { clubId: number; koName: string };
+    stadium: { stadiumId: number; koName: string; address: string };
+  };
+  seats: {
+    matchSeatId: number;
+    sectionId: number;
+    sectionName: string;
+    blockId: number;
+    blockCode: string;
+    rowNo: number;
+    seatNo: number;
+    adultPrice: number;
+  }[];
+  summary: {
+    seatCount: number;
+    bookingFee: number;
+  };
+};
+
+/* 주문 생성 */
+export type CreateOrderRequest = {
+  matchId: number;
+  matchSeatIds: number[];
+  totalPrice: number;
+  ordererName: string;
+  ordererEmail: string;
+  ordererPhone: string;
+  ordererBirthDate: string;
+};
+
+export type OrderStatusType =
+  | "PAYMENT_PENDING"
+  | "PAID"
+  | "CANCEL_REQUESTED"
+  | "CANCELLED"
+  | "REFUND_PROCESSING"
+  | "REFUND_COMPLETED";
+
+export type CreateOrderResponse = {
+  orderId: number;
+  status: OrderStatusType;
+  matchId: number;
+  seatCount: number;
+  totalAmount: number;
+  bookingFee: number;
+  createdAt: string;
+};
+
+/* 결제 처리 */
+export type PaymentMethodType =
+  | "BANK_TRANSFER"
+  | "TOSS_PAY"
+  | "KAKAO_PAY";
+
+export type PaymentStatusType =
+  | "PENDING"
+  | "COMPLETED"
+  | "CANCELLED"
+  | "REFUNDED";
+
+export type ProcessPaymentRequest = {
+  paymentMethod: PaymentMethodType;
+};
+
+export type ProcessPaymentResponse = {
+  orderId: number;
+  orderStatus: OrderStatusType;
+  paymentMethod: PaymentMethodType;
+  paymentStatus: PaymentStatusType;
+  paidAt: string | null;
+  account: {
+    bank: string;
+    accountNumber: string;
+    holder: string;
+    depositDeadline: string;
+  } | null;
+};
+
+/* 현금 영수증 신청 */
+export type CashReceiptPurposeType =
+  | "PERSONAL_DEDUCTION"
+  | "BUSINESS_EXPENSE";
+
+export type CreateCashReceiptRequest = {
+  purpose: CashReceiptPurposeType;
+  number: string;
+};
+
+export type CreateCashReceiptResponse = {
+  orderId: number;
+  purpose: CashReceiptPurposeType;
+  number: string;
+};

--- a/goorm-gongbang/lib/types/seat.types.ts
+++ b/goorm-gongbang/lib/types/seat.types.ts
@@ -170,7 +170,7 @@ export type SeatHoldCreateRequest = {
 
 export type SeatHoldCreateResponse = {
   matchId: number;
-  seatIds: number[];
+  matchSeatIds: number[];
   seatCount: number;
   holdExpiresAt: string;
 };


### PR DESCRIPTION
feat(GBGB-289-fe-pay-api): PAY API 연동 완료

🔧 작업 내용
- 주문 생성, 결제 처리, 현금영수증 신청 API를 결제 플로우에 연동
- `handleNextStep`에서 주문 생성 후 결제 단계로 이동하도록 흐름 분리
- `handleSubmitPayment`에서 결제 처리 API 호출 후 결제 수단별 페이지 이동 처리
- 결제 완료 페이지가 응답/전달 파라미터 기반으로 동작하도록 하드코딩 제거
- 결제 실패 시 노출할 `PaymentFailureModal` 공통 컴포넌트 추가

🧩 구현 상세 (선택)
- `createOrder` 성공 시 `createdOrderId`를 상태로 저장하고 `setStep("payment")` 수행
- `processPayment` 응답값(`paymentMethod`, `paymentStatus`, `paidAt`, 계좌정보 등)을 다음 페이지 파라미터로 전달
- 현금영수증 신청은 결제 처리 이후 조건부로 호출하도록 구조 정리
- 결제 완료 페이지에서 `useSearchParams()`로 결제/경기/좌석/금액 정보 렌더링
- 결제 금액, 날짜/시간 포맷 및 취소 기한 계산 로직 반영

📌 관련 Jira Issue
GBGB-289-fe-pay-api

🧪 테스트 방법(선택)
- 좌석 선택 후 예매자 정보 입력
- `다음 단계` 클릭 시 주문 생성 후 결제 단계 진입 확인
- 결제 수단별 결제 처리 후 완료/무통장 페이지 이동 확인
- 현금영수증 신청 여부에 따른 API 호출 및 결과 확인
- 결제 완료 페이지의 결제 정보/좌석 정보/금액 정보 노출 확인

❗ 참고 사항
- 현금영수증 API는 결제 완료 주문 기준으로만 호출되도록 순서 보장이 필요
- `BANK_TRANSFER`는 입금 대기 상태이므로 즉시 현금영수증 신청 가능 여부를 백엔드 정책과 함께 확인 필요

Fixes: GBGB-289
