### PR TITLE
fix(telemetry): restore env-based AI base URL

### DIFF
--- a/goorm-gongbang/lib/telemetry/index.ts
+++ b/goorm-gongbang/lib/telemetry/index.ts
@@ -30,6 +30,7 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 import { TelemetryCollector } from './collector';
 import { AITelemetryApi, AIApiError } from './api';
 import { registerTelemetryRuntime, unregisterTelemetryRuntime } from './runtime';
+import { resolveAiBaseUrl } from './baseUrl';
 import type {
   TelemetryConfig,
   TicketingStage,
@@ -47,7 +48,7 @@ export interface UseTelemetryOptions {
   /** 경기 ID */
   matchId: number;
 
-  /** AI API base URL (기본: /ai) */
+  /** AI API base URL (기본: NEXT_PUBLIC_API_BASE/NEXT_PUBLIC_API_URL 기반) */
   aiBaseUrl?: string;
 
   /** 디버그 모드 */
@@ -92,7 +93,7 @@ export interface TelemetryInstance {
  * 사용자 행동을 수집하고, 필요한 시점에 현재 Stage 기준으로 AI Runtime에 전송
  */
 export function useTelemetry(options: UseTelemetryOptions): TelemetryInstance {
-  const { matchId, aiBaseUrl = '/ai', debug = false, autoStart = true } = options;
+  const { matchId, aiBaseUrl = resolveAiBaseUrl(), debug = false, autoStart = true } = options;
   const [stage, setStageState] = useState<TicketingStage>('QUEUE_ENTER_PRECLICK');
   const previousStageRef = useRef<TicketingStage>('QUEUE_ENTER_PRECLICK');
 


### PR DESCRIPTION
## Summary
- restore the telemetry hook default AI base URL to `resolveAiBaseUrl()`
- use `NEXT_PUBLIC_API_BASE` or `NEXT_PUBLIC_API_URL` again instead of falling back to frontend `/ai`
- recover the behavior introduced in #95 that was overwritten later

## Verification
- verified the isolated file change in a clean worktree based on `origin/dev`
- linted `goorm-gongbang/lib/telemetry/index.ts`

## Context
PR #95 (`refactor(telemetry): AI 호출 기본 경로를 환경변수 기반으로 변경`) added `resolveAiBaseUrl()`, but the default in `lib/telemetry/index.ts` was later reverted to `'/ai'` during subsequent merges. This PR restores only that regression fix.