### PR TITLE
chore: disable source maps for staging and production

### DIFF
--- a/goorm-gongbang/next.config.ts
+++ b/goorm-gongbang/next.config.ts
@@ -30,7 +30,7 @@ const nextConfig = {
   // 기존 OTel 및 권장 설정 유지
   compress: true,
   poweredByHeader: false,
-  // 완전 비활성화 
+  // 브라우저 소스 맵 비활성화
   productionBrowserSourceMaps: false,
 
   // 보안 헤더 유지

--- a/goorm-gongbang/next.config.ts
+++ b/goorm-gongbang/next.config.ts
@@ -30,8 +30,8 @@ const nextConfig = {
   // 기존 OTel 및 권장 설정 유지
   compress: true,
   poweredByHeader: false,
-  // staging에서만 sourcemap 활성화 (디버깅용)
-  productionBrowserSourceMaps: process.env.NEXT_PUBLIC_ENV === "staging",
+  // 완전 비활성화 
+  productionBrowserSourceMaps: false,
 
   // 보안 헤더 유지
   async headers() {


### PR DESCRIPTION
## 변경 내용
- Next.js source map 비활성화

## 목적
- staging 환경에서도 source map 노출 방지
- production과 동일한 보안 정책 적용

## 영향
- staging/prod 환경에서 source map 기반 디버깅 불가