### PR TITLE
refactor(telemetry): AI 호출 기본 경로를 환경변수 기반으로 변경

### DIFF
--- a/goorm-gongbang/lib/telemetry/baseUrl.ts
+++ b/goorm-gongbang/lib/telemetry/baseUrl.ts
@@ -1,0 +1,14 @@
+const AI_PATH_SUFFIX = '/ai';
+
+function normalizeBaseUrl(value: string): string {
+  const trimmed = value.trim().replace(/\/+$/, '');
+  if (!trimmed) return AI_PATH_SUFFIX;
+  return trimmed.endsWith(AI_PATH_SUFFIX) ? trimmed : `${trimmed}${AI_PATH_SUFFIX}`;
+}
+
+export function resolveAiBaseUrl(): string {
+  const publicBase =
+    process.env.NEXT_PUBLIC_API_BASE?.trim() || process.env.NEXT_PUBLIC_API_URL?.trim() || '';
+
+  return publicBase ? normalizeBaseUrl(publicBase) : AI_PATH_SUFFIX;
+}

--- a/goorm-gongbang/lib/telemetry/collector.ts
+++ b/goorm-gongbang/lib/telemetry/collector.ts
@@ -10,6 +10,7 @@ import type {
   TicketingStage,
   TelemetryConfig,
 } from './types';
+import { resolveAiBaseUrl } from './baseUrl';
 
 const DEFAULT_MOUSE_SAMPLE_INTERVAL = 50;
 const DEFAULT_MAX_BUFFER_SIZE = 1000;
@@ -27,7 +28,7 @@ export class TelemetryCollector {
       matchId: config.matchId,
       mouseSampleInterval: config.mouseSampleInterval ?? DEFAULT_MOUSE_SAMPLE_INTERVAL,
       maxBufferSize: config.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE,
-      aiBaseUrl: config.aiBaseUrl ?? '/ai',
+      aiBaseUrl: config.aiBaseUrl ?? resolveAiBaseUrl(),
       debug: config.debug ?? false,
     };
   }

--- a/goorm-gongbang/lib/telemetry/index.ts
+++ b/goorm-gongbang/lib/telemetry/index.ts
@@ -30,13 +30,13 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 import { TelemetryCollector } from './collector';
 import { AITelemetryApi, AIApiError } from './api';
 import { registerTelemetryRuntime, unregisterTelemetryRuntime } from './runtime';
+import { resolveAiBaseUrl } from './baseUrl';
 import type {
   TelemetryConfig,
   TicketingStage,
   TelemetryEvent,
   ChallengeStartResponse,
   ChallengeVerifyInput,
-  ChallengeVerifyRequest,
   ChallengeVerifyResponse,
 } from './types';
 
@@ -48,7 +48,7 @@ export interface UseTelemetryOptions {
   /** 경기 ID */
   matchId: number;
 
-  /** AI API base URL (기본: /ai) */
+  /** AI API base URL (기본: NEXT_PUBLIC_API_BASE/NEXT_PUBLIC_API_URL 기반) */
   aiBaseUrl?: string;
 
   /** 디버그 모드 */
@@ -93,7 +93,7 @@ export interface TelemetryInstance {
  * 사용자 행동을 수집하고, 필요한 시점에 현재 Stage 기준으로 AI Runtime에 전송
  */
 export function useTelemetry(options: UseTelemetryOptions): TelemetryInstance {
-  const { matchId, aiBaseUrl = '/ai', debug = false, autoStart = true } = options;
+  const { matchId, aiBaseUrl = resolveAiBaseUrl(), debug = false, autoStart = true } = options;
   const [stage, setStageState] = useState<TicketingStage>('QUEUE_ENTER_PRECLICK');
   const previousStageRef = useRef<TicketingStage>('QUEUE_ENTER_PRECLICK');
 


### PR DESCRIPTION
### 🔧 작업 내용
- AI 텔레메트리 기본 호출 경로를 상대경로 /ai 고정값 대신 환경변수 기반으로 계산하도록 변경했습니다.
- NEXT_PUBLIC_API_BASE 또는 NEXT_PUBLIC_API_URL이 설정되어 있으면 해당 값을 기준으로 AI base URL을 구성하고, 없을 때만 /ai로 fallback 하도록 정리했습니다.
- dev 환경에서 dev.goormgb.space/ai/*로 요청이 나가던 문제를 줄이고, api.goormgb.space/ai/* direct call 구조를 사용할 수 있도록 기반을 맞췄습니다.
- 실제 도메인 값은 코드에 하드코딩하지 않고 배포 환경변수로만 주입되도록 유지했습니다.
### 🧩 구현 상세 (선택)
- lib/telemetry/baseUrl.ts를 추가해 AI base URL 계산 로직을 한 곳으로 모았습니다.
- useTelemetry와 TelemetryCollector에서 동일한 resolver를 사용하도록 바꿔 기본값 불일치를 막았습니다.
- base URL 끝에 /ai가 이미 포함된 경우와 아닌 경우를 모두 처리하도록 정규화 로직을 넣었습니다.

❗ 참고 사항
- 이 PR은 프론트의 AI 호출 기본 경로 계산 방식만 변경합니다.
- 실제 dev 환경에서 direct call을 사용하려면 AI 서버 배포 환경에 CORS 허용 설정이 함께 반영되어야 합니다.
- 코드에는 실제 서비스 URL을 추가하지 않았고, 배포 환경변수 설정이 전제됩니다.