### PR TITLE
Feat/mypage api

### DIFF
--- a/goorm-gongbang/app/(protected)/my/reservations/[id]/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/reservations/[id]/page.tsx
@@ -3,151 +3,86 @@
 import { useRouter } from "next/navigation";
 import { Copy, ChevronLeft } from "lucide-react";
 import { toast } from "sonner";
-import { useState, use } from "react";
+import { useState, useEffect, useRef, use } from "react";
 import { CancelTicketModal } from "@/components/my/CancelTicketModal";
 import { TicketInfo } from "@/components/my/TicketDetailModal";
-import { MOCK_RESERVATIONS, Reservation, RESERVATION_STATUS_MAP } from "../page";
+import { RESERVATION_STATUS_MAP } from "../page";
+import { getTicketDetail } from "@/lib/services";
+import type { TicketDetail } from "@/lib/types";
 
-/* ===========================
-   [API 연동 가이드]
-   1. 데이터 Fetching:
-      - 진입 시 `GET /api/v1/my/reservations/{id}` 형식의 상세 조회 API를 호출하세요.
-      - Next.js 15 환경이므로 상단의 `resolvedParams.id` 값을 파라미터로 넘겨 사용해야 합니다.
-   
-   2. 상태값(status) 분기:
-      - 백엔드 응답의 status 필드가 "PAYMENT_WAITING"(입금 대기) 혹은 "RESERVED"(결제 완료) 등에 따라
-        본문의 UI 컴포넌트(`입금 안내 정보`, `증빙 서류 발급`, `결제 정보` 등)가 조건부 렌더링되게 구성되어 있습니다.
-      - 해당 상수값들을 백엔드 DTO(Enum)에 맞추어 변경해주세요.
+function formatDate(iso: string): string {
+    const d = new Date(iso);
+    const pad = (n: number) => String(n).padStart(2, "0");
+    return `${d.getFullYear()}. ${pad(d.getMonth() + 1)}. ${pad(d.getDate())} (${pad(d.getHours())}:${pad(d.getMinutes())})`;
+}
 
-   3. 주요 연동 포인트:
-      - (1) 입금 대기 상태(`depositInfo` 객체): 계좌, 예금주, 기한일시 바인딩
-      - (2) 결제 완료 상태(`paymentInfo`, `document` 객체): 가격 테이블 및 증빙 자료 바인딩
-      - (3) 하단 [취소하기] 버튼 액션: `CancelTicketModal`로 데이터 전달 및 취소 요청 결과 콜백 처리
-=========================== */
+const CANCEL_STATUSES = [
+    "CANCEL_REQUESTED",
+    "CANCEL_PROCESSING",
+    "CANCELLED",
+    "REFUND_PROCESSING",
+    "CANCEL_COMPLETED",
+    "REFUND_COMPLETED",
+];
+
 export default function ReservationDetailPage({ params }: { params: Promise<{ id: string }> }) {
     const router = useRouter();
     const resolvedParams = use(params);
 
-    /* ===========================
-       [TODO: 실제 API 연동 시나리오]
-       const { data: detail, isLoading } = useQuery(['reservationDetail', resolvedParams.id], () => fetchDetail(resolvedParams.id));
-       if (isLoading) return <Skeleton... />
-    =========================== */
-
-    // MVP: 리스트 페이지의 MOCK에서 데이터를 찾아와 동적 객체를 만들어 줍니다.
-    const reservation = MOCK_RESERVATIONS.find(r => r.id === resolvedParams.id);
-
+    const [detail, setDetail] = useState<TicketDetail | null>(null);
     const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
+    const fetchedRef = useRef(false);
 
-    if (!reservation) {
+    useEffect(() => {
+        if (fetchedRef.current) return;
+        fetchedRef.current = true;
+        getTicketDetail(Number(resolvedParams.id)).then(setDetail);
+    }, [resolvedParams.id]);
+
+    if (!detail) {
         return (
             <div className="flex h-screen items-center justify-center font-bold text-lg text-[#666]">
-                존재하지 않는 예매 내역입니다.
+                불러오는 중...
             </div>
         );
     }
 
-    // 좌석 데이터 파싱 
-    // e.g "오렌지석 206블럭 F열 23번, 24번" -> ["오렌지석 206블럭 F열 23번", "오렌지석 206블럭 F열 24번"]
-    const seatParts = reservation.seat.split(', ');
-    const prefixResult = seatParts[0].split(' ').slice(0, -1).join(' '); // "오렌지석 206블럭 F열"
-    const parsedSeats = seatParts.map((s, idx) => idx === 0 ? s : `${prefixResult} ${s}`);
+    const isCancelled = CANCEL_STATUSES.includes(detail.status);
+    const isPastMatch = new Date(detail.match.matchAt) < new Date();
+    const statusLabel = RESERVATION_STATUS_MAP[detail.status] ?? detail.status;
 
-    // 일시 데이터 파싱 (MVP용) "2026. 03. 28 (14:00)" -> "2026. 03. 28 (14:00)"
-    const totalAmount = parsedSeats.length * 20000 + 2000;
+    const matchDateStr = formatDate(detail.match.matchAt);
+    const matchTitle = `${detail.match.homeClub.koName} vs ${detail.match.awayClub.koName}`;
+    const seatLabels = detail.seats.map(
+        (s) => `${s.sectionName} ${s.blockCode}블럭 ${s.rowNo}열 ${s.seatNo}번`
+    );
 
-    const detail = {
-        id: reservation.id,
-        status: reservation.status,
-        depositInfo: reservation.status === "PAYMENT_WAITING" ? {
-            deadline: "2026년 3월 24일 (화) 23:59",
-            bank: "국민",
-            account: "000-0000-0000-00",
-            holder: "윤정빈"
-        } : undefined,
-        matchInfo: {
-            dateStr: reservation.date,
-            matchTitle: reservation.matchTitle,
-            stadium: "잠실종합운동장 잠실야구장", // 경기 정보에서 넘어온 장소가 "잠실" 정도로만 되어있어 임의 매핑
-            address: "서울 송파구 올림픽로 19-2 서울종합운동장",
-            seats: parsedSeats
-        },
-        paymentInfo: {
-            paymentDate: reservation.status === "PAYMENT_WAITING" ? "-" : "2026년 3월 22일 (일) 14:39",
-            method: reservation.status === "PAYMENT_WAITING" ? "-" : (reservation.id === "12" ? "무통장 입금" : "토스 페이 사용"),
-            totalAmount: totalAmount,
-            seatPrices: parsedSeats.map(s => ({ label: s, price: 20000 })),
-            fee: 2000,
-            cancelDeadline: "2026년 2월 11일 (수) 23:59",
-            cancelFeeRule: "티켓 금액의 0~10%"
-        },
-        document: {
-            cashReceipt: reservation.status === "PAYMENT_WAITING" ? "미발급" : "발급",
-            cashReceiptInfo: reservation.status === "PAYMENT_WAITING" ? "-" : "개인소득공제용",
-            cashReceiptPhone: reservation.status === "PAYMENT_WAITING" ? "-" : "(010-0000-0000)",
-            depositReceiptAmount: reservation.status === "PAYMENT_WAITING" ? 0 : totalAmount
-        },
-        cancelInfo: ["CANCEL_PROCESSING", "REFUND_PROCESSING", "CANCEL_COMPLETED", "REFUND_COMPLETED"].includes(reservation.status) ? {
-            cancelStatus: ["REFUND_PROCESSING", "REFUND_COMPLETED"].includes(reservation.status) ? (reservation.status === "REFUND_COMPLETED" ? "환불 완료" : "환불 처리 중") : `${RESERVATION_STATUS_MAP[reservation.status]}(환불 예정)`,
-            cancelDate: "2026년 3월 25일 (수) 14:39"
-        } : undefined
-    };
-
-    const isCancelled = ["CANCEL_PROCESSING", "REFUND_PROCESSING", "CANCEL_COMPLETED", "REFUND_COMPLETED"].includes(detail.status);
-    const isRefunded = ["REFUND_PROCESSING", "REFUND_COMPLETED"].includes(detail.status);
-    const isProcessing = ["CANCEL_PROCESSING", "REFUND_PROCESSING"].includes(detail.status);
-    const isCompleted = ["CANCEL_COMPLETED", "REFUND_COMPLETED"].includes(detail.status);
-
-    // [TODO] 클립보드 복사 유틸. 추후 범용 훅이나 모듈로 분리할 수 있습니다.
     const handleCopyAddress = () => {
-        navigator.clipboard.writeText(detail.matchInfo.address).then(() => {
+        navigator.clipboard.writeText(detail.match.stadium.address).then(() => {
             toast.success("주소가 복사되었습니다.");
         });
     };
 
-    const handleOpenCancelModal = () => {
-        setIsCancelModalOpen(true);
-    };
-
-    // [API 연동 가이드] 취소 완료 후 처리 콜백
-    // 백엔드 상태가 취소 됨("CANCEL_PROCESSING" 등)으로 갱신된 다음,
-    // toast 알림과 함께 리스트로 돌아가거나(router.back) 상태 변경 API를 리프레시하세요.
     const handleCancelSuccess = () => {
         toast.success("예매가 취소되었습니다.");
         router.back();
     };
 
-    /* ===========================
-       [TODO] 취소 모달용 데이터 재가공
-       - 하단 <CancelTicketModal />로 넘길 때는 모달 뷰 스펙(TicketInfo 타입)에 맞게 
-         응답 string을 분리/파싱해 넘기게 되어있습니다.
-       - 백엔드에 아예 type, zone, block, row, number 등을 개별 필드로 받아온다면 
-         아래와 같이 파싱할 필요 없이 직접 바인딩하세요.
-    =========================== */
-    const seatNumbers = detail.matchInfo.seats.map(s => s.split(' ').slice(2).join(' ')).join(', ');
-
-    // 오늘 이전 날짜 판별 (과거 경기 체크)
-    const matchDateStr = detail.matchInfo.dateStr.split(" (")[0].replace(/\./g, "-");
-    const matchDate = new Date(matchDateStr);
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const isPastMatch = matchDate.getTime() < today.getTime();
-
     const cancelTicketInfo: TicketInfo = {
-        matchTitle: detail.matchInfo.matchTitle,
-        count: detail.matchInfo.seats.length,
-        type: detail.matchInfo.seats[0]?.split(' ')[0] || "",
-        zone: detail.matchInfo.seats[0]?.split(' ')[1] || "",
-        seat: seatNumbers,
-        date: detail.matchInfo.dateStr.split(' (')[0] || "",
-        time: detail.matchInfo.dateStr.match(/\((.*?)\)/)?.[1] || "",
-        location: detail.matchInfo.stadium,
-        dateStr: detail.matchInfo.dateStr
+        matchTitle,
+        count: detail.seats.length,
+        type: detail.seats[0]?.sectionName ?? "",
+        zone: detail.seats[0]?.blockCode ?? "",
+        seat: detail.seats.map((s) => `${s.rowNo}열 ${s.seatNo}번`).join(", "),
+        date: matchDateStr.split(" (")[0],
+        time: matchDateStr.match(/\((.*?)\)/)?.[1] ?? "",
+        location: detail.match.stadium.koName,
+        dateStr: matchDateStr,
     };
 
     return (
         <div className="min-h-screen bg-[#F5F5F5] font-pretendard pb-20">
-            {/* ─── 상단 헤더 (breadcrumb) ─── */}
+            {/* 상단 헤더 */}
             <div className="sticky top-0 z-10 bg-white border-b border-[#F0F0F0]">
                 <div className="max-w-[1200px] mx-auto px-4 h-12 flex items-center justify-end">
                     <nav className="flex items-center gap-1.5 text-[13px] text-[#9E9E9E]">
@@ -160,12 +95,10 @@ export default function ReservationDetailPage({ params }: { params: Promise<{ id
                 </div>
             </div>
 
-            {/* ─── 본문 ─── */}
             <div className="max-w-[1200px] mx-auto px-4 py-12 flex justify-center min-h-[calc(100vh-48px)]">
-
-                {/* 메인 폼 영역 */}
                 <div className="w-full max-w-[800px] flex flex-col gap-10">
 
+                    {/* 제목 */}
                     <div className="flex items-center gap-1 -ml-2">
                         <button
                             type="button"
@@ -175,23 +108,21 @@ export default function ReservationDetailPage({ params }: { params: Promise<{ id
                             <ChevronLeft size={26} className="text-[#1A1A1A]" />
                         </button>
                         <h1 className="text-[22px] font-bold text-[#1A1A1A] mb-[1px]">
-                            {isProcessing ? "취소/환불 처리 상세 내역" : (isRefunded ? "환불 상세 내역" : (isCancelled ? "취소 상세 내역" : "예매 상세 내역"))}
+                            {isCancelled ? "취소/환불 상세 내역" : "예매 상세 내역"}
                         </h1>
                     </div>
 
-                    {/* 취소된 상태 안내 메시지 */}
+                    {/* 취소/환불 상태 안내 배너 */}
                     {isCancelled && (
                         <div className="flex flex-col items-center justify-center -mt-2 mb-2 text-center w-full">
                             <h2 className="text-[20px] font-bold text-[var(--foundation-primary-500)]">
-                                {isProcessing
-                                    ? "본 예매 내역은 취소/환불 처리 중인 예매 내역입니다."
-                                    : (isRefunded ? "본 예매 내역은 환불 완료된 예매 내역입니다." : "본 예매 내역은 취소된 예매 내역입니다.")}
+                                현재 진행 상황: {statusLabel}
                             </h2>
                         </div>
                     )}
 
-                    {/* 입금 대기 상태 안내 메시지 */}
-                    {detail.status === "PAYMENT_WAITING" && (
+                    {/* 입금 대기 안내 */}
+                    {detail.status === "PAYMENT_PENDING" && (
                         <div className="flex flex-col items-center justify-center -mt-2 gap-2 text-center">
                             <h2 className="text-[20px] font-bold text-[var(--foundation-primary-500)]">예약된 티켓 확정을 위해 기한 내 결제를 완료해주세요.</h2>
                             <p className="text-[14px] font-medium text-[#888]">입금 기한 내 입금이 완료되지 않을 시, 예매된 티켓이 취소됩니다.</p>
@@ -199,21 +130,21 @@ export default function ReservationDetailPage({ params }: { params: Promise<{ id
                     )}
 
                     {/* 입금 안내 정보 */}
-                    {detail.status === "PAYMENT_WAITING" && detail.depositInfo && (
+                    {detail.status === "PAYMENT_PENDING" && detail.virtualAccount && (
                         <section className="flex flex-col gap-4">
                             <h2 className="text-[18px] font-bold text-[#1A1A1A]">입금 안내 정보</h2>
                             <div className="bg-white border border-[var(--foundation-primary-500)] rounded-2xl p-6 flex flex-col gap-5">
                                 <div className="grid grid-cols-[100px_1fr] items-center">
                                     <span className="text-[14px] text-[#999] font-medium mt-[1px]">입금 기한</span>
-                                    <span className="text-[15px] font-bold text-[#1A1A1A]">{detail.depositInfo.deadline}</span>
+                                    <span className="text-[15px] font-bold text-[#1A1A1A]">{formatDate(detail.virtualAccount.depositDeadline)}</span>
                                 </div>
                                 <div className="grid grid-cols-[100px_1fr] items-center">
                                     <span className="text-[14px] text-[#999] font-medium mt-[1px]">입금 계좌</span>
-                                    <span className="text-[15px] font-bold text-[#1A1A1A]">{detail.depositInfo.bank} {detail.depositInfo.account}</span>
+                                    <span className="text-[15px] font-bold text-[#1A1A1A]">{detail.virtualAccount.bank} {detail.virtualAccount.accountNumber}</span>
                                 </div>
                                 <div className="grid grid-cols-[100px_1fr] items-center">
                                     <span className="text-[14px] text-[#999] font-medium mt-[1px]">예금주</span>
-                                    <span className="text-[15px] font-bold text-[#1A1A1A]">{detail.depositInfo.holder}</span>
+                                    <span className="text-[15px] font-bold text-[#1A1A1A]">{detail.virtualAccount.holder}</span>
                                 </div>
                             </div>
                         </section>
@@ -224,35 +155,31 @@ export default function ReservationDetailPage({ params }: { params: Promise<{ id
                         <div className="flex items-center gap-3">
                             <h2 className="text-[18px] font-bold text-[#1A1A1A]">경기 정보</h2>
                             <h3 className="text-[18px] font-bold text-[var(--foundation-primary-500)]">
-                                {detail.matchInfo.dateStr} | {detail.matchInfo.matchTitle}
+                                {matchDateStr} | {matchTitle}
                             </h3>
                         </div>
-
                         <div className="bg-white border border-[#E8E8E8] rounded-2xl p-6">
-                            {/* 경기 장소 */}
                             <div className="grid grid-cols-[100px_1fr] items-start pb-5 border-b border-[#F0F0F0]">
                                 <span className="text-[14px] text-[#999] font-medium mt-[1px]">경기 장소</span>
                                 <div className="flex flex-col gap-1">
-                                    <span className="text-[15px] font-medium text-[#1A1A1A]">{detail.matchInfo.stadium}</span>
+                                    <span className="text-[15px] font-medium text-[#1A1A1A]">{detail.match.stadium.koName}</span>
                                     <div className="flex items-center gap-1.5 mt-1">
-                                        <span className="text-[12px] text-[#999]">{detail.matchInfo.address}</span>
+                                        <span className="text-[12px] text-[#999]">{detail.match.stadium.address}</span>
                                         <button onClick={handleCopyAddress} className="text-[#999] hover:text-[#666] transition-colors" aria-label="주소 복사">
                                             <Copy size={13} />
                                         </button>
                                     </div>
                                 </div>
                             </div>
-                            {/* 경기 시간 */}
                             <div className="grid grid-cols-[100px_1fr] items-center py-5 border-b border-[#F0F0F0]">
                                 <span className="text-[14px] text-[#999] font-medium">경기 시간</span>
-                                <span className="text-[15px] font-medium text-[#1A1A1A]">{detail.matchInfo.dateStr}</span>
+                                <span className="text-[15px] font-medium text-[#1A1A1A]">{matchDateStr}</span>
                             </div>
-                            {/* 선택 좌석 */}
                             <div className="grid grid-cols-[100px_1fr] items-start pt-5">
                                 <span className="text-[14px] text-[#999] font-medium mt-[1px]">선택 좌석</span>
                                 <div className="flex flex-col gap-1.5">
-                                    {detail.matchInfo.seats.map((seat, i) => (
-                                        <span key={i} className={`text-[15px] font-bold ${isCancelled ? (isProcessing ? 'text-[#999999]' : 'text-[#3B82F6]') : 'text-[var(--foundation-primary-500)]'}`}>
+                                    {seatLabels.map((seat, i) => (
+                                        <span key={i} className={`text-[15px] font-bold ${isCancelled ? "text-[#A3A3A3]" : "text-[var(--foundation-primary-500)]"}`}>
                                             {seat}
                                         </span>
                                     ))}
@@ -261,200 +188,177 @@ export default function ReservationDetailPage({ params }: { params: Promise<{ id
                         </div>
                     </section>
 
-                    {/* 결제 및 취소 정보 (취소 상태일 때 표시) */}
-                    {isCancelled && detail.cancelInfo && (
+                    {/* 취소/환불 정보 */}
+                    {isCancelled && (
                         <section className="flex flex-col gap-4">
-                            <h2 className="text-[18px] font-bold text-[#1A1A1A]">{isProcessing ? "취소/환불 진행 정보" : "결제 및 취소 정보"}</h2>
-                            <div className="bg-white border border-[#E8E8E8] rounded-2xl p-6">
-                                <div className="grid grid-cols-[100px_1fr] items-center pb-5 border-b border-[#F0F0F0]">
-                                    <span className="text-[14px] text-[#999] font-medium">결제 상태</span>
-                                    <span className={`text-[15px] font-bold ${isProcessing ? 'text-[#999]' : 'text-[#3B82F6]'}`}>{detail.cancelInfo.cancelStatus}</span>
+                            <h2 className="text-[18px] font-bold text-[#1A1A1A]">취소/환불 정보</h2>
+                            <div className="bg-white border border-[#E8E8E8] rounded-2xl p-6 flex flex-col gap-0">
+                                <div className="grid grid-cols-[120px_1fr] items-center pb-5 border-b border-[#F0F0F0]">
+                                    <span className="text-[14px] text-[#999] font-medium">진행 상태</span>
+                                    <span className="text-[15px] font-bold text-[#A3A3A3]">{statusLabel}</span>
                                 </div>
-                                <div className="grid grid-cols-[100px_1fr] items-center py-5 border-b border-[#F0F0F0]">
-                                    <span className="text-[14px] text-[#999] font-medium">결제 일시</span>
-                                    <span className="text-[15px] font-medium text-[#1A1A1A]">{detail.paymentInfo.paymentDate}</span>
-                                </div>
-                                <div className="grid grid-cols-[100px_1fr] items-center py-5 border-b border-[#F0F0F0]">
-                                    <span className="text-[14px] text-[#999] font-medium">결제 수단</span>
-                                    <span className="text-[15px] font-medium text-[#1A1A1A]">{detail.paymentInfo.method}</span>
-                                </div>
-                                <div className="grid grid-cols-[100px_1fr] items-center pt-5">
-                                    <span className="text-[14px] text-[#999] font-medium">{isProcessing ? "취소/환불 접수일시" : "취소 일시"}</span>
-                                    <span className="text-[15px] font-medium text-[#1A1A1A]">{detail.cancelInfo.cancelDate}</span>
-                                </div>
-                            </div>
-                        </section>
-                    )}
-
-                    {/* 환불 예정 금액 (취소 혹은 환불 상태일 때 표시) */}
-                    {isCancelled && detail.cancelInfo && (
-                        <section className="flex flex-col gap-4">
-                            <h2 className="text-[18px] font-bold text-[#1A1A1A]">{isProcessing ? "환불 예정 금액" : "환불 금액"}</h2>
-                            <div className="bg-white border border-[#E8E8E8] rounded-2xl p-6">
-                                {/* 헤더 */}
-                                <div className="flex justify-between items-center pb-4 border-b border-[#E8E8E8]">
-                                    <span className="text-[18px] font-bold text-[#1A1A1A]">{isProcessing ? "예상 환불 금액" : "총 환불 금액"}</span>
-                                    <span className={`text-[20px] font-bold ${isProcessing ? 'text-[var(--foundation-primary-500)]' : 'text-[var(--foundation-red-500)]'}`}>
-                                        {(detail.paymentInfo.totalAmount - detail.paymentInfo.fee).toLocaleString()} 원
-                                    </span>
-                                </div>
-                                {/* 디테일 */}
-                                <div className="flex flex-col gap-2.5 py-5 border-b border-[#E8E8E8]">
-                                    <div className="flex justify-between items-center text-[14px]">
-                                        <span className="text-[#333] font-medium">총 결제 금액</span>
-                                        <span className="text-[#1A1A1A] font-medium">{detail.paymentInfo.totalAmount.toLocaleString()} 원</span>
-                                    </div>
-                                    {detail.paymentInfo.seatPrices.map((seat, idx) => (
-                                        <div key={idx} className="flex justify-between items-center text-[13px] text-[#666] ml-2">
-                                            <span>{seat.label}</span>
-                                            <span>{seat.price.toLocaleString()} 원</span>
+                                {detail.payment && (
+                                    <>
+                                        <div className="grid grid-cols-[120px_1fr] items-center py-5 border-b border-[#F0F0F0]">
+                                            <span className="text-[14px] text-[#999] font-medium">결제 일시</span>
+                                            <span className="text-[15px] font-medium text-[#1A1A1A]">{formatDate(detail.payment.paidAt)}</span>
                                         </div>
-                                    ))}
-                                    <div className="flex justify-between items-center text-[14px]">
-                                        <span className="text-[#333] font-medium">취소 수수료</span>
-                                        <span className="text-[#3B82F6] font-medium">({detail.paymentInfo.fee.toLocaleString()} 원)</span>
-                                    </div>
-                                </div>
-                                {/* 취소 기한/수수료 */}
-                                <div className="grid grid-cols-[100px_1fr] items-center py-5 border-b border-[#F0F0F0]">
-                                    <span className="text-[14px] text-[#999] font-medium">취소 기한</span>
-                                    <span className="text-[14px] text-[#333] font-medium">{detail.paymentInfo.cancelDeadline}</span>
-                                </div>
-                                <div className="grid grid-cols-[100px_1fr_auto] items-center pt-5">
-                                    <span className="text-[14px] text-[#999] font-medium">취소 수수료</span>
-                                    <span className="text-[14px] text-[#333] font-medium">{detail.paymentInfo.cancelFeeRule}</span>
-                                    <button className="px-3 py-1.5 rounded-full border border-[var(--foundation-primary-500)] text-[var(--foundation-primary-500)] text-[12px] font-bold hover:bg-[var(--foundation-primary-50)] transition-colors">자세히보기</button>
-                                </div>
-                                {isRefunded && detail.paymentInfo.method === "무통장 입금" && (
-                                    <div className="grid grid-cols-[100px_1fr] items-center pt-5 mt-5 border-t border-[#F0F0F0]">
-                                        <span className="text-[14px] text-[#999] font-medium">환불 계좌</span>
-                                        <span className="text-[14px] font-medium text-[#1A1A1A]">국민 000-000***-00-00 (윤정빈)</span>
+                                        <div className="grid grid-cols-[120px_1fr] items-center py-5 border-b border-[#F0F0F0]">
+                                            <span className="text-[14px] text-[#999] font-medium">결제 수단</span>
+                                            <span className="text-[15px] font-medium text-[#1A1A1A]">{detail.payment.paymentMethod}</span>
+                                        </div>
+                                    </>
+                                )}
+                                {detail.cancellation && (
+                                    <div className="grid grid-cols-[120px_1fr] items-center pt-5">
+                                        <span className="text-[14px] text-[#999] font-medium">취소 접수 일시</span>
+                                        <span className="text-[15px] font-medium text-[#1A1A1A]">{formatDate(detail.cancellation.cancelledAt)}</span>
                                     </div>
                                 )}
                             </div>
                         </section>
                     )}
 
-                    {/* 결제 정보 (결제 완료 상태일 때만 표시, 취소 아닐 때) */}
-                    {detail.status === "RESERVED" && !isCancelled && (
+                    {/* 환불 금액 */}
+                    {isCancelled && (detail.cancellation || detail.payment) && (
+                        <section className="flex flex-col gap-4">
+                            <h2 className="text-[18px] font-bold text-[#1A1A1A]">환불 금액</h2>
+                            <div className="bg-white border border-[#E8E8E8] rounded-2xl p-6">
+                                <div className="flex justify-between items-center pb-4 border-b border-[#E8E8E8]">
+                                    <span className="text-[18px] font-bold text-[#1A1A1A]">환불 금액</span>
+                                    <span className="text-[20px] font-bold text-[var(--foundation-red-500)]">
+                                        {detail.cancellation
+                                            ? detail.cancellation.refundedAmount.toLocaleString()
+                                            : (detail.payment?.totalAmount ?? 0).toLocaleString()
+                                        } 원
+                                    </span>
+                                </div>
+                                <div className="flex flex-col gap-2.5 py-5 border-b border-[#E8E8E8]">
+                                    {detail.payment && (
+                                        <div className="flex justify-between items-center text-[14px]">
+                                            <span className="text-[#333] font-medium">총 결제 금액</span>
+                                            <span className="text-[#1A1A1A] font-medium">{detail.payment.totalAmount.toLocaleString()} 원</span>
+                                        </div>
+                                    )}
+                                    {detail.cancellation && (
+                                        <div className="flex justify-between items-center text-[14px]">
+                                            <span className="text-[#333] font-medium">취소 수수료</span>
+                                            <span className="text-[#3B82F6] font-medium">({detail.cancellation.cancellationFee.toLocaleString()} 원)</span>
+                                        </div>
+                                    )}
+                                </div>
+                                {detail.cancellationPolicy && (
+                                    <>
+                                        <div className="grid grid-cols-[120px_1fr] items-center py-5 border-b border-[#F0F0F0]">
+                                            <span className="text-[14px] text-[#999] font-medium">취소 기한</span>
+                                            <span className="text-[14px] text-[#333] font-medium">{formatDate(detail.cancellationPolicy.deadline)}</span>
+                                        </div>
+                                        <div className="grid grid-cols-[120px_1fr] items-center pt-5">
+                                            <span className="text-[14px] text-[#999] font-medium">취소 수수료율</span>
+                                            <span className="text-[14px] text-[#333] font-medium">{detail.cancellationPolicy.feeRate}</span>
+                                        </div>
+                                    </>
+                                )}
+                            </div>
+                        </section>
+                    )}
+
+                    {/* 결제 정보 (일반 예매) */}
+                    {!isCancelled && detail.payment && (
                         <section className="flex flex-col gap-4">
                             <h2 className="text-[18px] font-bold text-[#1A1A1A]">결제 정보</h2>
                             <div className="bg-white border border-[#E8E8E8] rounded-2xl p-6">
                                 <div className="grid grid-cols-[100px_1fr] items-center pb-5 border-b border-[#F0F0F0]">
                                     <span className="text-[14px] text-[#999] font-medium">결제 일시</span>
-                                    <span className="text-[15px] font-medium text-[#1A1A1A]">{detail.paymentInfo.paymentDate}</span>
+                                    <span className="text-[15px] font-medium text-[#1A1A1A]">{formatDate(detail.payment.paidAt)}</span>
                                 </div>
                                 <div className="grid grid-cols-[100px_1fr] items-center pt-5">
                                     <span className="text-[14px] text-[#999] font-medium">결제 수단</span>
-                                    <span className="text-[15px] font-medium text-[#1A1A1A]">{detail.paymentInfo.method}</span>
+                                    <span className="text-[15px] font-medium text-[#1A1A1A]">{detail.payment.paymentMethod}</span>
                                 </div>
                             </div>
                         </section>
                     )}
 
-                    {/* 결제 금액 */}
-                    <section className="flex flex-col gap-4">
-                        <h2 className="text-[18px] font-bold text-[#1A1A1A]">결제 금액</h2>
-                        <div className="bg-white border border-[#E8E8E8] rounded-2xl p-6">
-
-                            {/* 총 결제 금액 Header */}
-                            <div className="flex justify-between items-center pb-4 border-b border-[#E8E8E8]">
-                                <span className="text-[18px] font-bold text-[var(--foundation-primary-500)]">총 결제 금액</span>
-                                <span className="text-[20px] font-bold text-[var(--foundation-primary-500)]">{detail.paymentInfo.totalAmount.toLocaleString()} 원</span>
-                            </div>
-
-                            {/* Breakdown List */}
-                            <div className="flex flex-col gap-2.5 py-5 border-b border-[#E8E8E8]">
-                                {detail.paymentInfo.seatPrices.map((seat, idx) => (
-                                    <div key={idx} className="flex justify-between items-center text-[14px]">
-                                        <span className="text-[#333] font-medium">{seat.label}</span>
-                                        <span className="text-[#1A1A1A] font-medium">{seat.price.toLocaleString()} 원</span>
-                                    </div>
-                                ))}
-                                <div className="flex justify-between items-center text-[14px]">
-                                    <span className="text-[#333] font-medium">수수료</span>
-                                    <span className="text-[#1A1A1A] font-medium">{detail.paymentInfo.fee.toLocaleString()} 원</span>
+                    {/* 결제 금액 (일반 예매) */}
+                    {!isCancelled && detail.payment && (
+                        <section className="flex flex-col gap-4">
+                            <h2 className="text-[18px] font-bold text-[#1A1A1A]">결제 금액</h2>
+                            <div className="bg-white border border-[#E8E8E8] rounded-2xl p-6">
+                                <div className="flex justify-between items-center pb-4 border-b border-[#E8E8E8]">
+                                    <span className="text-[18px] font-bold text-[var(--foundation-primary-500)]">총 결제 금액</span>
+                                    <span className="text-[20px] font-bold text-[var(--foundation-primary-500)]">{detail.payment.totalAmount.toLocaleString()} 원</span>
                                 </div>
+                                <div className="flex flex-col gap-2.5 py-5 border-b border-[#E8E8E8]">
+                                    {seatLabels.map((label, idx) => (
+                                        <div key={idx} className="flex justify-between items-center text-[14px]">
+                                            <span className="text-[#333] font-medium">{label}</span>
+                                            <span className="text-[#1A1A1A] font-medium">{(detail.payment!.totalAmount - detail.payment!.serviceFee).toLocaleString()} 원</span>
+                                        </div>
+                                    ))}
+                                    <div className="flex justify-between items-center text-[14px]">
+                                        <span className="text-[#333] font-medium">수수료</span>
+                                        <span className="text-[#1A1A1A] font-medium">{detail.payment.serviceFee.toLocaleString()} 원</span>
+                                    </div>
+                                </div>
+                                {detail.cancellationPolicy && (
+                                    <>
+                                        <div className="grid grid-cols-[100px_1fr] items-center py-5 border-b border-[#F0F0F0]">
+                                            <span className="text-[14px] text-[#999] font-medium">취소 기한</span>
+                                            <span className="text-[14px] text-[#333] font-medium">{formatDate(detail.cancellationPolicy.deadline)}</span>
+                                        </div>
+                                        <div className="grid grid-cols-[100px_1fr] items-center pt-5">
+                                            <span className="text-[14px] text-[#999] font-medium">취소 수수료</span>
+                                            <span className="text-[14px] text-[#333] font-medium">{detail.cancellationPolicy.feeRate}</span>
+                                        </div>
+                                    </>
+                                )}
                             </div>
+                        </section>
+                    )}
 
-                            {/* Cancellation rules */}
-                            <div className="grid grid-cols-[100px_1fr] items-center py-5 border-b border-[#F0F0F0]">
-                                <span className="text-[14px] text-[#999] font-medium">취소 기한</span>
-                                <span className="text-[14px] text-[#333] font-medium">{detail.paymentInfo.cancelDeadline}</span>
-                            </div>
-                            <div className="grid grid-cols-[100px_1fr_auto] items-center pt-5">
-                                <span className="text-[14px] text-[#999] font-medium">취소 수수료</span>
-                                <span className="text-[14px] text-[#333] font-medium">{detail.paymentInfo.cancelFeeRule}</span>
-                                <button className="px-3 py-1.5 rounded-full border border-[var(--foundation-primary-500)] text-[var(--foundation-primary-500)] text-[12px] font-bold hover:bg-[var(--foundation-primary-50)] transition-colors">자세히보기</button>
-                            </div>
-                        </div>
-                    </section>
-
-                    {/* 증빙 서류 발급 (취소 아닐 때 결제 완료시에만 표시) */}
-                    {detail.status === "RESERVED" && !isCancelled && (
+                    {/* 증빙 서류 발급 */}
+                    {!isCancelled && detail.payment?.cashReceipt && (
                         <section className="flex flex-col gap-4">
                             <h2 className="text-[18px] font-bold text-[#1A1A1A]">증빙 서류 발급</h2>
                             <div className="bg-white border border-[#E8E8E8] rounded-2xl p-6">
                                 <div className="grid grid-cols-[100px_1fr] items-start pb-5 border-b border-[#F0F0F0] gap-y-4">
                                     <span className="text-[14px] text-[#999] font-medium mt-1">현금영수증</span>
                                     <div className="flex flex-col gap-3">
-                                        <span className="text-[15px] font-medium text-[#1A1A1A]">{detail.document.cashReceipt}</span>
+                                        <span className="text-[15px] font-medium text-[#1A1A1A]">발급</span>
                                         <div className="flex justify-between items-center bg-white rounded-[12px] border border-[#E8E8E8] px-5 py-4">
-                                            <span className="text-[14px] text-[#1A1A1A] font-medium">{detail.document.cashReceiptInfo}</span>
-                                            <span className="text-[14px] text-[#666]">{detail.document.cashReceiptPhone}</span>
+                                            <span className="text-[14px] text-[#1A1A1A] font-medium">{detail.payment.cashReceipt.type}</span>
+                                            <span className="text-[14px] text-[#666]">({detail.payment.cashReceipt.number})</span>
                                         </div>
                                     </div>
                                 </div>
                                 <div className="grid grid-cols-[100px_1fr_auto] items-center pt-5">
                                     <span className="text-[14px] text-[#999] font-medium">입금증</span>
-                                    <span className="text-[15px] font-medium text-[#1A1A1A]">총 발행 금액: {detail.document.depositReceiptAmount.toLocaleString()} 원</span>
+                                    <span className="text-[15px] font-medium text-[#1A1A1A]">총 발행 금액: {detail.payment.cashReceipt.totalAmount.toLocaleString()} 원</span>
                                     <button className="px-4 py-2 rounded-full border border-[var(--foundation-primary-500)] text-[var(--foundation-primary-500)] text-[13px] font-bold hover:bg-[var(--foundation-primary-50)] transition-colors">인쇄하기</button>
                                 </div>
                             </div>
                         </section>
                     )}
 
-                    {/* Buttons */}
-                    {!isCancelled && (
-                        <div className="flex items-center gap-3 mt-4">
-                            {detail.status === "RESERVED" ? (
-                                !isPastMatch ? (
-                                    <button
-                                        onClick={handleOpenCancelModal}
-                                        className="flex-1 py-4 rounded-2xl bg-[var(--foundation-red-500)] text-white text-[16px] font-bold hover:bg-[#E63946] transition-colors active:scale-[0.99]"
-                                    >
-                                        취소 진행하기
-                                    </button>
-                                ) : (
-                                    <button
-                                        onClick={() => router.back()}
-                                        className="flex-1 py-4 bg-[#E8E8E8] text-[#1A1A1A] rounded-2xl font-bold text-[16px] hover:bg-[#D4D4D4] transition-colors"
-                                    >
-                                        돌아가기
-                                    </button>
-                                )
-                            ) : (
-                                <button
-                                    onClick={() => router.back()}
-                                    className="flex-1 py-4 bg-[#E8E8E8] text-[#1A1A1A] rounded-2xl font-bold text-[16px] hover:bg-[#D4D4D4] transition-colors"
-                                >
-                                    목록으로 돌아가기
-                                </button>
-                            )}
-                        </div>
-                    )}
-
-                    {/* 취소 완료나 처리 중 상태에서는 하단에 별도 버튼 없음 (MVP 기획 대응) */}
-                    {isCancelled && (
-                        <div className="flex items-center gap-3 mt-4">
+                    {/* 버튼 */}
+                    <div className="flex items-center gap-3 mt-4">
+                        {!isCancelled && detail.actions.canCancel && !isPastMatch ? (
+                            <button
+                                onClick={() => setIsCancelModalOpen(true)}
+                                className="flex-1 py-4 rounded-2xl bg-[var(--foundation-red-500)] text-white text-[16px] font-bold hover:bg-[#E63946] transition-colors active:scale-[0.99]"
+                            >
+                                취소 진행하기
+                            </button>
+                        ) : (
                             <button
                                 onClick={() => router.back()}
                                 className="flex-1 py-4 bg-[#E8E8E8] text-[#1A1A1A] rounded-2xl font-bold text-[16px] hover:bg-[#D4D4D4] transition-colors"
                             >
                                 목록으로 돌아가기
                             </button>
-                        </div>
-                    )}
+                        )}
+                    </div>
 
                 </div>
             </div>
@@ -464,11 +368,14 @@ export default function ReservationDetailPage({ params }: { params: Promise<{ id
                 isOpen={isCancelModalOpen}
                 onClose={() => setIsCancelModalOpen(false)}
                 ticketInfo={cancelTicketInfo}
-                paymentAmount={detail.paymentInfo.totalAmount}
-                cancelFee={detail.paymentInfo.fee}
+                ticketId={Number(resolvedParams.id)}
+                paymentAmount={detail.payment?.totalAmount ?? 0}
+                cancelFee={detail.cancellationPolicy
+                    ? Math.round((detail.payment?.totalAmount ?? 0) * parseFloat((detail.cancellationPolicy.feeRate ?? "0").replace("%", "")) / 100)
+                    : 0
+                }
                 onCancelSuccess={handleCancelSuccess}
             />
-
-        </div >
+        </div>
     );
 }

--- a/goorm-gongbang/app/(protected)/my/reservations/[id]/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/reservations/[id]/page.tsx
@@ -3,11 +3,12 @@
 import { useRouter } from "next/navigation";
 import { Copy, ChevronLeft } from "lucide-react";
 import { toast } from "sonner";
-import { useState, useEffect, useRef, use } from "react";
+import { useState, useEffect, use } from "react";
 import { CancelTicketModal } from "@/components/my/CancelTicketModal";
 import { TicketInfo } from "@/components/my/TicketDetailModal";
 import { RESERVATION_STATUS_MAP } from "../page";
 import { getTicketDetail } from "@/lib/services";
+import { parseFeeRate } from "@/lib/utils";
 import type { TicketDetail } from "@/lib/types";
 
 function formatDate(iso: string): string {
@@ -31,11 +32,8 @@ export default function ReservationDetailPage({ params }: { params: Promise<{ id
 
     const [detail, setDetail] = useState<TicketDetail | null>(null);
     const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
-    const fetchedRef = useRef(false);
-
     useEffect(() => {
-        if (fetchedRef.current) return;
-        fetchedRef.current = true;
+        setDetail(null);
         getTicketDetail(Number(resolvedParams.id)).then(setDetail);
     }, [resolvedParams.id]);
 
@@ -371,7 +369,7 @@ export default function ReservationDetailPage({ params }: { params: Promise<{ id
                 ticketId={Number(resolvedParams.id)}
                 paymentAmount={detail.payment?.totalAmount ?? 0}
                 cancelFee={detail.cancellationPolicy
-                    ? Math.round((detail.payment?.totalAmount ?? 0) * parseFloat((detail.cancellationPolicy.feeRate ?? "0").replace("%", "")) / 100)
+                    ? Math.round((detail.payment?.totalAmount ?? 0) * parseFeeRate(detail.cancellationPolicy.feeRate))
                     : 0
                 }
                 onCancelSuccess={handleCancelSuccess}

--- a/goorm-gongbang/app/(protected)/my/reservations/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/reservations/page.tsx
@@ -1,25 +1,56 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { ChevronRight, ChevronsLeft, ChevronsRight, ChevronLeft } from "lucide-react";
+import { ChevronLeft } from "lucide-react";
+import {
+    Pagination,
+    PaginationContent,
+    PaginationEllipsis,
+    PaginationItem,
+    PaginationLink,
+    PaginationNext,
+    PaginationPrevious,
+} from "@/components/ui/pagination";
 import { PaymentDepositModal } from "@/components/my/PaymentDepositModal";
 import { CancelTicketModal } from "@/components/my/CancelTicketModal";
 import { TicketInfo } from "@/components/my/TicketDetailModal";
 import { ReservationItem } from "@/components/my/ReservationItem";
+import { getTicketList, getTicketDetail } from "@/lib/services";
+import type { TicketItem, TicketSummary } from "@/lib/types";
 
 /* ===========================
-   [API 연동 가이드] - 데이터 모델
-   - 백엔드 측 API (예: GET /api/v1/my/reservations) 명세에 맞추어 아래 Mock 데이터를 실제 Type으로 변경하세요.
-   - status 필드의 경우 Enum Type("PAYMENT_WAITING", "RESERVED", "CANCEL_PROCESSING", "REFUND_PROCESSING") 활용을 권장합니다.
+   Reservation 타입 (UI용)
 =========================== */
-export type ReservationStatus = "PAYMENT_WAITING" | "RESERVED" | "UNDER_REVIEW" | "CANCEL_PROCESSING" | "REFUND_PROCESSING" | "CANCEL_COMPLETED" | "REFUND_COMPLETED";
+export type ReservationStatus =
+    | "PAYMENT_PENDING"
+    | "PAID"
+    | "RESERVED"
+    | "UNDER_REVIEW"
+    | "CANCEL_REQUESTED"
+    | "CANCEL_PROCESSING"
+    | "CANCELLED"
+    | "REFUND_PROCESSING"
+    | "CANCEL_COMPLETED"
+    | "REFUND_COMPLETED";
 
-export const RESERVATION_STATUS_MAP: Record<ReservationStatus, string> = {
-    PAYMENT_WAITING: "입금 대기",
+export const CANCEL_REFUND_STATUSES: ReservationStatus[] = [
+    "CANCEL_REQUESTED",
+    "CANCEL_PROCESSING",
+    "CANCELLED",
+    "REFUND_PROCESSING",
+    "CANCEL_COMPLETED",
+    "REFUND_COMPLETED",
+];
+
+export const RESERVATION_STATUS_MAP: Record<string, string> = {
+    PAYMENT_PENDING: "입금 대기",
+    PAID: "결제 완료",
     RESERVED: "결제 완료",
     UNDER_REVIEW: "정밀 확인 중",
+    CANCEL_REQUESTED: "취소 요청 중",
     CANCEL_PROCESSING: "취소 처리 중",
+    CANCELLED: "취소 완료",
     REFUND_PROCESSING: "환불 처리 중",
     CANCEL_COMPLETED: "취소 완료",
     REFUND_COMPLETED: "환불 완료",
@@ -35,21 +66,58 @@ export interface Reservation {
     status: ReservationStatus;
 }
 
-export const MOCK_RESERVATIONS: Reservation[] = [
-    { id: "5", date: "2026. 04. 02 (14:00)", matchTitle: "LG 트윈스 vs kt 위즈", location: "잠실", count: 3, seat: "블루석 123블럭 E열 23번, 24번, 25번", status: "CANCEL_PROCESSING" },
-    { id: "4", date: "2026. 04. 01 (18:30)", matchTitle: "LG 트윈스 vs SSG 랜더스", location: "잠실", count: 4, seat: "블루석 201블럭 I열 2번, 3번, 4번, 5번", status: "RESERVED" },
-    { id: "3", date: "2026. 03. 31 (18:30)", matchTitle: "LG 트윈스 vs KIA 타이거즈", location: "잠실", count: 2, seat: "오렌지석 206블럭 F열 23번, 24번", status: "CANCEL_PROCESSING" },
-    { id: "2", date: "2026. 03. 29 (14:00)", matchTitle: "LG 트윈스 vs kt 위즈", location: "잠실", count: 3, seat: "오렌지석 206블럭 3열 13번, 14번", status: "RESERVED" },
-    { id: "1", date: "2026. 03. 28 (14:00)", matchTitle: "LG 트윈스 vs kt 위즈", location: "잠실", count: 2, seat: "오렌지석 201블럭 H열 13번, 14번", status: "PAYMENT_WAITING" },
-    { id: "13", date: "2026. 04. 05 (14:00)", matchTitle: "LG 트윈스 vs 키움 히어로즈", location: "잠실", count: 2, seat: "블루석 108블럭 K열 10번, 11번", status: "UNDER_REVIEW" }, // 테스트용 추가
-    { id: "10", date: "2025. 10. 27 (18:30)", matchTitle: "LG 트윈스 vs 한화 이글스", location: "잠실", count: 5, seat: "오렌지석 206블럭 F열 23번, 24번", status: "RESERVED" },
-    { id: "9", date: "2025. 10. 26 (14:00)", matchTitle: "LG 트윈스 vs 한화 이글스", location: "잠실", count: 2, seat: "오렌지석 206블럭 F열 23번, 24번", status: "RESERVED" },
-    { id: "8", date: "2025. 10. 01 (18:30)", matchTitle: "LG 트윈스 vs NC 다이노즈", location: "잠실", count: 1, seat: "오렌지석 206블럭 F열 23번, 24번", status: "RESERVED" },
-    { id: "7", date: "2025. 09. 07 (17:00)", matchTitle: "LG 트윈스 vs SSG 랜더스", location: "잠실", count: 3, seat: "오렌지석 206블럭 F열 23번, 24번", status: "RESERVED" },
-    { id: "6", date: "2025. 09. 06 (17:00)", matchTitle: "두산 베어스 vs LG 트윈스", location: "잠실", count: 3, seat: "오렌지석 206블럭 F열 23번, 24번", status: "REFUND_PROCESSING" },
-    { id: "11", date: "2025. 08. 15 (14:00)", matchTitle: "LG 트윈스 vs 롯데 자이언츠", location: "잠실", count: 2, seat: "오렌지석 206블럭 F열 23번, 24번", status: "CANCEL_COMPLETED" },
-    { id: "12", date: "2025. 08. 14 (18:30)", matchTitle: "LG 트윈스 vs 롯데 자이언츠", location: "잠실", count: 4, seat: "블루석 201블럭 I열 2번, 3번, 4번, 5번", status: "REFUND_COMPLETED" },
-];
+const PAGE_SIZE = 10;
+
+function getPageRange(current: number, total: number): (number | "ellipsis")[] {
+    if (total <= 7) return Array.from({ length: total }, (_, i) => i);
+
+    const pages: (number | "ellipsis")[] = [0];
+    const left = Math.max(1, current - 1);
+    const right = Math.min(total - 2, current + 1);
+
+    if (left > 1) pages.push("ellipsis");
+    for (let i = left; i <= right; i++) pages.push(i);
+    if (right < total - 2) pages.push("ellipsis");
+    pages.push(total - 1);
+
+    return pages;
+}
+
+function toReservation(item: TicketItem): Reservation {
+    const d = new Date(item.matchAt);
+    const pad = (n: number) => String(n).padStart(2, "0");
+    const date = `${d.getFullYear()}. ${pad(d.getMonth() + 1)}. ${pad(d.getDate())} (${pad(d.getHours())}:${pad(d.getMinutes())})`;
+    const seat = item.seats
+        .map((s) => `${s.sectionName} ${s.blockCode}블럭 ${s.rowNo}열 ${s.seatNo}번`)
+        .join(", ");
+
+    return {
+        id: String(item.ticketId),
+        date,
+        matchTitle: `${item.homeClub.koName} vs ${item.awayClub.koName}`,
+        location: item.stadiumName,
+        count: item.seatCount,
+        seat,
+        status: item.status as ReservationStatus,
+    };
+}
+
+// API 탭의 전체 페이지를 순차적으로 모두 불러옴
+async function fetchAllPages(tab: "BOOKED" | "CANCEL_REFUND"): Promise<{ items: TicketItem[]; summary: TicketSummary }> {
+    const first = await getTicketList({ tab, page: 0, size: 10 });
+    const items: TicketItem[] = [...first.tickets];
+
+    if (first.pagination.totalPages > 1) {
+        const rest = await Promise.all(
+            Array.from({ length: first.pagination.totalPages - 1 }, (_, i) =>
+                getTicketList({ tab, page: i + 1, size: 10 })
+            )
+        );
+        rest.forEach((d) => items.push(...d.tickets));
+    }
+
+    return { items, summary: first.summary };
+}
 
 const MOCK_DEPOSIT_INFO = {
     bankName: "국민",
@@ -62,45 +130,83 @@ const MOCK_DEPOSIT_INFO = {
 export default function ReservationsPage() {
     const router = useRouter();
 
-    // TODO: [API 연동 가이드] - 선택된 탭 정보(예: '?tab=history')를 Query String으로 관리하거나 State로 관리합니다.
     const [activeTab, setActiveTab] = useState<"HISTORY" | "CANCEL">("HISTORY");
+    const [currentPage, setCurrentPage] = useState(0);
+    const [summary, setSummary] = useState<TicketSummary | null>(null);
+    const [allItems, setAllItems] = useState<Reservation[]>([]);
 
-    /* ===========================
-       TODO: [API 연동 가이드] - 통계 정보 및 리스트 조회 
-       1. 화면 진입 시 통계 데이터 API (ex: GET /api/v1/my/reservations/summary) 통신
-       2. 페이징 및 필터별 리스트 데이터 API (ex: GET /api/v1/my/reservations?page=1&size=10&tab=HISTORY) 통신
-       3. isLoading 상태를 두어 Suspense 혹은 Skeleton UI 적용 권장
-    =========================== */
-    const mockSummary = {
-        total: 72,
-        upcoming: 3,
-        canceling: 2,
-        completed: 67
-    };
+    // 클라이언트 페이지네이션
+    const totalPages = Math.ceil(allItems.length / PAGE_SIZE);
+    const pagedItems = allItems.slice(currentPage * PAGE_SIZE, (currentPage + 1) * PAGE_SIZE);
 
-    const [reservations, setReservations] = useState<Reservation[]>(MOCK_RESERVATIONS);
-
-    // 모달 상태 관리
     const [isDepositModalOpen, setIsDepositModalOpen] = useState(false);
     const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
     const [selectedTicketInfo, setSelectedTicketInfo] = useState<TicketInfo | null>(null);
     const [selectedReservationId, setSelectedReservationId] = useState<string | null>(null);
+    const [cancelInfo, setCancelInfo] = useState<{ paymentAmount: number; cancelFee: number } | null>(null);
 
-    // 액션 핸들러
+    const loadHistoryItems = async () => {
+        const { items, summary } = await fetchAllPages("BOOKED");
+        setSummary(summary);
+        setAllItems(
+            items.map(toReservation).filter((r) => !CANCEL_REFUND_STATUSES.includes(r.status))
+        );
+    };
+
+    const loadCancelItems = async () => {
+        const [cancelRefundResult, bookedResult] = await Promise.all([
+            fetchAllPages("CANCEL_REFUND"),
+            fetchAllPages("BOOKED"),
+        ]);
+        setSummary(cancelRefundResult.summary);
+        const cancelRequested = bookedResult.items
+            .filter((t) => t.status === "CANCEL_REQUESTED")
+            .map(toReservation);
+        const cancelRefund = cancelRefundResult.items.map(toReservation);
+        setAllItems([...cancelRequested, ...cancelRefund]);
+    };
+
+    const reload = () => {
+        if (activeTab === "HISTORY") {
+            loadHistoryItems();
+        } else {
+            loadCancelItems();
+        }
+    };
+
+    useEffect(() => {
+        setCurrentPage(0);
+        reload();
+    }, [activeTab]);
+
+    // allItems 갱신 후 currentPage가 범위를 벗어나면 마지막 페이지로 이동
+    useEffect(() => {
+        if (allItems.length === 0) return;
+        const newTotal = Math.ceil(allItems.length / PAGE_SIZE);
+        if (currentPage >= newTotal) {
+            setCurrentPage(newTotal - 1);
+        }
+    }, [allItems]);
+
+    const handleTabChange = (tab: "HISTORY" | "CANCEL") => {
+        setActiveTab(tab);
+    };
+
+    const handlePageChange = (page: number) => {
+        setCurrentPage(page);
+    };
+
     const handleActionClick = (e: React.MouseEvent, item: Reservation) => {
         e.stopPropagation();
-        if (item.status === "PAYMENT_WAITING") {
+        if (item.status === "PAYMENT_PENDING") {
             setIsDepositModalOpen(true);
         } else if (item.status === "UNDER_REVIEW") {
-            // "고객센터 문의" 액션 - 1:1 문의 페이지로 이동
             router.push("/my/support");
-        } else if (item.status === "RESERVED") {
-            // "오렌지석 201블럭 H열 13번, 14번" 파싱
+        } else if (item.status === "PAID" || item.status === "RESERVED") {
             const parts = item.seat.split(" ");
             const type = parts[0] || "";
             const zone = parts[1] || "";
             const seat = parts.slice(2).join(" ");
-
             const datePart = item.date.split(" (")[0];
             const timePart = item.date.match(/\((.*?)\)/)?.[1] || "";
 
@@ -113,10 +219,17 @@ export default function ReservationsPage() {
                 date: datePart,
                 time: timePart,
                 location: item.location,
-                dateStr: item.date
+                dateStr: item.date,
             });
             setSelectedReservationId(item.id);
-            setIsCancelModalOpen(true);
+            getTicketDetail(Number(item.id)).then((detail) => {
+                const totalAmount = detail.payment?.totalAmount ?? 0;
+                const feeRate = detail.cancellationPolicy?.feeRate ?? "0";
+                const rate = parseFloat(feeRate.replace("%", "")) / 100;
+                const cancelFee = Math.round(totalAmount * rate);
+                setCancelInfo({ paymentAmount: totalAmount, cancelFee });
+                setIsCancelModalOpen(true);
+            });
         }
     };
 
@@ -155,34 +268,31 @@ export default function ReservationsPage() {
                     <h1 className="text-[24px] font-bold text-[#1A1A1A]">예매 내역</h1>
                 </div>
 
-                {/* 요약(Summary) 카드 4개 구성 */}
-                {/* TODO: [API 연동 가이드] API 응답 데이터 (mockSummary 속성들)를 바인딩 하세요. */}
+                {/* 요약(Summary) 카드 */}
                 <div className="grid grid-cols-4 gap-4 mb-8">
                     <div className="bg-white rounded-[16px] border border-[#E8E8E8] p-6 flex flex-col gap-3 shadow-sm">
                         <span className="text-[15px] font-bold text-[#333]">총 예매 수</span>
-                        <span className="text-[32px] font-bold text-[#1A1A1A] leading-none">{mockSummary.total}</span>
+                        <span className="text-[32px] font-bold text-[#1A1A1A] leading-none">{summary?.totalCount ?? "-"}</span>
                     </div>
                     <div className="bg-white rounded-[16px] border border-[#E8E8E8] p-6 flex flex-col gap-3 shadow-sm">
                         <span className="text-[15px] font-bold text-[#333]">경기 예정</span>
-                        <span className="text-[32px] font-bold text-[var(--foundation-primary-500)] leading-none">{mockSummary.upcoming}</span>
+                        <span className="text-[32px] font-bold text-[var(--foundation-primary-500)] leading-none">{summary?.upcomingCount ?? "-"}</span>
                     </div>
                     <div className="bg-white rounded-[16px] border border-[#E8E8E8] p-6 flex flex-col gap-3 shadow-sm">
                         <span className="text-[15px] font-bold text-[#333]">취소 처리 중</span>
-                        <span className="text-[32px] font-bold text-[var(--foundation-red-500)] leading-none">{mockSummary.canceling}</span>
+                        <span className="text-[32px] font-bold text-[var(--foundation-red-500)] leading-none">{summary?.cancelProcessingCount ?? "-"}</span>
                     </div>
                     <div className="bg-white rounded-[16px] border border-[#E8E8E8] p-6 flex flex-col gap-3 shadow-sm">
                         <span className="text-[15px] font-bold text-[#333]">경기 완료</span>
-                        <span className="text-[32px] font-bold text-[#A3A3A3] leading-none">{mockSummary.completed}</span>
+                        <span className="text-[32px] font-bold text-[#A3A3A3] leading-none">{summary?.completedCount ?? "-"}</span>
                     </div>
                 </div>
 
                 {/* 탭 네비게이션 */}
-                {/* TODO: [API 연동 가이드] 탭 변경(onClick) 시 List Fetch API를 재호출하도록 연동하세요. */}
                 <div className="flex items-center gap-6 border-b border-[#E8E8E8] mb-6">
                     <button
-                        onClick={() => setActiveTab("HISTORY")}
-                        className={`pb-3 text-[16px] font-bold transition-colors relative ${activeTab === "HISTORY" ? "text-[var(--foundation-primary-500)]" : "text-[#9E9E9E] hover:text-[#666]"
-                            }`}
+                        onClick={() => handleTabChange("HISTORY")}
+                        className={`pb-3 text-[16px] font-bold transition-colors relative ${activeTab === "HISTORY" ? "text-[var(--foundation-primary-500)]" : "text-[#9E9E9E] hover:text-[#666]"}`}
                     >
                         예매 내역
                         {activeTab === "HISTORY" && (
@@ -190,9 +300,8 @@ export default function ReservationsPage() {
                         )}
                     </button>
                     <button
-                        onClick={() => setActiveTab("CANCEL")}
-                        className={`pb-3 text-[16px] font-bold transition-colors relative ${activeTab === "CANCEL" ? "text-[var(--foundation-primary-500)]" : "text-[#9E9E9E] hover:text-[#666]"
-                            }`}
+                        onClick={() => handleTabChange("CANCEL")}
+                        className={`pb-3 text-[16px] font-bold transition-colors relative ${activeTab === "CANCEL" ? "text-[var(--foundation-primary-500)]" : "text-[#9E9E9E] hover:text-[#666]"}`}
                     >
                         취소/환불
                         {activeTab === "CANCEL" && (
@@ -201,9 +310,8 @@ export default function ReservationsPage() {
                     </button>
                 </div>
 
-                {/* 테이블 (리스트 영역) */}
+                {/* 테이블 */}
                 <div className="bg-white rounded-[12px] border border-[#E8E8E8] overflow-hidden">
-                    {/* 테이블 헤더 */}
                     <div className="grid grid-cols-[minmax(180px,1fr)_minmax(200px,1fr)_100px_80px_minmax(280px,2fr)_minmax(200px,1fr)] items-center px-6 py-4 bg-[#FAFAFA] border-b border-[#E8E8E8] text-[14px] text-[#666] font-semibold">
                         <div>경기 일시</div>
                         <div>경기 정보</div>
@@ -212,44 +320,69 @@ export default function ReservationsPage() {
                         <div>좌석 정보</div>
                         <div className="pl-4">진행 상황</div>
                     </div>
-
-                    {/* 테이블 바디 */}
                     <div className="flex flex-col">
-                        {
-                            // 탭에 따른 리스트 분기 처리 (취소/환불 탭의 경우 취소, 환불 완료된 건들만 노출)
-                            reservations
-                                .filter(item => {
-                                    if (activeTab === "CANCEL") {
-                                        return item.status === "CANCEL_COMPLETED" || item.status === "REFUND_COMPLETED";
-                                    }
-                                    return item.status !== "CANCEL_COMPLETED" && item.status !== "REFUND_COMPLETED";
-                                })
-                                .map((item, index, filteredArr) => {
-                                    return (
-                                        <ReservationItem
-                                            key={item.id}
-                                            item={item}
-                                            index={index}
-                                            isLast={index === filteredArr.length - 1}
-                                            onActionClick={handleActionClick}
-                                        />
-                                    );
-                                })}
+                        {pagedItems.length === 0 ? (
+                            <div className="py-16 text-center text-[#999] text-[14px]">
+                                {activeTab === "CANCEL" ? "취소/환불 내역이 없습니다." : "예매 내역이 없습니다."}
+                            </div>
+                        ) : (
+                            pagedItems.map((item, index) => (
+                                <ReservationItem
+                                    key={item.id}
+                                    item={item}
+                                    index={index}
+                                    isLast={index === pagedItems.length - 1}
+                                    onActionClick={handleActionClick}
+                                />
+                            ))
+                        )}
                     </div>
                 </div>
 
                 {/* Pagination */}
-                {/* TODO: [API 연동 가이드] 백엔드에서 전달받은 Total Elements 수를 기반으로 Pagination 컴포넌트를 동작시키세요. */}
-                <div className="mt-12 mb-8 flex items-center justify-center gap-5 text-[#999999] text-[15px]">
-                    <button className="hover:text-[#1A1A1A] transition-colors"><ChevronsLeft size={16} /></button>
-                    <button className="hover:text-[#1A1A1A] transition-colors"><ChevronLeft size={16} /></button>
-                    <button className="text-[var(--foundation-primary-500)] font-bold text-[16px] underline underline-offset-4">1</button>
-                    <button className="hover:text-[#1A1A1A] transition-colors">2</button>
-                    <button className="hover:text-[#1A1A1A] transition-colors">3</button>
-                    <button className="hover:text-[#1A1A1A] transition-colors">4</button>
-                    <button className="hover:text-[#1A1A1A] transition-colors"><ChevronRight size={16} /></button>
-                    <button className="hover:text-[#1A1A1A] transition-colors"><ChevronsRight size={16} /></button>
-                </div>
+                {totalPages > 1 && (
+                    <div className="mt-8 mb-4">
+                        <Pagination>
+                            <PaginationContent>
+                                <PaginationItem>
+                                    <PaginationPrevious
+                                        href="#"
+                                        onClick={(e) => { e.preventDefault(); if (currentPage > 0) handlePageChange(currentPage - 1); }}
+                                        aria-disabled={currentPage === 0}
+                                        className={currentPage === 0 ? "pointer-events-none opacity-40" : ""}
+                                    />
+                                </PaginationItem>
+
+                                {getPageRange(currentPage, totalPages).map((page, idx) =>
+                                    page === "ellipsis" ? (
+                                        <PaginationItem key={`ellipsis-${idx}`}>
+                                            <PaginationEllipsis />
+                                        </PaginationItem>
+                                    ) : (
+                                        <PaginationItem key={page}>
+                                            <PaginationLink
+                                                href="#"
+                                                isActive={currentPage === page}
+                                                onClick={(e) => { e.preventDefault(); handlePageChange(page); }}
+                                            >
+                                                {page + 1}
+                                            </PaginationLink>
+                                        </PaginationItem>
+                                    )
+                                )}
+
+                                <PaginationItem>
+                                    <PaginationNext
+                                        href="#"
+                                        onClick={(e) => { e.preventDefault(); if (currentPage < totalPages - 1) handlePageChange(currentPage + 1); }}
+                                        aria-disabled={currentPage === totalPages - 1}
+                                        className={currentPage === totalPages - 1 ? "pointer-events-none opacity-40" : ""}
+                                    />
+                                </PaginationItem>
+                            </PaginationContent>
+                        </Pagination>
+                    </div>
+                )}
 
                 {/* 입금 안내 모달 */}
                 <PaymentDepositModal
@@ -261,23 +394,13 @@ export default function ReservationsPage() {
                 {/* 취소 모달 */}
                 <CancelTicketModal
                     isOpen={isCancelModalOpen}
-                    onClose={() => setIsCancelModalOpen(false)}
+                    onClose={() => { setIsCancelModalOpen(false); setCancelInfo(null); }}
                     ticketInfo={selectedTicketInfo}
-                    paymentAmount={selectedTicketInfo ? selectedTicketInfo.count * 20000 + 2000 : 0} // 선택된 좌석 수에 맞게 동적 설정
-                    cancelFee={2000} // 예시 고정값
-                    onCancelSuccess={() => {
-                        if (selectedReservationId) {
-                            setReservations(prev =>
-                                prev.map(res =>
-                                    res.id === selectedReservationId
-                                        ? { ...res, status: "CANCEL_PROCESSING" }
-                                        : res
-                                )
-                            );
-                        }
-                    }}
+                    ticketId={selectedReservationId ? Number(selectedReservationId) : undefined}
+                    paymentAmount={cancelInfo?.paymentAmount ?? 0}
+                    cancelFee={cancelInfo?.cancelFee ?? 0}
+                    onCancelSuccess={reload}
                 />
-
             </div>
         </div>
     );

--- a/goorm-gongbang/app/(protected)/my/reservations/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/reservations/page.tsx
@@ -17,6 +17,7 @@ import { CancelTicketModal } from "@/components/my/CancelTicketModal";
 import { TicketInfo } from "@/components/my/TicketDetailModal";
 import { ReservationItem } from "@/components/my/ReservationItem";
 import { getTicketList, getTicketDetail } from "@/lib/services";
+import { parseFeeRate } from "@/lib/utils";
 import type { TicketItem, TicketSummary } from "@/lib/types";
 
 /* ===========================
@@ -102,22 +103,7 @@ function toReservation(item: TicketItem): Reservation {
     };
 }
 
-// API 탭의 전체 페이지를 순차적으로 모두 불러옴
-async function fetchAllPages(tab: "BOOKED" | "CANCEL_REFUND"): Promise<{ items: TicketItem[]; summary: TicketSummary }> {
-    const first = await getTicketList({ tab, page: 0, size: 10 });
-    const items: TicketItem[] = [...first.tickets];
 
-    if (first.pagination.totalPages > 1) {
-        const rest = await Promise.all(
-            Array.from({ length: first.pagination.totalPages - 1 }, (_, i) =>
-                getTicketList({ tab, page: i + 1, size: 10 })
-            )
-        );
-        rest.forEach((d) => items.push(...d.tickets));
-    }
-
-    return { items, summary: first.summary };
-}
 
 const MOCK_DEPOSIT_INFO = {
     bankName: "국민",
@@ -133,71 +119,50 @@ export default function ReservationsPage() {
     const [activeTab, setActiveTab] = useState<"HISTORY" | "CANCEL">("HISTORY");
     const [currentPage, setCurrentPage] = useState(0);
     const [summary, setSummary] = useState<TicketSummary | null>(null);
-    const [allItems, setAllItems] = useState<Reservation[]>([]);
-
-    // 클라이언트 페이지네이션
-    const totalPages = Math.ceil(allItems.length / PAGE_SIZE);
-    const pagedItems = allItems.slice(currentPage * PAGE_SIZE, (currentPage + 1) * PAGE_SIZE);
+    const [items, setItems] = useState<Reservation[]>([]);
+    const [totalPages, setTotalPages] = useState(0);
 
     const [isDepositModalOpen, setIsDepositModalOpen] = useState(false);
     const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
     const [selectedTicketInfo, setSelectedTicketInfo] = useState<TicketInfo | null>(null);
     const [selectedReservationId, setSelectedReservationId] = useState<string | null>(null);
     const [cancelInfo, setCancelInfo] = useState<{ paymentAmount: number; cancelFee: number } | null>(null);
+    const [loadingId, setLoadingId] = useState<string | null>(null);
 
-    const loadHistoryItems = async () => {
-        const { items, summary } = await fetchAllPages("BOOKED");
-        setSummary(summary);
-        setAllItems(
-            items.map(toReservation).filter((r) => !CANCEL_REFUND_STATUSES.includes(r.status))
-        );
-    };
+    const loadData = async () => {
+        try {
+            const apiTab = activeTab === "HISTORY" ? "BOOKED" : "CANCEL_REFUND";
+            const result = await getTicketList({ 
+                tab: apiTab, 
+                page: currentPage, 
+                size: PAGE_SIZE 
+            });
 
-    const loadCancelItems = async () => {
-        const [cancelRefundResult, bookedResult] = await Promise.all([
-            fetchAllPages("CANCEL_REFUND"),
-            fetchAllPages("BOOKED"),
-        ]);
-        setSummary(cancelRefundResult.summary);
-        const cancelRequested = bookedResult.items
-            .filter((t) => t.status === "CANCEL_REQUESTED")
-            .map(toReservation);
-        const cancelRefund = cancelRefundResult.items.map(toReservation);
-        setAllItems([...cancelRequested, ...cancelRefund]);
-    };
-
-    const reload = () => {
-        if (activeTab === "HISTORY") {
-            loadHistoryItems();
-        } else {
-            loadCancelItems();
+            setSummary(result.summary);
+            setTotalPages(result.pagination.totalPages);
+            setItems(result.tickets.map(toReservation));
+        } catch (error: any) {
+            toast.error(error.message || "예매 내역을 불러오지 못했습니다.");
         }
     };
 
     useEffect(() => {
-        setCurrentPage(0);
-        reload();
-    }, [activeTab]);
-
-    // allItems 갱신 후 currentPage가 범위를 벗어나면 마지막 페이지로 이동
-    useEffect(() => {
-        if (allItems.length === 0) return;
-        const newTotal = Math.ceil(allItems.length / PAGE_SIZE);
-        if (currentPage >= newTotal) {
-            setCurrentPage(newTotal - 1);
-        }
-    }, [allItems]);
+        loadData();
+    }, [activeTab, currentPage]);
 
     const handleTabChange = (tab: "HISTORY" | "CANCEL") => {
         setActiveTab(tab);
+        setCurrentPage(0);
     };
 
     const handlePageChange = (page: number) => {
         setCurrentPage(page);
     };
 
-    const handleActionClick = (e: React.MouseEvent, item: Reservation) => {
+    const handleActionClick = async (e: React.MouseEvent, item: Reservation) => {
         e.stopPropagation();
+        if (loadingId) return;
+
         if (item.status === "PAYMENT_PENDING") {
             setIsDepositModalOpen(true);
         } else if (item.status === "UNDER_REVIEW") {
@@ -222,14 +187,19 @@ export default function ReservationsPage() {
                 dateStr: item.date,
             });
             setSelectedReservationId(item.id);
-            getTicketDetail(Number(item.id)).then((detail) => {
+            
+            setLoadingId(item.id);
+            try {
+                const detail = await getTicketDetail(Number(item.id));
                 const totalAmount = detail.payment?.totalAmount ?? 0;
-                const feeRate = detail.cancellationPolicy?.feeRate ?? "0";
-                const rate = parseFloat(feeRate.replace("%", "")) / 100;
-                const cancelFee = Math.round(totalAmount * rate);
+                const cancelFee = Math.round(totalAmount * parseFeeRate(detail.cancellationPolicy?.feeRate));
                 setCancelInfo({ paymentAmount: totalAmount, cancelFee });
                 setIsCancelModalOpen(true);
-            });
+            } catch (error: any) {
+                toast.error(error.message || "예매 상세 정보를 불러오지 못했습니다.");
+            } finally {
+                setLoadingId(null);
+            }
         }
     };
 
@@ -321,18 +291,19 @@ export default function ReservationsPage() {
                         <div className="pl-4">진행 상황</div>
                     </div>
                     <div className="flex flex-col">
-                        {pagedItems.length === 0 ? (
+                        {items.length === 0 ? (
                             <div className="py-16 text-center text-[#999] text-[14px]">
                                 {activeTab === "CANCEL" ? "취소/환불 내역이 없습니다." : "예매 내역이 없습니다."}
                             </div>
                         ) : (
-                            pagedItems.map((item, index) => (
+                            items.map((item, index) => (
                                 <ReservationItem
                                     key={item.id}
                                     item={item}
                                     index={index}
-                                    isLast={index === pagedItems.length - 1}
+                                    isLast={index === items.length - 1}
                                     onActionClick={handleActionClick}
+                                    isLoading={loadingId === item.id}
                                 />
                             ))
                         )}
@@ -399,7 +370,7 @@ export default function ReservationsPage() {
                     ticketId={selectedReservationId ? Number(selectedReservationId) : undefined}
                     paymentAmount={cancelInfo?.paymentAmount ?? 0}
                     cancelFee={cancelInfo?.cancelFee ?? 0}
-                    onCancelSuccess={reload}
+                    onCancelSuccess={loadData}
                 />
             </div>
         </div>

--- a/goorm-gongbang/app/(protected)/my/reservations/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/reservations/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 import { ChevronLeft } from "lucide-react";
 import {

--- a/goorm-gongbang/app/(protected)/my/support/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/support/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useEffect, useCallback } from "react";
+import { useRouter, usePathname } from "next/navigation";
 import { ChevronLeft } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { ActionButton } from "@/components/common/Button";
 import { InquiryItem, Inquiry } from "@/components/my/InquiryItem";
 
 /* ===========================
@@ -63,16 +63,18 @@ const MOCK_INQUIRIES: Inquiry[] = [
 
 export default function SupportPage() {
     const router = useRouter();
+    const pathname = usePathname();
     const [inquiries, setInquiries] = useState<Inquiry[]>([]);
 
-    useEffect(() => {
-        // 로컬스토리지에서 새로 작성된 문의 가져오기
+    const loadInquiries = useCallback(() => {
         const saved = localStorage.getItem("my-inquiries");
         const localInquiries = saved ? JSON.parse(saved) : [];
-        
-        // 기존 MOCK 데이터와 합치기
         setInquiries([...localInquiries, ...MOCK_INQUIRIES]);
     }, []);
+
+    useEffect(() => {
+        loadInquiries();
+    }, [loadInquiries, pathname]);
 
     return (
         <div className="min-h-screen bg-[#F8F9FA]">
@@ -107,16 +109,16 @@ export default function SupportPage() {
 
                 <div className="mb-10 flex items-center justify-between">
                     <h1 className="text-[32px] font-extrabold tracking-tight text-[#1A1A1A]">1:1 문의</h1>
+                    <ActionButton
+                        onClick={() => router.push("/my/support/write")}
+                        size="lg"
+                    >
+                        1:1 문의 작성
+                    </ActionButton>
                 </div>
 
                 {/* 문의한 내용 섹션 */}
                 <div className="flex flex-col gap-6">
-                    <button 
-                        type="button"
-                        onClick={() => router.push("/my/support/write")}
-                        className="cursor-pointer self-stretch px-8 py-6 bg-[var(--background-white)] rounded-[20px] outline outline-1 outline-offset-[-1px] outline-[var(--stroke-interactive-neutral-default)] inline-flex flex-col justify-start items-start gap-4 text-left">
-                        <div className="justify-start text-black text-xl font-semibold font-['Pretendard_Variable'] leading-8">1:1 문의작성</div>
-                    </button>
 
                     <div className="bg-white rounded-xl border border-[#E9ECEF] overflow-hidden px-8 py-6">
                         <div className="flex items-center justify-between mb-4">

--- a/goorm-gongbang/app/(protected)/my/support/write/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/support/write/page.tsx
@@ -1,16 +1,16 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { ChevronLeft, ChevronDown, X } from "lucide-react";
+import { ChevronLeft, ChevronDown } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
-import { useState, useRef, type ChangeEvent } from "react";
+import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { toast } from "sonner";
-import { PrimaryButton } from "@/components/common/Button";
-import { createInquiry, issueInquiryPresignedUrl, confirmInquiryFile } from "@/lib/services";
+import { ActionButton } from "@/components/common/Button";
+import { createInquiry, getAccountInfo } from "@/lib/services";
 import type { CreateInquiryRequest, InquiryCategory } from "@/lib/types";
 
 /* ===========================
@@ -53,58 +53,30 @@ export default function SupportWritePage() {
 
     const [isSubmitting, setIsSubmitting] = useState(false);
 
-    const [isEditingWriter, setIsEditingWriter] = useState(false);
-    const [writerName, setWriterName] = useState("윤정빈");
-    const [writerEmail, setWriterEmail] = useState("playball123@gmail.com");
-    const [phoneNumber, setPhoneNumber] = useState("010-0000-0000");
+    const [writerName, setWriterName] = useState("");
+    const [writerEmail, setWriterEmail] = useState("");
+    const [phoneNumber, setPhoneNumber] = useState("");
+
+    useEffect(() => {
+        const fetchUserData = async () => {
+            try {
+                const data = await getAccountInfo();
+                setWriterName(data.nickname);
+                setWriterEmail(data.email);
+            } catch (error) {
+                console.error("Failed to fetch account info:", error);
+            }
+        };
+        fetchUserData();
+    }, []);
     const onlyDigits = (v: string) => v.replace(/\D/g, "");
     const phoneDigits = onlyDigits(phoneNumber);
-    const isPhoneValid = /^01[0-9]\d{7,8}$/.test(phoneDigits) && phoneDigits.length === 11;
+    const isPhoneValid = phoneNumber.length === 0 || (/^01[0-9]\d{7,8}$/.test(phoneDigits) && (phoneDigits.length === 10 || phoneDigits.length === 11));
     const formatPhone = (value: string) => {
         const digits = value.replace(/\D/g, "").slice(0, 11); // 숫자만, 최대 11자리
         if (digits.length < 4) return digits;
         if (digits.length < 8) return `${digits.slice(0, 3)}-${digits.slice(3)}`;
         return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
-    };
-    const [imageFiles, setImageFiles] = useState<File[]>([]);
-    const fileInputRef = useRef<HTMLInputElement | null>(null);
-
-    const handleImageChange = (e: ChangeEvent<HTMLInputElement>) => {
-        const files = Array.from(e.target.files ?? []);
-        setImageFiles(files);
-    };
-
-    const handleClearImages = () => {
-        setImageFiles([]);
-
-        if (fileInputRef.current) {
-            fileInputRef.current.value = "";
-        }
-    };
-
-    const uploadInquiryImage = async (inquiryId: number, file: File) => {
-        const { presignedUrl, fileKey } = await issueInquiryPresignedUrl(inquiryId, {
-            fileName: file.name,
-        });
-
-        const contentType = file.type;
-        if (!contentType) {
-            throw new Error("파일 형식을 확인할 수 없습니다.");
-        }
-
-        const uploadResponse = await fetch(presignedUrl, {
-            method: "PUT",
-            headers: { 
-                "Content-Type": file.type,
-                "Content-Disposition": "attachment" },
-            body: file,
-        });
-
-        if (!uploadResponse.ok) {
-            throw new Error("첨부파일 업로드에 실패했습니다.");
-        }
-
-        await confirmInquiryFile(inquiryId, { fileKey });
     };
 
     const isFormValid = !!type && title.trim().length > 0 && content.trim().length > 0 && isPhoneValid;
@@ -113,50 +85,52 @@ export default function SupportWritePage() {
         if (!type) return;
         if (!isFormValid) return;
 
+        setIsSubmitting(true);
         try {
-            setIsSubmitting(true);
-
             const body: CreateInquiryRequest = {
                 category: CATEGORY_MAP[type],
                 title: title.trim(),
                 content: content.trim(),
                 phoneNumber: phoneNumber.trim(),
             };
-            const result = await createInquiry(body);
 
-            const image = imageFiles[0];
-            if (image) {
-                await uploadInquiryImage(result.inquiryId, image);
+            // 1단계: 문의 등록
+            let result: Awaited<ReturnType<typeof createInquiry>>;
+            try {
+                result = await createInquiry(body);
+            } catch (e) {
+                const error = e as { status?: number; message?: string };
+                if (error.status === 400) toast.error("요청 값 오류");
+                else if (error.status === 401) { toast.error("인증 필요"); router.push("/login"); }
+                else if (error.status === 404) toast.error("사용자를 찾을 수 없습니다.");
+                else toast.error(error.message ?? "문의 등록 중 오류가 발생했습니다.");
+                return;
             }
+
+            const inquiryId = result?.inquiryId;
+            if (!inquiryId) {
+                toast.error("문의 등록에 실패했습니다. 다시 시도해주세요.");
+                return;
+            }
+
+            // 목록 페이지에서 즉시 반영되도록 localStorage에 저장
+            const saved = localStorage.getItem("my-inquiries");
+            const existing = saved ? JSON.parse(saved) : [];
+            const newInquiry = {
+                id: inquiryId,
+                status: "WAITING",
+                statusLabel: "답변 대기",
+                category: type,
+                title: body.title,
+                description: body.content,
+                date: new Date().toLocaleDateString("ko-KR", { year: "numeric", month: "2-digit", day: "2-digit" }).replace(/\. /g, ".").replace(/\.$/, ""),
+                answer: null,
+            };
+            localStorage.setItem("my-inquiries", JSON.stringify([newInquiry, ...existing]));
 
             toast.success("문의가 접수되었습니다.");
+            router.refresh();
             router.push("/my/support");
-        } catch (e) {
-            const error = e as { status?: number; message?: string };
-
-            if (error.status === 400) {
-                toast.error("요청 값 오류");
-                return;
-            }
-            if (error.status === 401) {
-                toast.error("인증 필요");
-                router.push("/login");
-                return;
-            }
-            if (error.status === 403) {
-                toast.error("본인 문의 아님");
-                return;
-            }
-            if (error.status === 404) {
-                toast.error("사용자 없음");
-                return;
-            }
-            if (error.status === 413) {
-                toast.error("파일 크기 제한 초과");
-                return;
-            }
-
-            toast.error(error.message ?? "문의 등록 중 오류가 발생했습니다.");
         } finally {
             setIsSubmitting(false);
         }
@@ -200,7 +174,7 @@ export default function SupportWritePage() {
                     이전으로 돌아가기
                 </button>
 
-                <div className="flex flex-col gap-8 shadow-sm">
+                <div className="flex flex-col gap-8">
                     <h1 className="text-2xl font-bold tracking-tight text-[var(--text-normal-n240)] font-['Pretendard']">1:1 문의 작성</h1>
                     {/* 문의 유형 */}
                     <div className="self-stretch px-8 py-6 bg-white rounded-[20px] border border-[var(--stroke-interactive-neutral-default)] flex flex-col items-start gap-2">
@@ -264,82 +238,44 @@ export default function SupportWritePage() {
                             className="min-h-[240px] rounded-[12px] border border-[#E0E0E0] p-5 text-[15px] hover:border-[var(--foundation-primary-500)] focus-visible:ring-0 focus-visible:border-[var(--foundation-primary-500)] focus-visible:outline-none transition-all resize-none leading-relaxed"
                         />
 
-                        {/* 이미지 */}
-                        <Label className="text-[16px] font-bold text-[#333333] ml-1">이미지</Label>
 
-                        <div className="relative w-full">
-                            <Input
-                                ref={fileInputRef}
-                                type="file"
-                                accept="image/*"
-                                onChange={handleImageChange}
-                                className="h-14 w-full rounded-[12px] border-[#E0E0E0] pr-12 px-4 text-[15px]"
-                            />
-
-                            {imageFiles.length > 0 && (
-                                <button
-                                    type="button"
-                                    onClick={handleClearImages}
-                                    className="cursor-pointer absolute right-4 top-1/2 -translate-y-1/2 inline-flex items-center justify-center text-[#999] hover:text-[#333] transition-colors"
-                                >
-                                    <X className="w-4 h-4" />
-                                </button>
-                            )}
-                        </div>
                     </div>
 
-                    <div className="self-stretch px-8 py-6 bg-white rounded-[20px] border border-[var(--stroke-interactive-neutral-default)] flex flex-col items-end gap-2">
+                    <div className="self-stretch px-8 py-6 bg-white rounded-[20px] border border-[var(--stroke-interactive-neutral-default)] flex flex-col items-start gap-4">
                         <div className="self-stretch text-black text-xl font-semibold leading-8">
                             작성자 정보
                         </div>
 
-                        <button
-                            type="button"
-                            onClick={() => setIsEditingWriter((prev) => !prev)}
-                            className="cursor-pointer text-sm font-normal underline leading-5 text-[#6C757D]"
-                        >
-                            {isEditingWriter ? "완료" : "변경하기"}
-                        </button>
-
-                        <div className="self-stretch p-5 bg-[var(--foundation-neutral-980)] rounded-[20px] flex items-center gap-2">
-                            {isEditingWriter ? (
-                                <>
-                                    <Input
-                                        value={writerName}
-                                        onChange={(e) => setWriterName(e.target.value)}
-                                        placeholder="이름을 입력해주세요"
-                                        className="h-12 rounded-[12px] border-[#E0E0E0] px-4 text-[15px]"
-                                    />
-                                    <Input
-                                        value={phoneNumber}
-                                        onChange={(e) => setPhoneNumber(formatPhone(e.target.value))}
-                                        placeholder="010-1234-5678"
-                                        className="h-12 rounded-[12px] border-[#E0E0E0] px-4 text-[15px]"
-                                    />
-                                    <Input
-                                        value={writerEmail}
-                                        onChange={(e) => setWriterEmail(e.target.value)}
-                                        placeholder="이메일을 입력해주세요"
-                                        className="h-12 rounded-[12px] border-[#E0E0E0] px-4 text-[15px]"
-                                    />
-                                </>
-                            ) : (
-                                <>
-                                    <div className="flex-1 text-[#1A1A1A] text-xl font-bold leading-7">
-                                        {writerName}
-                                    </div>
-
-                                    <div className="flex-1 flex flex-col items-end gap-2">
-                                        <div className="text-[#1A1A1A] text-lg font-bold leading-6">
-                                            {phoneNumber}
-                                        </div>
-                                        <div className="text-[#1A1A1A] text-base font-semibold leading-6">
-                                            {writerEmail}
-                                        </div>
-                                    </div>
-                                </>
-                            )}
-
+                        <div className="self-stretch grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div className="flex flex-col gap-2">
+                                <Label className="text-sm font-semibold text-[#666] ml-1">이름</Label>
+                                <Input
+                                    disabled
+                                    value={writerName}
+                                    onChange={(e) => setWriterName(e.target.value)}
+                                    placeholder="이름을 입력해주세요"
+                                    className="h-14 rounded-[12px] border-[#E0E0E0] px-4 text-[15px] focus-visible:border-[var(--foundation-primary-500)] focus-visible:ring-0 transition-all"
+                                />
+                            </div>
+                            <div className="flex flex-col gap-2">
+                                <Label className="text-sm font-semibold text-[#666] ml-1">이메일</Label>
+                                <Input
+                                    disabled
+                                    value={writerEmail}
+                                    onChange={(e) => setWriterEmail(e.target.value)}
+                                    placeholder="이메일을 입력해주세요"
+                                    className="h-14 rounded-[12px] border-[#E0E0E0] px-4 text-[15px] focus-visible:border-[var(--foundation-primary-500)] focus-visible:ring-0 transition-all"
+                                />
+                            </div>
+                            <div className="flex flex-col gap-2 md:col-span-2">
+                                <Label className="text-sm font-semibold text-[#666] ml-1">휴대폰 번호</Label>
+                                <Input
+                                    value={phoneNumber}
+                                    onChange={(e) => setPhoneNumber(formatPhone(e.target.value))}
+                                    placeholder="010-0000-0000"
+                                    className="h-14 rounded-[12px] border-[#E0E0E0] px-4 text-[15px] focus-visible:border-[var(--foundation-primary-500)] focus-visible:ring-0 transition-all"
+                                />
+                            </div>
                         </div>
                     </div>
 
@@ -353,12 +289,14 @@ export default function SupportWritePage() {
                     </div>
 
                     {/* 문의하기 버튼 */}
-                    <PrimaryButton
+                    <ActionButton
                         onClick={handleSubmit}
                         disabled={isSubmitting || !isFormValid}
+                        size="lg"
+                        className="w-full"
                     >
                         등록하기
-                    </PrimaryButton>
+                    </ActionButton>
                 </div>
             </div>
         </div>

--- a/goorm-gongbang/app/(protected)/my/tickets/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/tickets/page.tsx
@@ -1,86 +1,138 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { ChevronRight, ChevronsLeft, ChevronsRight, ChevronLeft } from "lucide-react";
 import { PaymentDepositModal } from "@/components/my/PaymentDepositModal";
 import { TicketDetailModal } from "@/components/my/TicketDetailModal";
 import { CancelTicketModal } from "@/components/my/CancelTicketModal";
-import { TicketCard, Ticket } from "@/components/my/TicketCard";
+import { TicketCard, Ticket, TicketStatus } from "@/components/my/TicketCard";
+import { getUpcomingTickets, getTicketDetail } from "@/lib/services";
+import type { UpcomingTicketItem } from "@/lib/types";
 
-const MOCK_TICKETS: Ticket[] = [
-  {
-    id: "1",
-    dDay: "D-Day",
-    status: "PAYMENT_WAITING",
-    count: 2,
-    matchTitle: "LG 트윈스 vs kt 위즈",
-    dateStr: "2026. 03. 28 (토) 14:00",
-    type: "블루석",
-    zone: "103",
-    seat: "G열 23, 24",
-    date: "3월 28일",
-    location: "잠실 경기장",
-    time: "14:00"
-  },
-  {
-    id: "2",
-    dDay: "D-1",
-    status: "RESERVED",
-    count: 3,
-    matchTitle: "LG 트윈스 vs kt 위즈",
-    dateStr: "2026. 03. 29 (일) 14:00",
-    type: "블루석",
-    zone: "103",
-    seat: "G열 23, 24, 25",
-    date: "3월 29일",
-    location: "잠실 경기장",
-    time: "14:00"
-  },
-  {
-    id: "3",
-    dDay: "D-4",
-    status: "UNDER_REVIEW",
-    count: 4,
-    matchTitle: "LG 트윈스 vs SSG 랜더스",
-    dateStr: "2026. 04. 01 (수) 14:00",
-    type: "레드석",
-    zone: "201",
-    seat: "A열 1, 2, 3, 4",
-    date: "4월 1일",
-    location: "잠실 경기장",
-    time: "14:00"
-  }
-];
-
-const MOCK_DEPOSIT_INFO = {
-  bankName: "국민",
-  accountNumber: "000-0000-0000-00",
-  accountHolder: "윤정빈",
-  amount: 42000,
-  deadline: "2026년 3월 24일 (화) 23:59",
+/* UpcomingTicketItem (API) → Ticket (UI) 매핑 */
+const API_STATUS_MAP: Record<string, TicketStatus> = {
+  PAYMENT_PENDING: "PAYMENT_WAITING",
+  PAID: "RESERVED",
+  RESERVED: "RESERVED",
+  UNDER_REVIEW: "UNDER_REVIEW",
 };
+
+function toTicket(item: UpcomingTicketItem): Ticket {
+  const d = new Date(item.match.matchAt);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const weekdays = ["일", "월", "화", "수", "목", "금", "토"];
+  const dateStr = `${d.getFullYear()}. ${pad(d.getMonth() + 1)}. ${pad(d.getDate())} (${weekdays[d.getDay()]}) ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  const date = `${d.getMonth() + 1}월 ${d.getDate()}일`;
+  const time = `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+
+  const type = item.seats[0]?.sectionName ?? "";
+  const zone = item.seats[0]?.blockCode ?? "";
+  const rowGroups = item.seats.reduce<Record<string, number[]>>((acc, s) => {
+    (acc[String(s.rowNo)] ??= []).push(s.seatNo);
+    return acc;
+  }, {});
+  const seat = Object.entries(rowGroups)
+    .map(([row, nums]) => `${row}열 ${nums.join(", ")}`)
+    .join(" / ");
+
+  const dDayLabel = item.dDay === 0 ? "D-Day" : `D-${item.dDay}`;
+
+  return {
+    id: String(item.ticketId),
+    dDay: dDayLabel,
+    status: API_STATUS_MAP[item.status] ?? "RESERVED",
+    statusLabel: item.statusLabel,
+    actions: item.actions,
+    dateStr,
+    matchTitle: `${item.match.homeClub.koName} vs ${item.match.awayClub.koName}`,
+    count: item.seatCount,
+    type,
+    zone,
+    seat,
+    date,
+    location: item.match.stadium.koName,
+    time,
+  };
+}
+
+function formatDepositDeadline(iso: string): string {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const weekdays = ["일", "월", "화", "수", "목", "금", "토"];
+  return `${d.getFullYear()}년 ${d.getMonth() + 1}월 ${d.getDate()}일 (${weekdays[d.getDay()]}) ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
 
 export default function TicketsPage() {
   const router = useRouter();
 
-  // TODO: [API 연동 가이드] - 경기 예정 티켓 목록 조회
-  // 1. 컴포넌트 마운트 시 리액트 쿼리(useQuery) 또는 useEffect + fetch 로 백엔드 API(예: GET /api/my/tickets)를 호출합니다.
-  // 2. 서버에서 받은 데이터를 setTickets 에 저장하여 상태를 업데이트합니다.
-  // 3. 로딩 상태(isLoading)를 추가하여 데이터 요청 중일 때는 스켈레톤 UI나 로딩 스피너를 보여주는 것이 좋습니다.
-  const [tickets, setTickets] = useState<Ticket[]>(MOCK_TICKETS);
+  const [tickets, setTickets] = useState<Ticket[]>([]);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(1);
+
+  const [depositInfo, setDepositInfo] = useState<{
+    bankName: string;
+    accountNumber: string;
+    accountHolder: string;
+    amount: number;
+    deadline: string;
+  } | null>(null);
   const [isDepositModalOpen, setIsDepositModalOpen] = useState(false);
 
-  // 티켓 상세 레이어 상태
   const [selectedTicket, setSelectedTicket] = useState<Ticket | null>(null);
   const [isTicketModalOpen, setIsTicketModalOpen] = useState(false);
-
-  // 티켓 취소 모달 상태
   const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
+  const [cancelInfo, setCancelInfo] = useState<{ paymentAmount: number; cancelFee: number } | null>(null);
+
+  const fetchedRef = useRef(false);
+
+  const fetchTickets = (page: number) => {
+    getUpcomingTickets({ page, size: 10 }).then((data) => {
+      setTickets(data.tickets.map(toTicket));
+      setTotalPages(data.pagination.totalPages);
+    });
+  };
+
+  useEffect(() => {
+    if (fetchedRef.current) return;
+    fetchedRef.current = true;
+    fetchTickets(currentPage);
+  }, []);
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+    fetchTickets(page);
+  };
 
   const handleOpenTicket = (ticket: Ticket) => {
     setSelectedTicket(ticket);
     setIsTicketModalOpen(true);
+  };
+
+  const handleDeposit = (ticket: Ticket) => {
+    getTicketDetail(Number(ticket.id)).then((detail) => {
+      if (!detail.virtualAccount) return;
+      setDepositInfo({
+        bankName: detail.virtualAccount.bank,
+        accountNumber: detail.virtualAccount.accountNumber,
+        accountHolder: detail.virtualAccount.holder,
+        amount: detail.payment?.totalAmount ?? 0,
+        deadline: formatDepositDeadline(detail.virtualAccount.depositDeadline),
+      });
+      setIsDepositModalOpen(true);
+    });
+  };
+
+  const handleCancel = (ticket: Ticket) => {
+    setSelectedTicket(ticket);
+    getTicketDetail(Number(ticket.id)).then((detail) => {
+      const totalAmount = detail.payment?.totalAmount ?? 0;
+      const feeRate = detail.cancellationPolicy?.feeRate ?? "0";
+      const rate = parseFloat(feeRate.replace("%", "")) / 100;
+      const cancelFee = Math.round(totalAmount * rate);
+      setCancelInfo({ paymentAmount: totalAmount, cancelFee });
+      setIsCancelModalOpen(true);
+    });
   };
 
   return (
@@ -129,53 +181,89 @@ export default function TicketsPage() {
                 key={ticket.id}
                 ticket={ticket}
                 onClick={handleOpenTicket}
-                onDeposit={(ticket) => setIsDepositModalOpen(true)}
-                onCancel={(ticket) => {
-                  setSelectedTicket(ticket);
-                  setIsCancelModalOpen(true);
-                }}
+                onDeposit={handleDeposit}
+                onCancel={handleCancel}
               />
             ))
           )}
         </div>
 
         {/* Pagination */}
-        <div className="mt-16 mb-8 flex items-center justify-center gap-5 text-[#999999] text-[15px]">
-          <button className="hover:text-[#1A1A1A] transition-colors"><ChevronsLeft size={16} /></button>
-          <button className="hover:text-[#1A1A1A] transition-colors"><ChevronLeft size={16} /></button>
-          <button className="text-[var(--foundation-primary-500)] font-bold text-[16px] underline underline-offset-4">1</button>
-          <button className="hover:text-[#1A1A1A] transition-colors"><ChevronRight size={16} /></button>
-          <button className="hover:text-[#1A1A1A] transition-colors"><ChevronsRight size={16} /></button>
-        </div>
+        {totalPages > 1 && (
+          <div className="mt-16 mb-8 flex items-center justify-center gap-5 text-[#999999] text-[15px]">
+            <button
+              className="hover:text-[#1A1A1A] transition-colors"
+              onClick={() => handlePageChange(0)}
+              disabled={currentPage === 0}
+            >
+              <ChevronsLeft size={16} />
+            </button>
+            <button
+              className="hover:text-[#1A1A1A] transition-colors"
+              onClick={() => handlePageChange(currentPage - 1)}
+              disabled={currentPage === 0}
+            >
+              <ChevronLeft size={16} />
+            </button>
+            {Array.from({ length: totalPages }, (_, i) => (
+              <button
+                key={i}
+                onClick={() => handlePageChange(i)}
+                className={
+                  currentPage === i
+                    ? "text-[var(--foundation-primary-500)] font-bold text-[16px] underline underline-offset-4"
+                    : "hover:text-[#1A1A1A] transition-colors"
+                }
+              >
+                {i + 1}
+              </button>
+            ))}
+            <button
+              className="hover:text-[#1A1A1A] transition-colors"
+              onClick={() => handlePageChange(currentPage + 1)}
+              disabled={currentPage === totalPages - 1}
+            >
+              <ChevronRight size={16} />
+            </button>
+            <button
+              className="hover:text-[#1A1A1A] transition-colors"
+              onClick={() => handlePageChange(totalPages - 1)}
+              disabled={currentPage === totalPages - 1}
+            >
+              <ChevronsRight size={16} />
+            </button>
+          </div>
+        )}
 
         {/* 입금 안내 모달 */}
-        <PaymentDepositModal
-          isOpen={isDepositModalOpen}
-          onClose={() => setIsDepositModalOpen(false)}
-          depositInfo={MOCK_DEPOSIT_INFO}
-        />
+        {depositInfo && (
+          <PaymentDepositModal
+            isOpen={isDepositModalOpen}
+            onClose={() => {
+              setIsDepositModalOpen(false);
+              setDepositInfo(null);
+            }}
+            depositInfo={depositInfo}
+          />
+        )}
 
         {/* 티켓 상세 모달 (Layer) */}
         <TicketDetailModal
           isOpen={isTicketModalOpen}
           onClose={() => setIsTicketModalOpen(false)}
           ticketInfo={selectedTicket}
+          ticketId={selectedTicket ? Number(selectedTicket.id) : undefined}
         />
 
         {/* 취소 모달 */}
         <CancelTicketModal
           isOpen={isCancelModalOpen}
-          onClose={() => setIsCancelModalOpen(false)}
+          onClose={() => { setIsCancelModalOpen(false); setCancelInfo(null); }}
           ticketInfo={selectedTicket}
-          // TODO: [API 연동 가이드] - 실제 API 응답 받은 티켓 세부 결제 정보(총 금액, 취소 수수료)를 바인딩 하세요.
-          paymentAmount={selectedTicket ? selectedTicket.count * 20000 + 2000 : 0}
-          cancelFee={2000}
+          ticketId={selectedTicket ? Number(selectedTicket.id) : undefined}
+          paymentAmount={cancelInfo?.paymentAmount ?? 0}
+          cancelFee={cancelInfo?.cancelFee ?? 0}
           onCancelSuccess={() => {
-            /* 
-              TODO: [API 연동 가이드] - 목록 UI 갱신 (Optimistic Update)
-              모달에서 취소 처리(API 200 OK)가 성공하면, 
-              여기서 리스트 API를 재조회(refetch) 하거나 아래처럼 프론트엔드 State에서만 즉각적으로 필터링하여 카드를 분리합니다.
-            */
             if (selectedTicket) {
               setTickets(prev => prev.filter(t => t.id !== selectedTicket.id));
             }

--- a/goorm-gongbang/components/my/CancelTicketModal.tsx
+++ b/goorm-gongbang/components/my/CancelTicketModal.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { cancelTicket } from "@/lib/services";
+import type { TicketCancelResult } from "@/lib/types";
 import { TicketInfo } from "./TicketDetailModal";
 
 interface CancelTicketModalProps {
     isOpen: boolean;
     onClose: () => void;
     ticketInfo: TicketInfo | null;
+    ticketId?: number;
     paymentAmount: number;
     cancelFee: number;
     onCancelSuccess?: () => void;
@@ -14,9 +17,11 @@ interface CancelTicketModalProps {
 
 type ModalStep = "CONFIRM" | "COMPLETE";
 
-export function CancelTicketModal({ isOpen, onClose, ticketInfo, paymentAmount, cancelFee, onCancelSuccess }: CancelTicketModalProps) {
+export function CancelTicketModal({ isOpen, onClose, ticketInfo, ticketId, paymentAmount, cancelFee, onCancelSuccess }: CancelTicketModalProps) {
     const [mounted, setMounted] = useState(false);
     const [step, setStep] = useState<ModalStep>("CONFIRM");
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [cancelResult, setCancelResult] = useState<TicketCancelResult | null>(null);
 
     useEffect(() => {
         setMounted(true);
@@ -25,7 +30,10 @@ export function CancelTicketModal({ isOpen, onClose, ticketInfo, paymentAmount, 
     // 모달이 닫히면 다시 첫 단계로 리셋
     useEffect(() => {
         if (!isOpen) {
-            setTimeout(() => setStep("CONFIRM"), 300); // 애니메이션 후 리셋
+            setTimeout(() => {
+                setStep("CONFIRM");
+                setCancelResult(null);
+            }, 300); // 애니메이션 후 리셋
         }
     }, [isOpen]);
 
@@ -34,30 +42,19 @@ export function CancelTicketModal({ isOpen, onClose, ticketInfo, paymentAmount, 
     const estimatedRefund = paymentAmount - cancelFee;
 
     const handleCancelProceed = async () => {
-        /*
-          TODO: [API 연동 가이드] - 티켓 예매 취소 처리
-          1. 버튼이 클릭되면 (isSubmitting = true) 로딩 상태를 주어 중복 클릭을 방지합니다.
-          2. 백엔드 취소 API (예: POST /api/v1/tickets/${ticketInfo.id}/cancel) 를 호출합니다.
-          3. 취소 수수료 등의 민감한 정보는 클라이언트 연산(paymentAmount - cancelFee)이 아닌, 
-             서버 API가 검증/계산하여 내려준 최종 응답(response)을 사용하는 것이 권장됩니다.
-        */
+        if (!ticketId || isSubmitting) return;
+        setIsSubmitting(true);
         try {
-            // ex) await handleCancelApi(ticketInfo.id);
-
-            // API 호출이 정상적으로 완료되었다고 가정하고 다음 UI 스텝으로 이동합니다.
+            const result = await cancelTicket(ticketId);
+            setCancelResult(result);
             setStep("COMPLETE");
-
-            // onCancelSuccess 콜백이 있다면 실행하여, 부모(page.tsx)의 목록 상태를 업데이트합니다.
             if (onCancelSuccess) {
                 onCancelSuccess();
             }
-        } catch (error) {
-            /* 
-              TODO: [API 연동 가이드] - 에러 핸들링
-              취소 과정에서 발생한 에러(ex: 이미 취소된 티켓, 네트워크 오류 등)를 catch 하면
-              toast 등을 띄워 사용자에게 알맞게 공지하거나 이전 상태로 롤백해야 합니다.
-            */
-            console.error("티켓 취소 실패:", error);
+        } catch {
+            // toast는 서비스 레이어에서 처리됨
+        } finally {
+            setIsSubmitting(false);
         }
     };
 
@@ -116,9 +113,10 @@ export function CancelTicketModal({ isOpen, onClose, ticketInfo, paymentAmount, 
                         </button>
                         <button
                             onClick={handleCancelProceed}
-                            className="flex-1 py-4 rounded-[12px] bg-[var(--foundation-red-500)] text-white text-[16px] font-bold hover:bg-[#E63946] transition-colors active:scale-[0.99]"
+                            disabled={isSubmitting}
+                            className="flex-1 py-4 rounded-[12px] bg-[var(--foundation-red-500)] text-white text-[16px] font-bold hover:bg-[#E63946] transition-colors active:scale-[0.99] disabled:opacity-60 disabled:cursor-not-allowed"
                         >
-                            취소 진행하기
+                            {isSubmitting ? "취소 처리 중..." : "취소 진행하기"}
                         </button>
                     </div>
                 </div>
@@ -132,6 +130,22 @@ export function CancelTicketModal({ isOpen, onClose, ticketInfo, paymentAmount, 
                         <p className="text-[15px] text-[#333] font-medium mb-3">
                             예매가 정상적으로 취소되었습니다.
                         </p>
+                        {cancelResult && (
+                            <div className="border border-[#E8E8E8] rounded-[8px] mb-5 overflow-hidden">
+                                <div className="flex justify-between items-center py-3 px-5 border-b border-[#E8E8E8] bg-[#FAFAFA]">
+                                    <span className="text-[14px] font-bold text-[#666]">총 결제 금액</span>
+                                    <span className="text-[15px] font-bold text-[#1A1A1A]">{cancelResult.totalAmount.toLocaleString()} 원</span>
+                                </div>
+                                <div className="flex justify-between items-center py-3 px-5 border-b border-[#E8E8E8]">
+                                    <span className="text-[14px] font-bold text-[#666]">취소 수수료</span>
+                                    <span className="text-[15px] font-bold text-[#666]">({cancelResult.cancellationFee.toLocaleString()} 원)</span>
+                                </div>
+                                <div className="flex justify-between items-center py-3 px-5 bg-[#FAFAFA]">
+                                    <span className="text-[14px] font-bold text-[#1A1A1A]">환불 금액</span>
+                                    <span className="text-[15px] font-bold text-[var(--foundation-red-500)]">{cancelResult.refundedAmount.toLocaleString()} 원</span>
+                                </div>
+                            </div>
+                        )}
                         <ul className="text-[14px] text-[#666] flex flex-col gap-1.5 list-disc pl-5">
                             <li>환불 진행 상황은 예매 내역에서 확인하실 수 있습니다.</li>
                             <li>환불 처리까지 영업일 기준 3~5일이 소요될 수 있습니다.</li>

--- a/goorm-gongbang/components/my/InquiryItem.tsx
+++ b/goorm-gongbang/components/my/InquiryItem.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useState, ReactNode } from "react";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { ChevronDown, ChevronUp, Paperclip } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { getInquiryDetail } from "@/lib/services";
+import type { InquiryDetail } from "@/lib/types";
 
 export interface Inquiry {
     id: number;
@@ -22,12 +24,34 @@ interface InquiryItemProps {
 
 export function InquiryItem({ item, isLast }: InquiryItemProps) {
     const [isExpanded, setIsExpanded] = useState(false);
+    const [detail, setDetail] = useState<InquiryDetail | null>(null);
+    const [isFetching, setIsFetching] = useState(false);
+
+    const handleToggle = async () => {
+        const next = !isExpanded;
+        setIsExpanded(next);
+
+        if (next && !detail) {
+            setIsFetching(true);
+            try {
+                const data = await getInquiryDetail(item.id);
+                setDetail(data);
+            } catch {
+                // toast는 getInquiryDetail 내부에서 처리
+            } finally {
+                setIsFetching(false);
+            }
+        }
+    };
+
+    const displayCategory = detail?.category ?? item.category;
+    const displayContent = detail?.content ?? item.description;
 
     return (
         <div className={cn("bg-white", !isLast && "border-b border-[#F1F3F5]")}>
             <button
                 type="button"
-                onClick={() => setIsExpanded(!isExpanded)}
+                onClick={handleToggle}
                 className={cn(
                     "w-full flex items-center justify-between px-3 py-5 text-left hover:bg-gray-50/50 transition-colors group",
                 )}
@@ -37,8 +61,8 @@ export function InquiryItem({ item, isLast }: InquiryItemProps) {
                     <span
                         className={cn(
                             "shrink-0 inline-flex items-center justify-center px-3 py-1.5 rounded-full border text-[12px] font-bold whitespace-nowrap",
-                            item.status === "COMPLETED" 
-                                ? "text-[var(--foundation-primary-500)] border-[var(--foundation-primary-500)]" 
+                            item.status === "COMPLETED"
+                                ? "text-[var(--foundation-primary-500)] border-[var(--foundation-primary-500)]"
                                 : "text-[#999999] border-[#DEDEDE]"
                         )}
                     >
@@ -67,21 +91,41 @@ export function InquiryItem({ item, isLast }: InquiryItemProps) {
             {/* 확대 영역: 문의 내용 + 답변 내용 */}
             {isExpanded && (
                 <div className="px-10 pb-8 animate-in fade-in slide-in-from-top-2 duration-200">
-                    {/* 문의 내용 (Question) */}
-                    <div className="mb-6 px-2">
-                        <div className="text-[13px] font-bold text-[var(--foundation-primary-500)] mb-1">
-                            [{item.category}]
-                        </div>
-                        <p className="text-[15px] font-medium text-[#333333] leading-relaxed whitespace-pre-wrap">
-                            {item.description}
-                        </p>
-                    </div>
+                    {isFetching ? (
+                        <div className="py-6 text-center text-[14px] text-[#ADB5BD]">불러오는 중...</div>
+                    ) : (
+                        <>
+                            {/* 문의 내용 (Question) */}
+                            <div className="mb-6 px-2">
+                                <div className="text-[13px] font-bold text-[var(--foundation-primary-500)] mb-1">
+                                    [{displayCategory}]
+                                </div>
+                                <p className="text-[15px] font-medium text-[#333333] leading-relaxed whitespace-pre-wrap">
+                                    {displayContent}
+                                </p>
+                            </div>
 
-                    {/* 답변 내용 (Answer Box) */}
-                    {item.answer && (
-                        <div className="bg-[#F8F9FA] rounded-[12px] p-8 text-[15px] leading-relaxed text-[#495057] font-medium">
-                            {item.answer}
-                        </div>
+                            {/* 첨부파일 다운로드 버튼 */}
+                            {detail?.fileAttached && detail.downloadUrl && (
+                                <div className="mb-4 px-2">
+                                    <a
+                                        href={detail.downloadUrl}
+                                        download
+                                        className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-[#DEE2E6] text-[13px] font-medium text-[#495057] hover:bg-[#F8F9FA] transition-colors"
+                                    >
+                                        <Paperclip className="w-4 h-4" />
+                                        첨부파일 다운로드
+                                    </a>
+                                </div>
+                            )}
+
+                            {/* 답변 내용 (Answer Box) */}
+                            {item.answer && (
+                                <div className="bg-[#F8F9FA] rounded-[12px] p-8 text-[15px] leading-relaxed text-[#495057] font-medium">
+                                    {item.answer}
+                                </div>
+                            )}
+                        </>
                     )}
                 </div>
             )}

--- a/goorm-gongbang/components/my/MyPageLayout.tsx
+++ b/goorm-gongbang/components/my/MyPageLayout.tsx
@@ -12,21 +12,15 @@
    4. 프로필 이미지 업로드 기능 추가
 =========================== */
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useAuthStore } from "@/stores/authStore";
 import { cn } from "@/lib/utils";
 import { ChevronRight } from "lucide-react";
+import { getMyPageProfile } from "@/lib/services";
+import type { MyPageProfileData } from "@/lib/types";
 
-/* ===========================
-   Mock 데이터
-=========================== */
-const MOCK_USER = {
-    nickname: "트윈스심장",
-    profileImage: null as string | null,
-    loginType: "KAKAO" as "KAKAO" | "EMAIL" | null,
-};
 
 /* ===========================
    타입
@@ -85,12 +79,20 @@ export function MyPageLayout({ children }: Props) {
 
     const isLoggedIn = bootstrapped && !!accessToken && !!user;
 
+    const [profileData, setProfileData] = useState<MyPageProfileData | null>(null);
+
     // Guard
     useEffect(() => {
         if (bootstrapped && !isLoggedIn) {
             router.replace("/login");
         }
     }, [bootstrapped, isLoggedIn, router]);
+
+    useEffect(() => {
+        if (isLoggedIn) {
+            getMyPageProfile().then(setProfileData).catch(() => {});
+        }
+    }, [isLoggedIn]);
 
     // 로그아웃
     const handleLogout = () => {
@@ -109,7 +111,10 @@ export function MyPageLayout({ children }: Props) {
 
     if (!isLoggedIn) return null;
 
-    const initial = MOCK_USER.nickname.charAt(0);
+    const nickname = profileData?.profile.nickname ?? "";
+    const profileImageUrl = profileData?.profile.profileImageUrl ?? "";
+    const snsProvider = profileData?.profile.snsProvider ?? "";
+    const initial = nickname.charAt(0);
 
     return (
         <div className="min-h-screen bg-[#F5F5F5]">
@@ -122,9 +127,9 @@ export function MyPageLayout({ children }: Props) {
                     <div className="flex items-center gap-4">
 
                         {/* 프로필 이미지 */}
-                        {MOCK_USER.profileImage ? (
+                        {profileImageUrl ? (
                             <img
-                                src={MOCK_USER.profileImage}
+                                src={profileImageUrl}
                                 alt="프로필"
                                 className="w-[60px] h-[60px] rounded-full object-cover flex-shrink-0"
                             />
@@ -142,11 +147,11 @@ export function MyPageLayout({ children }: Props) {
                             {/* 닉네임 + 소셜 뱃지 */}
                             <div className="flex items-center gap-2">
                                 <span className="text-[#1A1A1A] text-[17px] font-bold leading-6">
-                                    {MOCK_USER.nickname}
+                                    {nickname}
                                 </span>
-                                {MOCK_USER.loginType === "KAKAO" && (
+                                {snsProvider && (
                                     <span className="inline-flex items-center gap-1 bg-[#FEE500] text-[#000000] text-[10px] font-semibold px-2 py-0.5 rounded-full">
-                                        KAKAO
+                                        {snsProvider.toUpperCase()}
                                     </span>
                                 )}
                             </div>

--- a/goorm-gongbang/components/my/PreferenceForm.tsx
+++ b/goorm-gongbang/components/my/PreferenceForm.tsx
@@ -25,7 +25,7 @@
       → 저장 함수 handleSave → API 호출로 교체 (saveOnboardingPreferences 참고)
 =========================== */
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { toast } from "sonner";
 import { ChevronUp, ChevronDown } from "lucide-react";
 import { ChipButton } from "@/components/common/Button";
@@ -39,6 +39,8 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { getOnboardingPreferences, updateOnboardingPreferences } from "@/lib/services";
+import type { Viewpoint, SeatHeight, Section, SeatPositionPref, EnvironmentPref, MoodPref, ObstructionSensitivity, PriceMode } from "@/lib/types";
 
 /* ===========================
    타입 정의 (온보딩과 동일)
@@ -83,19 +85,82 @@ const clubOptions = [
 ] as const;
 
 /* ===========================
-   Mock 초기값
+   Forward 매핑 (UI → API enum)
 =========================== */
-const MOCK_VIEW: ViewPreference[] = ["중앙", "1루 내야", "3루 내야"];
-const MOCK_CHEER: CheerPreference = "응원석 인접";
-const MOCK_CLUB = clubOptions[0]; // 두산 베어스
-const MOCK_HEIGHT: HeightPreference = "중단";
-const MOCK_ZONE: ZonePreference = "중앙 쪽";
-const MOCK_VIEWTYPE: ViewTypePreference = "통로 선호";
-const MOCK_ENV: EnvPreference = "그늘 선호";
-const MOCK_MOOD: MoodPreference = "열정적인 응원";
-const MOCK_DIST: DistPreference = "보통";
-const MOCK_PRICE: PricePreference = "14,000원~ 17,000원";
-const MOCK_BLOCKS: number[] = [70, 71, 72, 80, 81, 82]; // 예시 선택 블록
+const VIEWPOINT_MAP: Record<ViewPreference, Viewpoint> = {
+    "중앙": "CENTER", "1루 내야": "INFIELD_1B", "3루 내야": "INFIELD_3B",
+    "외야(좌)": "OUTFIELD_L", "외야(중)": "OUTFIELD_C", "외야(우)": "OUTFIELD_R",
+};
+const SEAT_HEIGHT_MAP: Record<HeightPreference, SeatHeight> = {
+    하단: "LOW", 중단: "MID", 상단: "HIGH", 무관: "ANY",
+};
+const SECTION_MAP: Record<ZonePreference, Section> = {
+    "중앙 쪽": "MIDDLE", 중간: "CENTER_SIDE", "코너(파울라인)": "CORNER", 무관: "ANY",
+};
+const CHEER_MAP: Record<CheerPreference, "NEAR" | "FAR" | "ANY"> = {
+    "응원석 인접": "NEAR", "응원석 비인접": "FAR", 무관: "ANY",
+};
+const SEAT_POSITION_MAP: Record<ViewTypePreference, SeatPositionPref> = {
+    "통로 선호": "AISLE", "중앙 선호": "MIDDLE", 무관: "ANY",
+};
+const ENV_MAP: Record<EnvPreference, EnvironmentPref> = {
+    "그늘 선호": "SHADE", "햇빛 무관": "SUN_OK", 무관: "ANY",
+};
+const MOOD_MAP: Record<MoodPreference, MoodPref> = {
+    "열정적인 응원": "CHEERFUL", "조용한 관람": "QUIET", 무관: "ANY",
+};
+const OBSTRUCTION_MAP: Record<DistPreference, ObstructionSensitivity> = {
+    "안전망 민감": "NET_SENSITIVE", "난간·기둥 민감": "RAIL_PILLAR_SENSITIVE", 보통: "NORMAL", 무관: "ANY",
+};
+
+/* ===========================
+   Reverse 매핑 (API enum → UI)
+=========================== */
+const R_VIEWPOINT: Record<string, ViewPreference> = {
+    CENTER: "중앙", INFIELD_1B: "1루 내야", INFIELD_3B: "3루 내야",
+    OUTFIELD_L: "외야(좌)", OUTFIELD_C: "외야(중)", OUTFIELD_R: "외야(우)",
+};
+const R_HEIGHT: Record<string, HeightPreference> = {
+    LOW: "하단", MID: "중단", HIGH: "상단", ANY: "무관",
+};
+const R_SECTION: Record<string, ZonePreference> = {
+    MIDDLE: "중앙 쪽", CENTER_SIDE: "중간", CORNER: "코너(파울라인)", ANY: "무관",
+};
+const R_CHEER: Record<string, CheerPreference> = {
+    NEAR: "응원석 인접", FAR: "응원석 비인접", ANY: "무관",
+};
+const R_SEAT_POSITION: Record<string, ViewTypePreference> = {
+    AISLE: "통로 선호", MIDDLE: "중앙 선호", ANY: "무관",
+};
+const R_ENV: Record<string, EnvPreference> = {
+    SHADE: "그늘 선호", SUN_OK: "햇빛 무관", ANY: "무관",
+};
+const R_MOOD: Record<string, MoodPreference> = {
+    CHEERFUL: "열정적인 응원", QUIET: "조용한 관람", ANY: "무관",
+};
+const R_OBSTRUCTION: Record<string, DistPreference> = {
+    NET_SENSITIVE: "안전망 민감", RAIL_PILLAR_SENSITIVE: "난간·기둥 민감", NORMAL: "보통", ANY: "무관",
+};
+
+function priceFromApi(priceMode: PriceMode, priceMin: number, priceMax: number): PricePreference | null {
+    if (priceMode === "ANY") return "무관";
+    if (priceMin === 0 && priceMax === 13000) return "~ 13,000원";
+    if (priceMin === 14000 && priceMax === 17000) return "14,000원~ 17,000원";
+    if (priceMin === 18000 && priceMax === 29000) return "18,000원~ 29,000원";
+    if (priceMin === 30000) return "30,000원~ ";
+    return null;
+}
+
+function priceToPayload(p: PricePreference | null): { priceMode: PriceMode; priceMin: number | null; priceMax: number | null } {
+    if (!p || p === "무관") return { priceMode: "ANY", priceMin: null, priceMax: null };
+    switch (p) {
+        case "~ 13,000원": return { priceMode: "RANGE", priceMin: 0, priceMax: 13000 };
+        case "14,000원~ 17,000원": return { priceMode: "RANGE", priceMin: 14000, priceMax: 17000 };
+        case "18,000원~ 29,000원": return { priceMode: "RANGE", priceMin: 18000, priceMax: 29000 };
+        case "30,000원~ ": return { priceMode: "RANGE", priceMin: 30000, priceMax: null };
+        default: return { priceMode: "ANY", priceMin: null, priceMax: null };
+    }
+}
 
 /* ===========================
    유틸 함수
@@ -222,16 +287,6 @@ function QuestionSection({
 /* ===========================
    구분선 + 섹션 타이틀
 =========================== */
-function SectionDivider({ title }: { title: string }) {
-    return (
-        <div className="self-stretch flex items-center gap-3 pt-2">
-            <div className="text-xs font-bold text-[#999999] whitespace-nowrap">
-                {title}
-            </div>
-            <div className="flex-1 h-px bg-[#F0F0F0]" />
-        </div>
-    );
-}
 
 /* ===========================
    메인 컴포넌트
@@ -240,50 +295,90 @@ export function PreferenceForm() {
     const router = useRouter();
 
     /* Step 0: 블록 선택 */
-    const [selectedBlocks, setSelectedBlocks] = useState<number[]>(MOCK_BLOCKS);
+    const [selectedBlocks, setSelectedBlocks] = useState<number[]>([]);
 
     /* Step 1: 필수성 질문들 */
-    const [view, setView] = useState<ViewPreference[]>(MOCK_VIEW);
-    const [selectedClub, setSelectedClub] = useState<(typeof clubOptions)[number] | null>(MOCK_CLUB);
-    const [cheer, setCheer] = useState<CheerPreference | null>(MOCK_CHEER);
-    const [zone, setZone] = useState<ZonePreference | null>(MOCK_ZONE);
-    const [height, setHeight] = useState<HeightPreference | null>(MOCK_HEIGHT);
+    const [view, setView] = useState<ViewPreference[]>([]);
+    const [selectedClub, setSelectedClub] = useState<(typeof clubOptions)[number] | null>(null);
+    const [cheer, setCheer] = useState<CheerPreference | null>(null);
+    const [zone, setZone] = useState<ZonePreference | null>(null);
+    const [height, setHeight] = useState<HeightPreference | null>(null);
 
     /* Step 2: 단일 선택 */
-    const [viewType, setViewType] = useState<ViewTypePreference | null>(MOCK_VIEWTYPE);
-    const [env, setEnv] = useState<EnvPreference | null>(MOCK_ENV);
-    const [mood, setMood] = useState<MoodPreference | null>(MOCK_MOOD);
-    const [dist, setDist] = useState<DistPreference | null>(MOCK_DIST);
-    const [price, setPrice] = useState<PricePreference | null>(MOCK_PRICE);
+    const [viewType, setViewType] = useState<ViewTypePreference | null>(null);
+    const [env, setEnv] = useState<EnvPreference | null>(null);
+    const [mood, setMood] = useState<MoodPreference | null>(null);
+    const [dist, setDist] = useState<DistPreference | null>(null);
+    const [price, setPrice] = useState<PricePreference | null>(null);
 
     /* UI 관련 상태 */
     const [optionalOpen, setOptionalOpen] = useState(false);
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [isClubOpen, setIsClubOpen] = useState(false);
+    const [isSaving, setIsSaving] = useState(false);
 
-    /**
-     * 변경 사항이 있는지 확인하는 함수
-     */
+    /* dirty 체크용 초기값 스냅샷 */
+    const initialRef = useRef({
+        blocks: [] as number[], view: [] as ViewPreference[],
+        clubId: null as number | null, cheer: null as CheerPreference | null,
+        zone: null as ZonePreference | null, height: null as HeightPreference | null,
+        viewType: null as ViewTypePreference | null, env: null as EnvPreference | null,
+        mood: null as MoodPreference | null, dist: null as DistPreference | null,
+        price: null as PricePreference | null,
+    });
+
+    /* API에서 기존 선호 데이터 로드 */
+    useEffect(() => {
+        getOnboardingPreferences().then((data) => {
+            const sorted = [...data.preferences].sort((a, b) => a.priority - b.priority);
+            const pref1 = sorted[0];
+
+            const loadedBlocks = data.preferredBlockIds;
+            const loadedView = sorted.map((p) => R_VIEWPOINT[p.viewpoint]).filter(Boolean) as ViewPreference[];
+            const loadedClub = clubOptions.find((c) => c.id === data.favoriteClubId) ?? null;
+            const loadedCheer = R_CHEER[data.cheerProximityPref] ?? null;
+            const loadedZone = pref1 ? (R_SECTION[pref1.section ?? "ANY"] ?? null) : null;
+            const loadedHeight = pref1 ? (R_HEIGHT[pref1.seatHeight ?? "ANY"] ?? null) : null;
+            const loadedViewType = pref1 ? (R_SEAT_POSITION[pref1.seatPositionPref ?? "ANY"] ?? null) : null;
+            const loadedEnv = pref1 ? (R_ENV[pref1.environmentPref ?? "ANY"] ?? null) : null;
+            const loadedMood = pref1 ? (R_MOOD[pref1.moodPref ?? "ANY"] ?? null) : null;
+            const loadedDist = pref1 ? (R_OBSTRUCTION[pref1.obstructionSensitivity ?? "ANY"] ?? null) : null;
+            const loadedPrice = pref1 ? priceFromApi(pref1.priceMode ?? "ANY", pref1.priceMin ?? 0, pref1.priceMax ?? 0) : null;
+
+            setSelectedBlocks(loadedBlocks);
+            setView(loadedView);
+            setSelectedClub(loadedClub);
+            setCheer(loadedCheer);
+            setZone(loadedZone);
+            setHeight(loadedHeight);
+            setViewType(loadedViewType);
+            setEnv(loadedEnv);
+            setMood(loadedMood);
+            setDist(loadedDist);
+            setPrice(loadedPrice);
+
+            initialRef.current = {
+                blocks: loadedBlocks, view: loadedView,
+                clubId: loadedClub?.id ?? null, cheer: loadedCheer,
+                zone: loadedZone, height: loadedHeight,
+                viewType: loadedViewType, env: loadedEnv,
+                mood: loadedMood, dist: loadedDist, price: loadedPrice,
+            };
+        }).catch(() => {});
+    }, []);
+
     const checkIsDirty = () => {
-        const isBlocksDirty = JSON.stringify([...selectedBlocks].sort()) !== JSON.stringify([...MOCK_BLOCKS].sort());
-        const isViewDirty = JSON.stringify(view) !== JSON.stringify(MOCK_VIEW);
-        const isClubDirty = selectedClub?.id !== MOCK_CLUB.id;
-        const isCheerDirty = cheer !== MOCK_CHEER;
-        const isZoneDirty = zone !== MOCK_ZONE;
-        const isHeightDirty = height !== MOCK_HEIGHT;
-        const isOtherDirty =
-            viewType !== MOCK_VIEWTYPE ||
-            env !== MOCK_ENV ||
-            mood !== MOCK_MOOD ||
-            dist !== MOCK_DIST ||
-            price !== MOCK_PRICE;
-
-        return isBlocksDirty || isViewDirty || isClubDirty || isCheerDirty || isZoneDirty || isHeightDirty || isOtherDirty;
+        const s = initialRef.current;
+        return (
+            JSON.stringify([...selectedBlocks].sort()) !== JSON.stringify([...s.blocks].sort()) ||
+            JSON.stringify(view) !== JSON.stringify(s.view) ||
+            (selectedClub?.id ?? null) !== s.clubId ||
+            cheer !== s.cheer || zone !== s.zone || height !== s.height ||
+            viewType !== s.viewType || env !== s.env ||
+            mood !== s.mood || dist !== s.dist || price !== s.price
+        );
     };
 
-    /**
-     * 뒤로가기 클릭 핸들러
-     */
     const handleBackClick = () => {
         if (checkIsDirty()) {
             setIsModalOpen(true);
@@ -292,34 +387,54 @@ export function PreferenceForm() {
         }
     };
 
-    /**
-     * 블록 토글 핸들러
-     */
     const handleBlockToggle = (idx: number) => {
         setSelectedBlocks((prev) =>
             prev.includes(idx) ? prev.filter((i) => i !== idx) : [...prev, idx]
         );
     };
 
-    /* 저장
-     * [TODO] 실제 API 연동 시 가이드 (onboarding 통합 시 필수 작업)
-     * 1. lib/services의 saveOnboardingPreferences API 사용
-     * 2. 서버 Enum으로 변환하기 위해 아래 매핑 상수와 통합 필요:
-     *    - VIEWPOINT_MAP, SEAT_HEIGHT_MAP, SECTION_MAP (onboarding/page.tsx)
-     *    - SEAT_POSITION_MAP, ENV_MAP, MOOD_MAP, OBSTRUCTION_MAP (onboarding/option/page.tsx)
-     */
-    const handleSave = () => {
-        const payload = {
-            step1: {
-                view: view.map((v, i) => ({ priority: i + 1, value: v })),
-                clubId: selectedClub?.id,
-                cheer,
-                zone,
-                height,
-            },
-            step2: { viewType, env, mood, dist, price },
-        };
-        toast.success("내블럭 및 선호 데이터가 업데이트되었습니다.");
+    const handleSave = async () => {
+        if (!selectedClub || !cheer || view.length === 0) {
+            toast.error("필수 항목을 모두 입력해주세요.");
+            return;
+        }
+
+        const preferences = view.map((v, i) =>
+            i === 0
+                ? {
+                    priority: 1 as const,
+                    viewpoint: VIEWPOINT_MAP[v],
+                    seatHeight: height ? SEAT_HEIGHT_MAP[height] : "ANY" as const,
+                    section: zone ? SECTION_MAP[zone] : "ANY" as const,
+                    seatPositionPref: viewType ? SEAT_POSITION_MAP[viewType] : "ANY" as const,
+                    environmentPref: env ? ENV_MAP[env] : "ANY" as const,
+                    moodPref: mood ? MOOD_MAP[mood] : "ANY" as const,
+                    obstructionSensitivity: dist ? OBSTRUCTION_MAP[dist] : "ANY" as const,
+                    ...priceToPayload(price),
+                }
+                : {
+                    priority: (i + 1) as 2 | 3,
+                    viewpoint: VIEWPOINT_MAP[v],
+                }
+        );
+
+        try {
+            setIsSaving(true);
+            await updateOnboardingPreferences({
+                favoriteClubId: selectedClub.id,
+                cheerProximityPref: CHEER_MAP[cheer],
+                preferredBlockIds: selectedBlocks,
+                preferences,
+            });
+            initialRef.current = {
+                blocks: selectedBlocks, view,
+                clubId: selectedClub.id, cheer,
+                zone, height, viewType, env, mood, dist, price,
+            };
+            toast.success("선호 데이터가 업데이트되었습니다.");
+        } finally {
+            setIsSaving(false);
+        }
     };
 
     return (
@@ -570,9 +685,10 @@ export function PreferenceForm() {
             <button
                 type="button"
                 onClick={handleSave}
-                className="w-full py-3.5 bg-[var(--foundation-primary-500)] hover:bg-[var(--foundation-primary-600)] active:scale-[0.99] text-white text-sm font-semibold rounded-[12px] transition-all"
+                disabled={isSaving}
+                className="w-full py-3.5 bg-[var(--foundation-primary-500)] hover:bg-[var(--foundation-primary-600)] active:scale-[0.99] text-white text-sm font-semibold rounded-[12px] transition-all disabled:opacity-60 disabled:cursor-not-allowed"
             >
-                저장하기
+                {isSaving ? "저장 중..." : "저장하기"}
             </button>
 
             {/* ─── 확인 모달 ─── */}

--- a/goorm-gongbang/components/my/ProfileEditForm.tsx
+++ b/goorm-gongbang/components/my/ProfileEditForm.tsx
@@ -25,19 +25,32 @@ export function ProfileEditForm() {
         if (fetchedRef.current) return;
         fetchedRef.current = true;
 
-        getAccountInfo().then((data) => {
-            setEmail(data.email);
-            setNickname(data.nickname);
-            setTempNickname(data.nickname);
-            setProfileImageUrl(data.profileImageUrl);
-        });
+        getAccountInfo()
+            .then((data) => {
+                setEmail(data.email);
+                setNickname(data.nickname);
+                setTempNickname(data.nickname);
+                setProfileImageUrl(data.profileImageUrl);
+            })
+            .catch((err) => {
+                toast.error(err.message || "계정 정보를 불러오지 못했습니다.");
+            });
     }, []);
 
     const handleSave = async () => {
-        await updateNickname({ nickname: tempNickname });
-        setNickname(tempNickname);
-        setIsEditing(false);
-        toast.success("개인정보가 업데이트되었습니다");
+        if (!tempNickname.trim()) {
+            toast.error("닉네임을 입력해주세요.");
+            return;
+        }
+
+        try {
+            await updateNickname({ nickname: tempNickname });
+            setNickname(tempNickname);
+            setIsEditing(false);
+            toast.success("개인정보가 업데이트되었습니다");
+        } catch (err: any) {
+            toast.error(err.message || "닉네임 수정에 실패했습니다.");
+        }
     };
 
     return (

--- a/goorm-gongbang/components/my/ProfileEditForm.tsx
+++ b/goorm-gongbang/components/my/ProfileEditForm.tsx
@@ -1,28 +1,40 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { toast } from "sonner";
 import { SquarePen, Check } from "lucide-react";
+import Image from "next/image";
+import { getAccountInfo, updateNickname } from "@/lib/services";
 
 /* ===========================
    개인정보 수정 폼
    - 계정 정보: 이메일(조회), 닉네임(수정), 본인 인증(조회)
    - 닉네임: 클릭 → input 전환, Enter/체크 아이콘으로 저장, ESC로 취소
-   - 저장 시: toast (API 미연동)
-
-   [TODO] API 연동 시
-   - mock 데이터("트윈스심장", "twins@email.com") → 실제 유저 정보로 교체
-   - handleSave → PATCH /api/users/me { nickname } 호출
-   - 닉네임 중복 / 유효성 검증 추가
-   - 본인 인증 미완료 상태 UI 추가 (현재는 "본인 인증 완료"로 하드코딩)
+   - 저장 시: toast
 =========================== */
 
 export function ProfileEditForm() {
-    const [nickname, setNickname] = useState("트윈스심장");
+    const [email, setEmail] = useState("");
+    const [profileImageUrl, setProfileImageUrl] = useState("");
+    const [nickname, setNickname] = useState("");
     const [isEditing, setIsEditing] = useState(false);
     const [tempNickname, setTempNickname] = useState(nickname);
+    const fetchedRef = useRef(false);
 
-    const handleSave = () => {
+    useEffect(() => {
+        if (fetchedRef.current) return;
+        fetchedRef.current = true;
+
+        getAccountInfo().then((data) => {
+            setEmail(data.email);
+            setNickname(data.nickname);
+            setTempNickname(data.nickname);
+            setProfileImageUrl(data.profileImageUrl);
+        });
+    }, []);
+
+    const handleSave = async () => {
+        await updateNickname({ nickname: tempNickname });
         setNickname(tempNickname);
         setIsEditing(false);
         toast.success("개인정보가 업데이트되었습니다");
@@ -39,10 +51,24 @@ export function ProfileEditForm() {
                 <div className="h-px bg-[#F0F0F0] mb-5" />
 
                 <div className="flex flex-col gap-7">
+                    {/* 프로필 이미지 */}
+                    {profileImageUrl && (
+                        <div className="flex items-center justify-between">
+                            <span className="text-sm font-medium text-[#1A1A1A]">프로필 이미지</span>
+                            <Image
+                                src={profileImageUrl}
+                                alt="프로필 이미지"
+                                width={40}
+                                height={40}
+                                className="rounded-full object-cover"
+                            />
+                        </div>
+                    )}
+
                     {/* 이메일 */}
                     <div className="flex items-center justify-between">
                         <span className="text-sm font-medium text-[#1A1A1A]">이메일</span>
-                        <span className="text-[15px] text-[#1A1A1A]">twins@email.com</span>
+                        <span className="text-[15px] text-[#1A1A1A]">{email}</span>
                     </div>
 
                     {/* 닉네임 (수정 가능 스타일) */}

--- a/goorm-gongbang/components/my/ReservationItem.tsx
+++ b/goorm-gongbang/components/my/ReservationItem.tsx
@@ -9,28 +9,32 @@ interface ReservationItemProps {
     onActionClick: (e: React.MouseEvent, item: Reservation) => void;
 }
 
-export function ReservationItem({ item, index, isLast, onActionClick }: ReservationItemProps) {
+export function ReservationItem({ item, isLast, onActionClick }: ReservationItemProps) {
     const router = useRouter();
 
-    // 오늘 이전 날짜 판별
+    // 오늘 이전/당일 날짜 판별
     const matchDateStr = item.date.split(" (")[0].replace(/\./g, "-");
     const matchDate = new Date(matchDateStr);
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     const isPastMatch = matchDate.getTime() < today.getTime();
+    const isDDay = matchDate.getTime() === today.getTime();
 
-    const showActionBtn = (item.status === "PAYMENT_WAITING" || item.status === "RESERVED" || item.status === "UNDER_REVIEW") && !isPastMatch;
+    const showActionBtn = (item.status === "PAYMENT_PENDING" || item.status === "PAID" || item.status === "RESERVED" || item.status === "UNDER_REVIEW") && !isPastMatch;
 
-    // 진행 상태별 뱃지 배경색 렌더링 도우미 함수 
+    // 진행 상태별 뱃지 배경색 렌더링 도우미 함수
     const getBadgeColor = (status: ReservationStatus) => {
         switch (status) {
-            case "PAYMENT_WAITING":
-                return "bg-[var(--foundation-primary-500)]"; // 초록색 테마
+            case "PAYMENT_PENDING":
+                return "bg-[var(--foundation-primary-500)]"; // 초록색
+            case "PAID":
             case "RESERVED":
                 return "bg-[#3B82F6]"; // 파란색
             case "UNDER_REVIEW":
-                return "bg-[var(--foundation-orange-500)]"; // 주황색 (확인 필요)
+                return "bg-[var(--foundation-orange-500)]"; // 주황색
+            case "CANCEL_REQUESTED":
             case "CANCEL_PROCESSING":
+            case "CANCELLED":
             case "REFUND_PROCESSING":
             case "CANCEL_COMPLETED":
             case "REFUND_COMPLETED":
@@ -62,12 +66,12 @@ export function ReservationItem({ item, index, isLast, onActionClick }: Reservat
                 </div>
 
                 {/* 버튼 렌더링 */}
-                {showActionBtn && (
+                {showActionBtn && !(isDDay && (item.status === "PAID" || item.status === "RESERVED")) && (
                     <button
                         className="flex items-center text-[13px] font-bold text-[#666] hover:text-[#1A1A1A] transition-colors"
                         onClick={(e) => onActionClick(e, item)}
                     >
-                        {item.status === "PAYMENT_WAITING" ? "입금하기" : item.status === "UNDER_REVIEW" ? "문의하기" : "취소하기"}
+                        {item.status === "PAYMENT_PENDING" ? "입금하기" : item.status === "UNDER_REVIEW" ? "문의하기" : "취소하기"}
                         <ChevronRight size={14} className="ml-0.5" />
                     </button>
                 )}

--- a/goorm-gongbang/components/my/ReservationItem.tsx
+++ b/goorm-gongbang/components/my/ReservationItem.tsx
@@ -7,9 +7,10 @@ interface ReservationItemProps {
     index: number;
     isLast: boolean;
     onActionClick: (e: React.MouseEvent, item: Reservation) => void;
+    isLoading?: boolean;
 }
 
-export function ReservationItem({ item, isLast, onActionClick }: ReservationItemProps) {
+export function ReservationItem({ item, isLast, onActionClick, isLoading }: ReservationItemProps) {
     const router = useRouter();
 
     // 오늘 이전/당일 날짜 판별
@@ -68,11 +69,12 @@ export function ReservationItem({ item, isLast, onActionClick }: ReservationItem
                 {/* 버튼 렌더링 */}
                 {showActionBtn && !(isDDay && (item.status === "PAID" || item.status === "RESERVED")) && (
                     <button
-                        className="flex items-center text-[13px] font-bold text-[#666] hover:text-[#1A1A1A] transition-colors"
+                        className="flex items-center text-[13px] font-bold text-[#666] hover:text-[#1A1A1A] transition-colors disabled:opacity-40 disabled:pointer-events-none"
                         onClick={(e) => onActionClick(e, item)}
+                        disabled={isLoading}
                     >
-                        {item.status === "PAYMENT_PENDING" ? "입금하기" : item.status === "UNDER_REVIEW" ? "문의하기" : "취소하기"}
-                        <ChevronRight size={14} className="ml-0.5" />
+                        {isLoading ? "처리 중..." : (item.status === "PAYMENT_PENDING" ? "입금하기" : item.status === "UNDER_REVIEW" ? "문의하기" : "취소하기")}
+                        {!isLoading && <ChevronRight size={14} className="ml-0.5" />}
                     </button>
                 )}
             </div>

--- a/goorm-gongbang/components/my/TicketCard.tsx
+++ b/goorm-gongbang/components/my/TicketCard.tsx
@@ -3,11 +3,19 @@ import { TicketInfo } from "@/components/my/TicketDetailModal";
 
 export type TicketStatus = "PAYMENT_WAITING" | "RESERVED" | "UNDER_REVIEW";
 
+export interface TicketActions {
+    canDeposit: boolean;
+    canCancel: boolean;
+    canViewDetail: boolean;
+}
+
 export interface Ticket extends TicketInfo {
     id: string;
-    dDay: string; // Legacy/API string, will be dynamically calculated
+    dDay: string;
     status: TicketStatus;
     dateStr: string;
+    actions?: TicketActions;
+    statusLabel?: string;
 }
 
 interface TicketCardProps {
@@ -18,95 +26,85 @@ interface TicketCardProps {
 }
 
 export function TicketCard({ ticket, onClick, onDeposit, onCancel }: TicketCardProps) {
-    // 오늘 이전 날짜 판별 (과거 경기 체크)
-    const matchDateStr = ticket.dateStr.split(" (")[0].replace(/\./g, "-");
-    const matchDate = new Date(matchDateStr);
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const timeDiff = matchDate.getTime() - today.getTime();
-    const diffDays = Math.ceil(timeDiff / (1000 * 3600 * 24));
-    const isPastMatch = diffDays < 0;
+    const isWaiting = ticket.actions ? ticket.actions.canDeposit : ticket.status === "PAYMENT_WAITING";
+    const isUnderReview = ticket.status === "UNDER_REVIEW";
 
-    let calculatedDDay = "";
-    if (diffDays === 0) {
-        calculatedDDay = "D-Day";
-    } else if (diffDays > 0) {
-        calculatedDDay = `D-${diffDays}`;
-    } else {
-        calculatedDDay = `D+${Math.abs(diffDays)}`;
-    }
-
-    // Badge Styles
-    const isDDay = calculatedDDay === "D-Day";
+    // D-Day 뱃지 표시
+    const dDayLabel = ticket.dDay;
+    const isDDay = dDayLabel === "D-Day";
     const dDayColor = isDDay ? "var(--foundation-pink-500)" : "var(--foundation-primary-500)";
 
-    // Card Styles
-    const isWaiting = ticket.status === "PAYMENT_WAITING";
-    const isUnderReview = ticket.status === "UNDER_REVIEW";
+    const canCancel = !isDDay && (ticket.actions ? ticket.actions.canCancel : ticket.status === "RESERVED");
+
+    // 클릭 가능 여부 (입금 대기 상태는 클릭 불가)
+    const isClickable = !isWaiting;
 
     return (
         <div
-            className={`bg-white rounded-xl p-6 border border-[#E8E8E8] flex flex-col transition-all ${!isWaiting ? "hover:border-[var(--foundation-primary-500)] hover:shadow-sm cursor-pointer" : ""}`}
-            onClick={!isWaiting ? () => onClick(ticket) : undefined}
+            className={`bg-white rounded-xl p-6 border border-[#E8E8E8] flex flex-col transition-all ${isClickable ? "hover:border-[var(--foundation-primary-500)] hover:shadow-sm cursor-pointer" : ""}`}
+            onClick={isClickable ? () => onClick(ticket) : undefined}
         >
             {/* 상단: 뱃지들 & 우측 버튼 */}
             <div className="flex justify-between items-center mb-5">
                 <div className="flex items-center gap-2">
                     {/* D-Day 뱃지 */}
                     <div
-                        className={`px-[10px] py-[3px] rounded-[100px] border text-[13px] font-bold`}
+                        className="px-[10px] py-[3px] rounded-[100px] border text-[13px] font-bold"
                         style={{ color: dDayColor, borderColor: dDayColor, backgroundColor: "#ffffff" }}
                     >
-                        {calculatedDDay}
+                        {dDayLabel}
                     </div>
                     {/* 입금 대기 뱃지 */}
                     {isWaiting && (
-                        <div
-                            className="px-[10px] py-[4px] rounded-[100px] text-white text-[13px] font-bold bg-[var(--foundation-primary-500)]"
-                        >
-                            입금 대기
+                        <div className="px-[10px] py-[4px] rounded-[100px] text-white text-[13px] font-bold bg-[var(--foundation-primary-500)]">
+                            {ticket.statusLabel ?? "입금 대기"}
                         </div>
                     )}
                     {/* 정밀 확인 중 뱃지 */}
                     {isUnderReview && (
-                        <div
-                            className="px-[10px] py-[4px] rounded-[100px] text-white text-[13px] font-bold bg-[var(--foundation-orange-500)]"
-                        >
-                            정밀 확인 중
+                        <div className="px-[10px] py-[4px] rounded-[100px] text-white text-[13px] font-bold bg-[var(--foundation-orange-500)]">
+                            {ticket.statusLabel ?? "정밀 확인 중"}
                         </div>
                     )}
                 </div>
 
                 {/* 우측 상단 액션 버튼 */}
                 <div>
-                    {!isPastMatch && (
-                        isWaiting ? (
-                            <button
-                                className="flex items-center text-[15px] font-bold text-[var(--foundation-primary-500)] hover:underline"
-                                onClick={(e) => {
-                                    e.stopPropagation();
-                                    onDeposit(ticket);
-                                }}
-                            >
-                                입금하기 <ChevronRight size={18} className="ml-0.5" />
-                            </button>
-                        ) : (
-                            <button
-                                className="flex items-center text-[15px] font-bold text-[#333333] hover:underline"
-                                onClick={(e) => {
-                                    e.stopPropagation();
-                                    if (isUnderReview) {
-                                        // 문의하기 (Reservations 페이지와 동일하게 처리하도록 유도하거나, Support 페이지로 이동)
-                                        window.location.href = "/my/support";
-                                    } else {
-                                        onCancel(ticket);
-                                    }
-                                }}
-                            >
-                                {isUnderReview ? "문의하기" : "취소하기"} <ChevronRight size={18} className="ml-0.5" />
-                            </button>
-                        )
-                    )}
+                    {isWaiting ? (
+                        <button
+                            className="flex items-center text-[15px] font-bold text-[var(--foundation-primary-500)] hover:underline"
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                onDeposit(ticket);
+                            }}
+                        >
+                            입금하기 <ChevronRight size={18} className="ml-0.5" />
+                        </button>
+                    ) : canCancel ? (
+                        <button
+                            className="flex items-center text-[15px] font-bold text-[#333333] hover:underline"
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                onCancel(ticket);
+                            }}
+                        >
+                            취소하기 <ChevronRight size={18} className="ml-0.5" />
+                        </button>
+                    ) : isUnderReview ? (
+                        <button
+                            className="flex items-center text-[15px] font-bold text-[#333333] hover:underline"
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                window.location.href = "/my/support";
+                            }}
+                        >
+                            문의하기 <ChevronRight size={18} className="ml-0.5" />
+                        </button>
+                    ) : ticket.status === "RESERVED" ? (
+                        <span className="text-[13px] font-medium text-[#999999]">
+                            당일 경기는 취소가 불가능합니다.
+                        </span>
+                    ) : null}
                 </div>
             </div>
 

--- a/goorm-gongbang/components/my/TicketDetailModal.tsx
+++ b/goorm-gongbang/components/my/TicketDetailModal.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Image from "next/image";
 import { RotateCcw } from "lucide-react";
-import { QrCode } from "lucide-react";
+import { QRCodeSVG } from "qrcode.react";
+import { getTicketQr } from "@/lib/services";
+import { ApiError } from "@/lib/api/error";
+import type { TicketQrData } from "@/lib/types";
 
 export interface TicketInfo {
     matchTitle: string;
@@ -22,35 +24,55 @@ interface TicketDetailModalProps {
     isOpen: boolean;
     onClose: () => void;
     ticketInfo: TicketInfo | null;
+    ticketId?: number;
 }
 
-export function TicketDetailModal({ isOpen, onClose, ticketInfo }: TicketDetailModalProps) {
+export function TicketDetailModal({ isOpen, onClose, ticketInfo, ticketId }: TicketDetailModalProps) {
     const [mounted, setMounted] = useState(false);
-    const [timeLeft, setTimeLeft] = useState(180); // 3분 = 180초
+    const [timeLeft, setTimeLeft] = useState(0);
     const [refreshKey, setRefreshKey] = useState(0);
+    const [qrData, setQrData] = useState<TicketQrData | null>(null);
+    const [qrLoading, setQrLoading] = useState(false);
+    const [qrUnavailableMessage, setQrUnavailableMessage] = useState<string | null>(null);
 
     useEffect(() => {
         setMounted(true);
     }, []);
 
+    // QR 데이터 fetch
     useEffect(() => {
-        let timer: NodeJS.Timeout;
-        if (isOpen) {
-            setTimeLeft(180); // 열릴 때마다 3분 초기화
-            timer = setInterval(() => {
-                setTimeLeft((prev) => {
-                    if (prev <= 1) {
-                        clearInterval(timer);
-                        return 0;
-                    }
-                    return prev - 1;
-                });
-            }, 1000);
-        }
-        return () => {
-            if (timer) clearInterval(timer);
-        };
-    }, [isOpen, refreshKey]);
+        if (!isOpen || !ticketId || ticketInfo?.status === "UNDER_REVIEW") return;
+        setQrData(null);
+        setQrUnavailableMessage(null);
+        setQrLoading(true);
+        getTicketQr(ticketId)
+            .then((data) => {
+                setQrData(data);
+                const remaining = Math.max(0, Math.floor((new Date(data.expiresAt).getTime() - Date.now()) / 1000));
+                setTimeLeft(remaining);
+            })
+            .catch((err) => {
+                if (err instanceof ApiError && err.status === 400) {
+                    setQrUnavailableMessage(err.message || "아직 입장 가능 시간이 아닙니다.");
+                }
+            })
+            .finally(() => setQrLoading(false));
+    }, [isOpen, ticketId, refreshKey]);
+
+    // 카운트다운
+    useEffect(() => {
+        if (!isOpen || !qrData || timeLeft <= 0) return;
+        const timer = setInterval(() => {
+            setTimeLeft((prev) => {
+                if (prev <= 1) {
+                    clearInterval(timer);
+                    return 0;
+                }
+                return prev - 1;
+            });
+        }, 1000);
+        return () => clearInterval(timer);
+    }, [isOpen, qrData]);
 
     if (!mounted || !isOpen || !ticketInfo) return null;
 
@@ -72,6 +94,12 @@ export function TicketDetailModal({ isOpen, onClose, ticketInfo }: TicketDetailM
         const m = Math.floor(seconds / 60);
         const s = seconds % 60;
         return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+    };
+
+    const formatExpiresAt = (iso: string) => {
+        const d = new Date(iso);
+        const pad = (n: number) => String(n).padStart(2, "0");
+        return `${d.getFullYear()}.${pad(d.getMonth() + 1)}.${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
     };
 
     const handleRefresh = () => {
@@ -133,7 +161,7 @@ export function TicketDetailModal({ isOpen, onClose, ticketInfo }: TicketDetailM
                                         본인이 직접 진행한 예매라면<br />
                                         고객센터로 문의해 주세요.
                                     </p>
-                                    <button 
+                                    <button
                                         onClick={() => window.location.href = "/my/support"}
                                         className="mt-4 px-6 py-2.5 rounded-[12px] border border-[#DEDEDE] text-[14px] font-bold text-[#666] hover:bg-gray-50 transition-colors"
                                     >
@@ -142,32 +170,47 @@ export function TicketDetailModal({ isOpen, onClose, ticketInfo }: TicketDetailM
                                 </div>
                             ) : (
                                 <>
-                                    {/* 실 QR 코드 이미지 */}
+                                    {/* QR 코드 영역 */}
                                     <div className="w-[190px] h-[190px] mb-4 flex items-center justify-center relative">
-                                        <Image
-                                            src="/qr-code.svg"
-                                            alt="QR Code"
-                                            fill
-                                            className={`object-contain transition-opacity duration-300 ${timeLeft === 0 ? "opacity-20" : ""}`}
-                                            unoptimized
-                                        />
-                                        {timeLeft === 0 && (
-                                            <div className="absolute inset-0 flex flex-col items-center justify-center">
-                                                <button
-                                                    onClick={handleRefresh}
-                                                    className="flex flex-col items-center gap-2 group"
-                                                >
-                                                    <div className="w-12 h-12 rounded-full bg-black/5 flex items-center justify-center group-hover:bg-black/10 transition-colors">
-                                                        <RotateCcw className="text-[#333]" size={24} strokeWidth={2} />
-                                                    </div>
-                                                    <span className="text-[14px] font-bold text-[#333]">새로고침</span>
-                                                </button>
+                                        {qrLoading ? (
+                                            <div className="w-full h-full flex items-center justify-center">
+                                                <div className="w-10 h-10 border-4 border-[#E8E8E8] border-t-[var(--foundation-primary-500)] rounded-full animate-spin" />
                                             </div>
-                                        )}
+                                        ) : qrUnavailableMessage ? (
+                                            <div className="w-full h-full flex flex-col items-center justify-center gap-2 text-center">
+                                                <p className="text-[13px] font-bold text-[#888]">{qrUnavailableMessage}</p>
+                                            </div>
+                                        ) : qrData ? (
+                                            <>
+                                                <div className={`transition-opacity duration-300 ${timeLeft === 0 ? "opacity-20" : ""}`}>
+                                                    <QRCodeSVG value={qrData.qrToken} size={190} />
+                                                </div>
+                                                {timeLeft === 0 && (
+                                                    <div className="absolute inset-0 flex flex-col items-center justify-center">
+                                                        <button
+                                                            onClick={handleRefresh}
+                                                            className="flex flex-col items-center gap-2 group"
+                                                        >
+                                                            <div className="w-12 h-12 rounded-full bg-black/5 flex items-center justify-center group-hover:bg-black/10 transition-colors">
+                                                                <RotateCcw className="text-[#333]" size={24} strokeWidth={2} />
+                                                            </div>
+                                                            <span className="text-[14px] font-bold text-[#333]">새로고침</span>
+                                                        </button>
+                                                    </div>
+                                                )}
+                                            </>
+                                        ) : null}
                                     </div>
-                                    <p className="text-[#999] text-[15px] font-medium">
-                                        유효 시간 <span className="font-medium text-[#999] ml-1">{formatTimeLeft(timeLeft)}</span>
-                                    </p>
+                                    {qrData && timeLeft > 0 && (
+                                        <p className="text-[#999] text-[15px] font-medium">
+                                            유효 시간 <span className="font-medium text-[#999] ml-1">{formatTimeLeft(timeLeft)}</span>
+                                        </p>
+                                    )}
+                                    {qrData && (
+                                        <p className="text-[#bbb] text-[12px] mt-1">
+                                            만료: {formatExpiresAt(qrData.expiresAt)}
+                                        </p>
+                                    )}
                                 </>
                             )}
                         </div>

--- a/goorm-gongbang/components/ui/pagination.tsx
+++ b/goorm-gongbang/components/ui/pagination.tsx
@@ -1,0 +1,127 @@
+import * as React from "react"
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  MoreHorizontalIcon,
+} from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants, type Button } from "@/components/ui/button"
+
+function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      role="navigation"
+      aria-label="pagination"
+      data-slot="pagination"
+      className={cn("mx-auto flex w-full justify-center", className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationContent({
+  className,
+  ...props
+}: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="pagination-content"
+      className={cn("flex flex-row items-center gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationItem({ ...props }: React.ComponentProps<"li">) {
+  return <li data-slot="pagination-item" {...props} />
+}
+
+type PaginationLinkProps = {
+  isActive?: boolean
+} & Pick<React.ComponentProps<typeof Button>, "size"> &
+  React.ComponentProps<"a">
+
+function PaginationLink({
+  className,
+  isActive,
+  size = "icon",
+  ...props
+}: PaginationLinkProps) {
+  return (
+    <a
+      aria-current={isActive ? "page" : undefined}
+      data-slot="pagination-link"
+      data-active={isActive}
+      className={cn(
+        buttonVariants({
+          variant: isActive ? "outline" : "ghost",
+          size,
+        }),
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function PaginationPrevious({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to previous page"
+      size="default"
+      className={cn("gap-1 px-2.5 sm:pl-2.5", className)}
+      {...props}
+    >
+      <ChevronLeftIcon />
+      <span className="hidden sm:block">Previous</span>
+    </PaginationLink>
+  )
+}
+
+function PaginationNext({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to next page"
+      size="default"
+      className={cn("gap-1 px-2.5 sm:pr-2.5", className)}
+      {...props}
+    >
+      <span className="hidden sm:block">Next</span>
+      <ChevronRightIcon />
+    </PaginationLink>
+  )
+}
+
+function PaginationEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      aria-hidden
+      data-slot="pagination-ellipsis"
+      className={cn("flex size-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontalIcon className="size-4" />
+      <span className="sr-only">More pages</span>
+    </span>
+  )
+}
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationLink,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
+}

--- a/goorm-gongbang/lib/datetime.ts
+++ b/goorm-gongbang/lib/datetime.ts
@@ -40,3 +40,4 @@ export const formatKST = (
     ...defaultOpts,
   }).format(date);
 };
+

--- a/goorm-gongbang/lib/services/index.ts
+++ b/goorm-gongbang/lib/services/index.ts
@@ -17,3 +17,6 @@ export * from "./recommendation.service";
 
 // Seat Service
 export * from "./seat.service";
+
+// Mypage Service
+export * from "./mypage.service";

--- a/goorm-gongbang/lib/services/mypage.service.ts
+++ b/goorm-gongbang/lib/services/mypage.service.ts
@@ -1,0 +1,185 @@
+/* ===========================
+   Mypage Service
+   - 마이페이지 관련 API 호출
+   - Backend: Mypage 서비스
+=========================== */
+
+import { API_BASE_URL } from "@/lib/api/config";
+import { auth } from "@/lib/api/fetch";
+import { ApiError } from "@/lib/api/error";
+import { toast } from "sonner";
+import type { AccountInfo, UpdateNicknameRequest, TicketListData, TicketListParams, TicketDetail, TicketQrData, UpcomingTicketData, TicketCancelResult, MyPageProfileData, InquiryDetail } from "@/lib/types";
+
+/* 닉네임 수정 */
+export const updateNickname = async (body: UpdateNicknameRequest): Promise<AccountInfo> => {
+  try {
+    return await auth.put<AccountInfo, UpdateNicknameRequest>(
+      `${API_BASE_URL}/order/mypage/account`,
+      body,
+    );
+  } catch (err) {
+    const message =
+      err instanceof ApiError && err.status === 400
+        ? "닉네임 입력값을 확인해주세요."
+        : err instanceof ApiError
+          ? err.message
+          : "닉네임 수정에 실패했습니다.";
+    toast.error(message);
+    throw err;
+  }
+};
+
+/* 예매 내역 조회 */
+export const getTicketList = async (params: TicketListParams = {}): Promise<TicketListData> => {
+  const query = new URLSearchParams();
+  if (params.tab !== undefined) query.set("tab", params.tab);
+  if (params.page !== undefined) query.set("page", String(params.page));
+  if (params.size !== undefined) query.set("size", String(params.size));
+  const qs = query.toString();
+
+  try {
+    return await auth.get<TicketListData>(
+      `${API_BASE_URL}/order/mypage/tickets${qs ? `?${qs}` : ""}`,
+    );
+  } catch (err) {
+    const message =
+      err instanceof ApiError && err.status === 400
+        ? "잘못된 요청입니다. 페이지 크기는 최대 10까지 가능합니다."
+        : err instanceof ApiError
+          ? err.message
+          : "예매 내역을 불러오지 못했습니다.";
+    toast.error(message);
+    throw err;
+  }
+};
+
+/* 예매 상세 조회 */
+export const getTicketDetail = async (ticketId: number): Promise<TicketDetail> => {
+  try {
+    return await auth.get<TicketDetail>(`${API_BASE_URL}/order/mypage/tickets/${ticketId}`);
+  } catch (err) {
+    const message =
+      err instanceof ApiError && err.status === 403
+        ? "본인 소유의 티켓만 조회할 수 있습니다."
+        : err instanceof ApiError && err.status === 404
+          ? "티켓 정보를 찾을 수 없습니다."
+          : err instanceof ApiError
+            ? err.message
+            : "예매 상세 정보를 불러오지 못했습니다.";
+    toast.error(message);
+    throw err;
+  }
+};
+
+/* 경기 예정 티켓 조회 */
+export const getUpcomingTickets = async (params: { page?: number; size?: number } = {}): Promise<UpcomingTicketData> => {
+  const query = new URLSearchParams();
+  if (params.page !== undefined) query.set("page", String(params.page));
+  if (params.size !== undefined) query.set("size", String(params.size));
+  const qs = query.toString();
+
+  try {
+    return await auth.get<UpcomingTicketData>(
+      `${API_BASE_URL}/order/mypage/tickets/upcoming${qs ? `?${qs}` : ""}`,
+    );
+  } catch (err) {
+    const message =
+      err instanceof ApiError && err.status === 400
+        ? "잘못된 요청입니다. 페이지 크기는 최대 10까지 가능합니다."
+        : err instanceof ApiError
+          ? err.message
+          : "경기 예정 티켓을 불러오지 못했습니다.";
+    toast.error(message);
+    throw err;
+  }
+};
+
+/* QR 토큰 조회 */
+export const getTicketQr = async (ticketId: number): Promise<TicketQrData> => {
+  try {
+    return await auth.get<TicketQrData>(`${API_BASE_URL}/order/mypage/tickets/${ticketId}/qr`);
+  } catch (err) {
+    // 400은 입장 가능 시간이 아닌 경우 등 UI에서 직접 처리하므로 toast 생략
+    if (err instanceof ApiError && err.status === 400) {
+      throw err;
+    }
+    const message =
+      err instanceof ApiError && err.status === 403
+        ? "본인 소유의 티켓만 조회할 수 있습니다."
+        : err instanceof ApiError && err.status === 404
+          ? "티켓 정보를 찾을 수 없습니다."
+          : err instanceof ApiError
+            ? err.message
+            : "QR 정보를 불러오지 못했습니다.";
+    toast.error(message);
+    throw err;
+  }
+};
+
+/* 티켓 취소 */
+export const cancelTicket = async (ticketId: number): Promise<TicketCancelResult> => {
+  try {
+    return await auth.post<TicketCancelResult>(
+      `${API_BASE_URL}/order/mypage/tickets/${ticketId}/cancel`,
+    );
+  } catch (err) {
+    const message =
+      err instanceof ApiError && err.status === 400
+        ? "취소할 수 없는 상태의 티켓입니다."
+        : err instanceof ApiError && err.status === 403
+          ? "본인 소유의 티켓만 취소할 수 있습니다."
+          : err instanceof ApiError && err.status === 404
+            ? "티켓 정보를 찾을 수 없습니다."
+            : err instanceof ApiError
+              ? err.message
+              : "티켓 취소에 실패했습니다.";
+    toast.error(message);
+    throw err;
+  }
+};
+
+/* 마이페이지 프로필 조회 */
+export const getMyPageProfile = async (): Promise<MyPageProfileData> => {
+  try {
+    return await auth.get<MyPageProfileData>(`${API_BASE_URL}/order/mypage/profile`);
+  } catch (err) {
+    const message =
+      err instanceof ApiError && err.status === 404
+        ? "사용자 정보를 찾을 수 없습니다."
+        : err instanceof ApiError
+          ? err.message
+          : "프로필 정보를 불러오지 못했습니다.";
+    toast.error(message);
+    throw err;
+  }
+};
+
+/* 문의 상세 조회 */
+export const getInquiryDetail = async (inquiryId: number): Promise<InquiryDetail> => {
+  try {
+    return await auth.get<InquiryDetail>(`${API_BASE_URL}/order/mypage/inquiries/${inquiryId}`);
+  } catch (err) {
+    const message =
+      err instanceof ApiError && err.status === 403
+        ? "본인 문의만 조회할 수 있습니다."
+        : err instanceof ApiError && err.status === 404
+          ? "문의 내역을 찾을 수 없습니다."
+          : err instanceof ApiError
+            ? err.message
+            : "문의 상세 정보를 불러오지 못했습니다.";
+    toast.error(message);
+    throw err;
+  }
+};
+
+/* 계정 기본 정보 조회 */
+export const getAccountInfo = async (): Promise<AccountInfo> => {
+  try {
+    return await auth.get<AccountInfo>(`${API_BASE_URL}/order/mypage/account`);
+  } catch (err) {
+    const message =
+      err instanceof ApiError ? err.message : "계정 정보를 불러오지 못했습니다.";
+    toast.error(message);
+    throw err;
+  }
+};

--- a/goorm-gongbang/lib/services/mypage.service.ts
+++ b/goorm-gongbang/lib/services/mypage.service.ts
@@ -7,7 +7,7 @@
 import { API_BASE_URL } from "@/lib/api/config";
 import { auth } from "@/lib/api/fetch";
 import { ApiError } from "@/lib/api/error";
-import { toast } from "sonner";
+
 import type { AccountInfo, UpdateNicknameRequest, TicketListData, TicketListParams, TicketDetail, TicketQrData, UpcomingTicketData, TicketCancelResult, MyPageProfileData, InquiryDetail } from "@/lib/types";
 
 /* 닉네임 수정 */
@@ -18,13 +18,9 @@ export const updateNickname = async (body: UpdateNicknameRequest): Promise<Accou
       body,
     );
   } catch (err) {
-    const message =
-      err instanceof ApiError && err.status === 400
-        ? "닉네임 입력값을 확인해주세요."
-        : err instanceof ApiError
-          ? err.message
-          : "닉네임 수정에 실패했습니다.";
-    toast.error(message);
+    if (err instanceof ApiError && err.status === 400) {
+      throw new Error("닉네임 입력값을 확인해주세요.");
+    }
     throw err;
   }
 };
@@ -42,13 +38,9 @@ export const getTicketList = async (params: TicketListParams = {}): Promise<Tick
       `${API_BASE_URL}/order/mypage/tickets${qs ? `?${qs}` : ""}`,
     );
   } catch (err) {
-    const message =
-      err instanceof ApiError && err.status === 400
-        ? "잘못된 요청입니다. 페이지 크기는 최대 10까지 가능합니다."
-        : err instanceof ApiError
-          ? err.message
-          : "예매 내역을 불러오지 못했습니다.";
-    toast.error(message);
+    if (err instanceof ApiError && err.status === 400) {
+      throw new Error("잘못된 요청입니다. 페이지 크기는 최대 10까지 가능합니다.");
+    }
     throw err;
   }
 };
@@ -58,15 +50,10 @@ export const getTicketDetail = async (ticketId: number): Promise<TicketDetail> =
   try {
     return await auth.get<TicketDetail>(`${API_BASE_URL}/order/mypage/tickets/${ticketId}`);
   } catch (err) {
-    const message =
-      err instanceof ApiError && err.status === 403
-        ? "본인 소유의 티켓만 조회할 수 있습니다."
-        : err instanceof ApiError && err.status === 404
-          ? "티켓 정보를 찾을 수 없습니다."
-          : err instanceof ApiError
-            ? err.message
-            : "예매 상세 정보를 불러오지 못했습니다.";
-    toast.error(message);
+    if (err instanceof ApiError) {
+      if (err.status === 403) throw new Error("본인 소유의 티켓만 조회할 수 있습니다.");
+      if (err.status === 404) throw new Error("티켓 정보를 찾을 수 없습니다.");
+    }
     throw err;
   }
 };
@@ -83,13 +70,9 @@ export const getUpcomingTickets = async (params: { page?: number; size?: number 
       `${API_BASE_URL}/order/mypage/tickets/upcoming${qs ? `?${qs}` : ""}`,
     );
   } catch (err) {
-    const message =
-      err instanceof ApiError && err.status === 400
-        ? "잘못된 요청입니다. 페이지 크기는 최대 10까지 가능합니다."
-        : err instanceof ApiError
-          ? err.message
-          : "경기 예정 티켓을 불러오지 못했습니다.";
-    toast.error(message);
+    if (err instanceof ApiError && err.status === 400) {
+      throw new Error("잘못된 요청입니다. 페이지 크기는 최대 10까지 가능합니다.");
+    }
     throw err;
   }
 };
@@ -99,19 +82,12 @@ export const getTicketQr = async (ticketId: number): Promise<TicketQrData> => {
   try {
     return await auth.get<TicketQrData>(`${API_BASE_URL}/order/mypage/tickets/${ticketId}/qr`);
   } catch (err) {
-    // 400은 입장 가능 시간이 아닌 경우 등 UI에서 직접 처리하므로 toast 생략
-    if (err instanceof ApiError && err.status === 400) {
-      throw err;
+    // 400은 입장 가능 시간이 아닌 경우 등 UI에서 직접 처리
+    if (err instanceof ApiError) {
+      if (err.status === 400) throw err;
+      if (err.status === 403) throw new Error("본인 소유의 티켓만 조회할 수 있습니다.");
+      if (err.status === 404) throw new Error("티켓 정보를 찾을 수 없습니다.");
     }
-    const message =
-      err instanceof ApiError && err.status === 403
-        ? "본인 소유의 티켓만 조회할 수 있습니다."
-        : err instanceof ApiError && err.status === 404
-          ? "티켓 정보를 찾을 수 없습니다."
-          : err instanceof ApiError
-            ? err.message
-            : "QR 정보를 불러오지 못했습니다.";
-    toast.error(message);
     throw err;
   }
 };
@@ -123,17 +99,11 @@ export const cancelTicket = async (ticketId: number): Promise<TicketCancelResult
       `${API_BASE_URL}/order/mypage/tickets/${ticketId}/cancel`,
     );
   } catch (err) {
-    const message =
-      err instanceof ApiError && err.status === 400
-        ? "취소할 수 없는 상태의 티켓입니다."
-        : err instanceof ApiError && err.status === 403
-          ? "본인 소유의 티켓만 취소할 수 있습니다."
-          : err instanceof ApiError && err.status === 404
-            ? "티켓 정보를 찾을 수 없습니다."
-            : err instanceof ApiError
-              ? err.message
-              : "티켓 취소에 실패했습니다.";
-    toast.error(message);
+    if (err instanceof ApiError) {
+      if (err.status === 400) throw new Error("취소할 수 없는 상태의 티켓입니다.");
+      if (err.status === 403) throw new Error("본인 소유의 티켓만 취소할 수 있습니다.");
+      if (err.status === 404) throw new Error("티켓 정보를 찾을 수 없습니다.");
+    }
     throw err;
   }
 };
@@ -143,13 +113,9 @@ export const getMyPageProfile = async (): Promise<MyPageProfileData> => {
   try {
     return await auth.get<MyPageProfileData>(`${API_BASE_URL}/order/mypage/profile`);
   } catch (err) {
-    const message =
-      err instanceof ApiError && err.status === 404
-        ? "사용자 정보를 찾을 수 없습니다."
-        : err instanceof ApiError
-          ? err.message
-          : "프로필 정보를 불러오지 못했습니다.";
-    toast.error(message);
+    if (err instanceof ApiError && err.status === 404) {
+      throw new Error("사용자 정보를 찾을 수 없습니다.");
+    }
     throw err;
   }
 };
@@ -159,15 +125,10 @@ export const getInquiryDetail = async (inquiryId: number): Promise<InquiryDetail
   try {
     return await auth.get<InquiryDetail>(`${API_BASE_URL}/order/mypage/inquiries/${inquiryId}`);
   } catch (err) {
-    const message =
-      err instanceof ApiError && err.status === 403
-        ? "본인 문의만 조회할 수 있습니다."
-        : err instanceof ApiError && err.status === 404
-          ? "문의 내역을 찾을 수 없습니다."
-          : err instanceof ApiError
-            ? err.message
-            : "문의 상세 정보를 불러오지 못했습니다.";
-    toast.error(message);
+    if (err instanceof ApiError) {
+      if (err.status === 403) throw new Error("본인 문의만 조회할 수 있습니다.");
+      if (err.status === 404) throw new Error("문의 내역을 찾을 수 없습니다.");
+    }
     throw err;
   }
 };
@@ -177,9 +138,6 @@ export const getAccountInfo = async (): Promise<AccountInfo> => {
   try {
     return await auth.get<AccountInfo>(`${API_BASE_URL}/order/mypage/account`);
   } catch (err) {
-    const message =
-      err instanceof ApiError ? err.message : "계정 정보를 불러오지 못했습니다.";
-    toast.error(message);
     throw err;
   }
 };

--- a/goorm-gongbang/lib/services/order-core.service.ts
+++ b/goorm-gongbang/lib/services/order-core.service.ts
@@ -18,6 +18,7 @@ import type {
   ClubDetail,
   OnboardingStatusResponse,
   OnboardingPreferencesRequest,
+  UpdateOnboardingPreferencesRequest,
   ClubMonthMatches,
   OnboardingPreferencesResponse,
   PreferredBlockUpdateRequest,
@@ -94,6 +95,10 @@ export const saveOnboardingPreferences = (body: OnboardingPreferencesRequest) =>
 /* 온보딩 선호도 응답 */
 export const getOnboardingPreferences = () =>
   auth.get<OnboardingPreferencesResponse>(`${API_BASE_URL}/order/onboarding/preferences`);
+
+/* 온보딩 선호도 수정 (온보딩 완료 후 마이페이지에서 업데이트) */
+export const updateOnboardingPreferences = (body: UpdateOnboardingPreferencesRequest) =>
+  auth.put(`${API_BASE_URL}/order/onboarding/preferences`, body);
 
 /* 선호 구역 수정 */
 export const saveOnboardingPreferencesBlocks = (body: PreferredBlockUpdateRequest) =>

--- a/goorm-gongbang/lib/types/index.ts
+++ b/goorm-gongbang/lib/types/index.ts
@@ -20,3 +20,6 @@ export * from "./recommendation.types";
 
 // Seat Service
 export * from "./seat.types";
+
+// Mypage Service
+export * from "./mypage.types";

--- a/goorm-gongbang/lib/types/mypage.types.ts
+++ b/goorm-gongbang/lib/types/mypage.types.ts
@@ -1,0 +1,260 @@
+/**
+ * Mypage Service Types
+ * 마이페이지 관련 타입 정의
+ */
+
+/* SNS 연동 계정 정보 */
+export type SnsAccount = {
+  provider: string;
+  providerUserId: string;
+};
+
+/* 계정 기본 정보 */
+export type AccountInfo = {
+  email: string;
+  nickname: string;
+  profileImageUrl: string;
+  snsAccount: SnsAccount;
+};
+
+/* 계정 정보 조회/수정 응답 래퍼 */
+export type AccountInfoResponse = {
+  code: string;
+  message: string;
+  data: AccountInfo;
+};
+
+/* 닉네임 수정 요청 */
+export type UpdateNicknameRequest = {
+  nickname: string;
+};
+
+/* ─── 예매 내역 조회 ─── */
+
+export type TicketTab = "BOOKED" | "CANCEL_REFUND";
+
+export type TicketListParams = {
+  tab?: TicketTab;
+  page?: number;
+  size?: number;
+};
+
+export type TicketSummary = {
+  totalCount: number;
+  upcomingCount: number;
+  cancelProcessingCount: number;
+  completedCount: number;
+};
+
+export type Pagination = {
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+  hasNext: boolean;
+};
+
+export type TicketClub = {
+  clubId: number;
+  koName: string;
+};
+
+export type TicketSeat = {
+  sectionName: string;
+  blockCode: string;
+  rowNo: number;
+  seatNo: number;
+};
+
+export type TicketActions = {
+  canDeposit: boolean;
+  canCancel: boolean;
+  canViewDetail: boolean;
+};
+
+export type TicketItem = {
+  ticketId: number;
+  matchAt: string;
+  homeClub: TicketClub;
+  awayClub: TicketClub;
+  stadiumName: string;
+  seatCount: number;
+  seats: TicketSeat[];
+  status: string;
+  actions: TicketActions;
+};
+
+export type TicketListData = {
+  summary: TicketSummary;
+  currentTab: string;
+  pagination: Pagination;
+  tickets: TicketItem[];
+};
+
+export type TicketListResponse = {
+  code: string;
+  message: string;
+  data: TicketListData;
+};
+
+/* ─── 예매 상세 조회 ─── */
+
+export type TicketStadium = {
+  stadiumId: number;
+  koName: string;
+  address: string;
+};
+
+export type TicketMatch = {
+  matchId: number;
+  matchAt: string;
+  homeClub: TicketClub;
+  awayClub: TicketClub;
+  stadium: TicketStadium;
+};
+
+export type CashReceipt = {
+  type: string;
+  number: string;
+  totalAmount: number;
+};
+
+export type TicketPayment = {
+  totalAmount: number;
+  serviceFee: number;
+  paymentMethod: string;
+  paidAt: string;
+  cashReceipt: CashReceipt | null;
+};
+
+export type CancellationPolicy = {
+  deadline: string;
+  feeRate: string;
+};
+
+export type VirtualAccount = {
+  bank: string;
+  accountNumber: string;
+  holder: string;
+  depositDeadline: string;
+};
+
+export type TicketCancellation = {
+  cancelledAt: string;
+  cancellationFee: number;
+  refundedAmount: number;
+};
+
+export type TicketDetail = {
+  ticketId: number;
+  status: string;
+  match: TicketMatch;
+  seats: TicketSeat[];
+  payment: TicketPayment | null;
+  cancellationPolicy: CancellationPolicy | null;
+  virtualAccount: VirtualAccount | null;
+  cancellation: TicketCancellation | null;
+  actions: TicketActions;
+};
+
+export type TicketDetailResponse = {
+  code: string;
+  message: string;
+  data: TicketDetail;
+};
+
+/* ─── 경기 예정 티켓 조회 ─── */
+
+export type UpcomingTicketItem = {
+  ticketId: number;
+  dDay: number;
+  status: string;
+  statusLabel: string;
+  seatCount: number;
+  match: TicketMatch;
+  seats: TicketSeat[];
+  actions: TicketActions;
+};
+
+export type UpcomingTicketData = {
+  totalCount: number;
+  pagination: Pagination;
+  tickets: UpcomingTicketItem[];
+};
+
+export type UpcomingTicketResponse = {
+  code: string;
+  message: string;
+  data: UpcomingTicketData;
+};
+
+/* ─── 마이페이지 프로필 조회 ─── */
+
+export type UserProfile = {
+  nickname: string;
+  profileImageUrl: string;
+  snsProvider: string;
+};
+
+export type MyPageProfileData = {
+  profile: UserProfile;
+  ticketSummary: TicketSummary;
+};
+
+export type MyPageProfileResponse = {
+  code: string;
+  message: string;
+  data: MyPageProfileData;
+};
+
+/* ─── 티켓 취소 ─── */
+
+export type TicketCancelResult = {
+  ticketId: number;
+  status: string;
+  totalAmount: number;
+  cancellationFee: number;
+  refundedAmount: number;
+};
+
+export type TicketCancelResponse = {
+  code: string;
+  message: string;
+  data: TicketCancelResult;
+};
+
+/* ─── 문의 상세 조회 ─── */
+
+export type InquiryDetail = {
+  inquiryId: number;
+  category: string;
+  title: string;
+  content: string;
+  phoneNumber: string;
+  status: string;
+  fileAttached: boolean;
+  downloadUrl: string | null;
+  createdAt: string;
+};
+
+export type InquiryDetailResponse = {
+  code: string;
+  message: string;
+  data: InquiryDetail;
+};
+
+/* ─── QR 토큰 조회 ─── */
+
+export type TicketQrData = {
+  ticketId: number;
+  qrToken: string;
+  expiresAt: string;
+  match: TicketMatch;
+  seats: TicketSeat[];
+};
+
+export type TicketQrResponse = {
+  code: string;
+  message: string;
+  data: TicketQrData;
+};

--- a/goorm-gongbang/lib/types/order-core.types.ts
+++ b/goorm-gongbang/lib/types/order-core.types.ts
@@ -165,9 +165,17 @@ export type PreferenceBase = Pick<
   "priority" | "viewpoint" | "seatHeight" | "section"
 >;
 
-/** 온보딩 선호도 저장 요청 */
+/** 온보딩 선호도 저장 요청 (POST - 최초 등록) */
 export type OnboardingPreferencesRequest = {
   marketingConsent: { marketingAgreed: boolean };
+  favoriteClubId: number;
+  cheerProximityPref: "NEAR" | "FAR" | "ANY";
+  preferredBlockIds: number[];
+  preferences: Preference[];
+};
+
+/** 온보딩 선호도 수정 요청 (PUT - 마이페이지에서 업데이트) */
+export type UpdateOnboardingPreferencesRequest = {
   favoriteClubId: number;
   cheerProximityPref: "NEAR" | "FAR" | "ANY";
   preferredBlockIds: number[];

--- a/goorm-gongbang/lib/utils.ts
+++ b/goorm-gongbang/lib/utils.ts
@@ -4,3 +4,13 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * 수수료율 문자열에서 숫자만 추출하여 비율로 변환합니다. (예: "10%" -> 0.1, "무료" -> 0)
+ */
+export function parseFeeRate(feeRate: string | null | undefined): number {
+  if (!feeRate) return 0;
+  const cleaned = feeRate.replace(/[^0-9.]/g, "");
+  const parsed = parseFloat(cleaned);
+  return isNaN(parsed) ? 0 : parsed / 100;
+}

--- a/goorm-gongbang/package-lock.json
+++ b/goorm-gongbang/package-lock.json
@@ -43,6 +43,7 @@
         "pino": "^10.3.0",
         "pino-http": "^11.0.0",
         "prom-client": "^15.1.3",
+        "qrcode.react": "^4.2.0",
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-day-picker": "^9.13.1",
@@ -11418,6 +11419,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/queue-microtask": {

--- a/goorm-gongbang/package.json
+++ b/goorm-gongbang/package.json
@@ -46,6 +46,7 @@
     "pino": "^10.3.0",
     "pino-http": "^11.0.0",
     "prom-client": "^15.1.3",
+    "qrcode.react": "^4.2.0",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-day-picker": "^9.13.1",


### PR DESCRIPTION
## 🔧 작업 내용
- 마이페이지 통합 API 연동 및 UI 고도화
   - 예매 내역 조회, 상세 정보 보기, 결제 취소, QR 티켓 조회 등 티켓 관련 기능 전반의 API 실데이터 바인딩을 완료했습니다.
   - 마이페이지 내 계정 설정 및 프로필 정보를 서버 데이터 기반으로 연동했습니다.
   - 1:1 문의 등록 페이지의 복잡도를 낮추기 위해 이미지 업로드 기능을 제거하고 UI를 간소화했습니다.
- 문제 해결
   - 기존의 하드코딩된 데이터를 제거하고 실제 백엔드 API 서버와 연동하여 실시간 데이터 반영이 가능하게 했습니다.
   - 문의 등록 시 작성자 정보를 매번 수동으로 입력해야 했던 번거로움을 계정 정보 자동 바인딩(Read-only)을 통해 해결했습니다.
- 구현 방식 사유
   - 마이페이지와 관련된 다양한 API 엔드포인트를 효율적으로 관리하기 위해 mypage.service.ts로 로직을 중앙 집중화했습니다.
   - 폼 입력 가독성을 높이기 위해 반응형 Grid 레이아웃을 적용하고, 상태에 따른 Input 스타일(disabled, focus 등)을 고도화했습니다.
## 🧩 구현 상세 (선택)
- 핵심 로직: mypage.service.ts
   - 계정 정보(getAccountInfo), 예매 목록(getTicketList), 문의 상세(getInquiryDetail) 등 여러 도메인의 마이페이지 관련 API를 단일 서비스 객체로 구조화하여 유지보수성을 높였습니다.
- UI 리팩토링: SupportWritePage
   - 이미지 업로드 섹션을 과감히 제거하여 문의 등록 프로세스를 최적화했습니다. 이는 불필요한 파일 핸들링 상태 로직을 줄이고, 사용자에게 핵심 입력 사항에만 집중하게 하는 사용자 경험(UX) 트레이드오프를 고려한 결과입니다.
## 📌 관련 Jira Issue
- GRGB-101 (마이페이지 API 연동 및 UI 개선)
## 🧪 테스트 방법 (선택)
- 테스로 대상: 마이페이지 전체 화면 (예매 목록, 상세, 계정 설정, 1:1 문의)
- Endpoint: /order/mypage/account, /order/mypage/tickets, /order/mypage/profile 등
- 체크 포인트:
   - 예매 내역 리스트에서 페이지네이션 작동 여부 및 데이터 로딩 상태 확인
   - 문의 등록 시 이름/이메일이 현재 로그인된 계정 정보로 올바르게 표시되는지 확인
   - 티켓 취소 시 정상적으로 상태값이 업데이트되는지 확인
## ❗ 참고 사항
- 리뷰 시 유의할 점: 1:1 문의 등록 화면에서 이미지 업로드 기능이 의도적으로 제거되었으므로, 해당 부분의 기획서 대응 내용을 확인해 주세요.
- 후속 작업 예정: 특정 예외 상황(이미 취소된 티켓 재취소 시도 등)에 대한 세부적인 에러 모달 추가 작업이 필요할 수 있습니다.

