### PR TITLE
fix(telemetry): restore env-based AI base URL

### DIFF
--- a/goorm-gongbang/lib/telemetry/index.ts
+++ b/goorm-gongbang/lib/telemetry/index.ts
@@ -30,6 +30,7 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 import { TelemetryCollector } from './collector';
 import { AITelemetryApi, AIApiError } from './api';
 import { registerTelemetryRuntime, unregisterTelemetryRuntime } from './runtime';
+import { resolveAiBaseUrl } from './baseUrl';
 import type {
   TelemetryConfig,
   TicketingStage,
@@ -47,7 +48,7 @@ export interface UseTelemetryOptions {
   /** 경기 ID */
   matchId: number;
 
-  /** AI API base URL (기본: /ai) */
+  /** AI API base URL (기본: NEXT_PUBLIC_API_BASE/NEXT_PUBLIC_API_URL 기반) */
   aiBaseUrl?: string;
 
   /** 디버그 모드 */
@@ -92,7 +93,7 @@ export interface TelemetryInstance {
  * 사용자 행동을 수집하고, 필요한 시점에 현재 Stage 기준으로 AI Runtime에 전송
  */
 export function useTelemetry(options: UseTelemetryOptions): TelemetryInstance {
-  const { matchId, aiBaseUrl = '/ai', debug = false, autoStart = true } = options;
+  const { matchId, aiBaseUrl = resolveAiBaseUrl(), debug = false, autoStart = true } = options;
   const [stage, setStageState] = useState<TicketingStage>('QUEUE_ENTER_PRECLICK');
   const previousStageRef = useRef<TicketingStage>('QUEUE_ENTER_PRECLICK');
 

--- a/goorm-gongbang/lib/telemetry/index.ts
+++ b/goorm-gongbang/lib/telemetry/index.ts
@@ -40,6 +40,8 @@ import type {
   ChallengeVerifyResponse,
 } from './types';
 
+const DEFAULT_AI_BASE_URL = resolveAiBaseUrl();
+
 // ============================================================================
 // React Hook
 // ============================================================================
@@ -93,7 +95,7 @@ export interface TelemetryInstance {
  * 사용자 행동을 수집하고, 필요한 시점에 현재 Stage 기준으로 AI Runtime에 전송
  */
 export function useTelemetry(options: UseTelemetryOptions): TelemetryInstance {
-  const { matchId, aiBaseUrl = resolveAiBaseUrl(), debug = false, autoStart = true } = options;
+  const { matchId, aiBaseUrl = DEFAULT_AI_BASE_URL, debug = false, autoStart = true } = options;
   const [stage, setStageState] = useState<TicketingStage>('QUEUE_ENTER_PRECLICK');
   const previousStageRef = useRef<TicketingStage>('QUEUE_ENTER_PRECLICK');
 


### PR DESCRIPTION
### 🔧 작업 내용
- AI telemetry hook의 기본 AI base URL 계산 로직을 복구했습니다.
- `NEXT_PUBLIC_API_BASE` 또는 `NEXT_PUBLIC_API_URL` 기반으로 AI 호출 경로를 구성하도록 다시 맞췄습니다.
- 이후 머지 과정에서 기본값이 `'/ai'`로 회귀된 문제를 수정했습니다.

### 🧩 구현 상세 (선택)
- `goorm-gongbang/lib/telemetry/index.ts`에서 `resolveAiBaseUrl` import를 다시 연결했습니다.
- `useTelemetry`의 `aiBaseUrl` 기본값을 `'/ai'`에서 `resolveAiBaseUrl()`로 변경했습니다.
- `baseUrl.ts`는 이미 살아 있는 상태였고, 실제 기본 호출 경로만 되돌리면 되는 회귀성 이슈라 변경 범위를 한 파일로 최소화했습니다.

### 📌 관련 Jira Issue
- 미기재

### 🧪 테스트 방법(선택)
- `goorm-gongbang/lib/telemetry/index.ts` 변경만 포함된 분리 브랜치에서 확인
- `eslint lib/telemetry/index.ts` 실행
- dev 기준 코드에서 telemetry/precheck 요청이 프론트 상대경로 `/ai/*` 고정이 아니라 환경변수 기반 AI base URL을 타도록 코드 경로 확인

### ❗ 참고 사항
- PR #95에서 반영됐던 변경이 이후 머지 과정에서 `index.ts` 기준으로만 되돌아간 회귀 이슈입니다.
- `baseUrl.ts` 파일 자체는 남아 있었고, 기본값 연결만 끊긴 상태였습니다.
- 변경 범위는 telemetry 기본 base URL 복구만 포함하며, 다른 VQA/telemetry 로직은 건드리지 않았습니다.
