### PR TITLE
[feat](my): 마이페이지 상세 UI 구현 및 티켓 정보 표시 개선

### DIFF
--- a/goorm-gongbang/app/(protected)/my/payments/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/payments/page.tsx
@@ -1,0 +1,409 @@
+"use client";
+
+/* ===========================
+   결제 수단 관리 페이지 (목업)
+   Route: /my/payments
+   - 등록된 결제 수단 목록 표시
+   - 결제 수단 추가 / 삭제 (목업, 실제 API 미연동)
+   - 지원 수단: 카카오페이, 토스페이, 무통장입금(가상계좌)
+
+   [TODO] API 연동 시
+   - MOCK_PAYMENT_METHODS → GET /api/users/me/payment-methods
+   - 결제 수단 삭제 → DELETE /api/users/me/payment-methods/:id
+   - 결제 수단 추가 → 카카오페이/토스페이 OAuth 연동 또는 계좌 인증 플로우
+=========================== */
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { ChevronLeft, Plus, Trash2, CreditCard, CheckCircle2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/* ===========================
+   타입
+=========================== */
+type PaymentMethodType = "kakaopay" | "tosspay" | "bank";
+
+type PaymentMethod = {
+    id: string;
+    type: PaymentMethodType;
+    label: string;
+    description: string;
+    isDefault: boolean;
+};
+
+/* ===========================
+   목업 데이터
+=========================== */
+const MOCK_PAYMENT_METHODS: PaymentMethod[] = [
+    {
+        id: "pm_001",
+        type: "kakaopay",
+        label: "카카오페이",
+        description: "",
+        isDefault: true,
+    },
+    {
+        id: "pm_002",
+        type: "tosspay",
+        label: "토스페이",
+        description: "",
+        isDefault: false,
+    },
+];
+
+/* ===========================
+   결제 수단 아이콘
+=========================== */
+function PaymentIcon({ type, size = 36 }: { type: PaymentMethodType; size?: number }) {
+    const base = `rounded-xl flex items-center justify-center flex-shrink-0 font-extrabold text-white`;
+
+    if (type === "kakaopay") {
+        return (
+            <div
+                className="rounded-xl flex-shrink-0 overflow-hidden bg-[#FEE500] flex items-center justify-center"
+                style={{ width: size, height: size }}
+            >
+                <img src="/pay/kakao.png" alt="카카오페이" style={{ width: size * 0.75, height: size * 0.75, objectFit: "contain" }} />
+            </div>
+        );
+    }
+    if (type === "tosspay") {
+        return (
+            <img
+                src="/pay/toss.png"
+                alt="토스페이"
+                className="rounded-xl flex-shrink-0"
+                style={{ width: size, height: size, objectFit: "cover" }}
+            />
+        );
+    }
+
+    // bank
+    return (
+        <div
+            className={base}
+            style={{ width: size, height: size, background: "#6B7280" }}
+        >
+            <CreditCard size={size * 0.5} color="#fff" />
+        </div>
+    );
+}
+
+/* ===========================
+   결제 수단 추가 모달
+=========================== */
+type AddModalProps = {
+    onClose: () => void;
+    onAdd: (type: PaymentMethodType) => void;
+    existingTypes: PaymentMethodType[];
+};
+
+function AddPaymentModal({ onClose, onAdd, existingTypes }: AddModalProps) {
+    const OPTIONS: { type: PaymentMethodType; label: string; desc: string }[] = [
+        { type: "kakaopay", label: "카카오페이", desc: "카카오 계정으로 간편 결제" },
+        { type: "tosspay", label: "토스페이", desc: "토스 앱으로 간편 결제" },
+    ];
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40"
+            onClick={onClose}
+        >
+            <div
+                className="bg-white w-full max-w-sm rounded-t-2xl sm:rounded-2xl p-6"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <h2 className="text-[17px] font-bold text-[#1A1A1A] mb-1">결제 수단 추가</h2>
+                <p className="text-xs text-[#9E9E9E] mb-5">추가할 결제 수단을 선택하세요</p>
+
+                <ul className="flex flex-col gap-2">
+                    {OPTIONS.map((opt) => {
+                        const alreadyAdded = existingTypes.includes(opt.type);
+                        return (
+                            <li key={opt.type}>
+                                <button
+                                    type="button"
+                                    disabled={alreadyAdded}
+                                    onClick={() => { onAdd(opt.type); onClose(); }}
+                                    className={cn(
+                                        "w-full flex items-center gap-3 px-4 py-3.5 rounded-xl border transition-colors text-left",
+                                        alreadyAdded
+                                            ? "border-[#F0F0F0] bg-[#FAFAFA] opacity-50 cursor-not-allowed"
+                                            : "border-[#E8E8E8] hover:border-[var(--foundation-primary-400)] hover:bg-[var(--foundation-primary-50)]"
+                                    )}
+                                >
+                                    <PaymentIcon type={opt.type} size={38} />
+                                    <div className="flex-1 min-w-0">
+                                        <p className="text-[14px] font-semibold text-[#1A1A1A]">{opt.label}</p>
+                                        <p className="text-[12px] text-[#9E9E9E]">{opt.desc}</p>
+                                    </div>
+                                    {alreadyAdded && (
+                                        <span className="text-[11px] text-[#ADADAD] font-medium whitespace-nowrap">등록됨</span>
+                                    )}
+                                </button>
+                            </li>
+                        );
+                    })}
+                </ul>
+
+                <button
+                    type="button"
+                    onClick={onClose}
+                    className="mt-4 w-full py-3 rounded-xl bg-[#F5F5F5] text-sm font-semibold text-[#5A5A5A] hover:bg-[#EBEBEB] transition-colors"
+                >
+                    취소
+                </button>
+            </div>
+        </div>
+    );
+}
+
+/* ===========================
+   삭제 확인 모달
+=========================== */
+type DeleteModalProps = {
+    method: PaymentMethod;
+    onClose: () => void;
+    onConfirm: () => void;
+};
+
+function DeleteConfirmModal({ method, onClose, onConfirm }: DeleteModalProps) {
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40"
+            onClick={onClose}
+        >
+            <div
+                className="bg-white w-full max-w-sm rounded-t-2xl sm:rounded-2xl p-6"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <h2 className="text-[17px] font-bold text-[#1A1A1A] mb-2">결제 수단 삭제</h2>
+                <p className="text-[14px] text-[#5A5A5A] leading-relaxed mb-6">
+                    <span className="font-semibold text-[#1A1A1A]">{method.label}</span>을(를) 삭제하시겠어요?<br />
+                    삭제 후에는 해당 결제 수단으로 결제가 불가합니다.
+                </p>
+                <div className="flex gap-2">
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="flex-1 py-3 rounded-xl bg-[#F5F5F5] text-sm font-semibold text-[#5A5A5A] hover:bg-[#EBEBEB] transition-colors"
+                    >
+                        취소
+                    </button>
+                    <button
+                        type="button"
+                        onClick={onConfirm}
+                        className="flex-1 py-3 rounded-xl bg-[var(--foundation-red-500)] text-sm font-semibold text-white hover:opacity-90 transition-opacity"
+                    >
+                        삭제
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+/* ===========================
+   메인 페이지
+=========================== */
+export default function PaymentsPage() {
+    const router = useRouter();
+
+    const [methods, setMethods] = useState<PaymentMethod[]>(MOCK_PAYMENT_METHODS);
+    const [showAddModal, setShowAddModal] = useState(false);
+    const [deleteTarget, setDeleteTarget] = useState<PaymentMethod | null>(null);
+
+    const existingTypes = methods.map((m) => m.type);
+
+    const handleAdd = (type: PaymentMethodType) => {
+        const labels: Record<PaymentMethodType, string> = {
+            kakaopay: "카카오페이",
+            tosspay: "토스페이",
+            bank: "무통장입금",
+        };
+        const descriptions: Record<PaymentMethodType, string> = {
+            kakaopay: "카카오 계정 연결됨",
+            tosspay: "토스 계정 연결됨",
+            bank: "가상계좌 발급 가능",
+        };
+        const newMethod: PaymentMethod = {
+            id: `pm_${Date.now()}`,
+            type,
+            label: labels[type],
+            description: descriptions[type],
+            isDefault: methods.length === 0,
+        };
+        setMethods((prev) => [...prev, newMethod]);
+    };
+
+    const handleDelete = (id: string) => {
+        setMethods((prev) => {
+            const next = prev.filter((m) => m.id !== id);
+            // 삭제된 게 기본 결제 수단이면 첫 번째를 기본으로 변경
+            const wasDefault = prev.find((m) => m.id === id)?.isDefault;
+            if (wasDefault && next.length > 0) {
+                next[0] = { ...next[0], isDefault: true };
+            }
+            return next;
+        });
+        setDeleteTarget(null);
+    };
+
+    const handleSetDefault = (id: string) => {
+        setMethods((prev) =>
+            prev.map((m) => ({ ...m, isDefault: m.id === id }))
+        );
+    };
+
+    return (
+        <div className="min-h-screen bg-[#F5F5F5]">
+            {/* ─── 상단 헤더 (breadcrumb) ─── */}
+            <div className="sticky top-0 z-10 bg-white border-b border-[#F0F0F0]">
+                <div className="max-w-[1200px] mx-auto px-4 h-12 flex items-center justify-end">
+                    <nav className="flex items-center gap-1.5 text-xs text-[#9E9E9E]">
+                        <button
+                            type="button"
+                            onClick={() => router.push("/my")}
+                            className="hover:text-[#1A1A1A] transition-colors"
+                        >
+                            마이페이지
+                        </button>
+                        <span>&gt;</span>
+                        <span className="text-[#1A1A1A] font-medium">결제 수단 관리</span>
+                    </nav>
+                </div>
+            </div>
+
+            {/* ─── 본문 ─── */}
+            <div className="max-w-[1200px] mx-auto px-4 py-8">
+                {/* 이전으로 돌아가기 */}
+                <button
+                    type="button"
+                    onClick={() => router.back()}
+                    className="mb-8 text-[13px] font-medium text-[#7A7A7A] hover:text-[#1A1A1A] transition-colors flex items-center gap-1"
+                >
+                    <ChevronLeft className="w-4 h-4" />
+                    이전으로 돌아가기
+                </button>
+
+                {/* 페이지 타이틀 */}
+                <div className="mb-6 ml-2">
+                    <h1 className="flex items-baseline gap-3">
+                        <span className="text-[32px] font-black tracking-tight text-[#1A1A1A]">결제 수단 관리</span>
+                        <span className="text-[15px] font-medium text-[#9E9E9E]">총 {methods.length}개</span>
+                    </h1>
+                    <p className="mt-1 text-[13px] text-[#9E9E9E]">결제 시 사용할 수단을 관리하세요</p>
+                </div>
+
+                {/* 결제 수단 목록 */}
+                <div className="bg-white rounded-xl border border-[#E8E8E8] overflow-hidden mb-4">
+                    {methods.length === 0 ? (
+                        <div className="flex flex-col items-center justify-center py-16 text-center px-4">
+                            <div className="w-14 h-14 rounded-full bg-[#F5F5F5] flex items-center justify-center mb-4">
+                                <CreditCard className="w-7 h-7 text-[#ADADAD]" />
+                            </div>
+                            <p className="text-[15px] font-semibold text-[#5A5A5A] mb-1">등록된 결제 수단이 없어요</p>
+                            <p className="text-[13px] text-[#ADADAD]">아래 버튼을 눌러 결제 수단을 추가해보세요</p>
+                        </div>
+                    ) : (
+                        <ul>
+                            {methods.map((method, idx) => (
+                                <li
+                                    key={method.id}
+                                    className={cn(
+                                        "flex items-center gap-4 px-5 py-4",
+                                        idx !== 0 && "border-t border-[#F0F0F0]"
+                                    )}
+                                >
+                                    {/* 아이콘 */}
+                                    <PaymentIcon type={method.type} size={44} />
+
+                                    {/* 텍스트 */}
+                                    <div className="flex-1 min-w-0">
+                                        <div className="flex items-center gap-2 mb-0.5">
+                                            <span className="text-[15px] font-bold text-[#1A1A1A]">
+                                                {method.label}
+                                            </span>
+                                            {method.isDefault && (
+                                                <span className="inline-flex items-center gap-1 bg-[var(--foundation-primary-50)] text-[var(--foundation-primary-600)] text-[10px] font-bold px-2 py-0.5 rounded-full border border-[var(--foundation-primary-200)]">
+                                                    <CheckCircle2 className="w-3 h-3" />
+                                                    기본
+                                                </span>
+                                            )}
+                                        </div>
+                                        {method.description && <p className="text-[13px] text-[#9E9E9E]">{method.description}</p>}
+                                    </div>
+
+                                    {/* 액션 */}
+                                    <div className="flex items-center gap-2 flex-shrink-0">
+                                        {!method.isDefault && (
+                                            <button
+                                                type="button"
+                                                onClick={() => handleSetDefault(method.id)}
+                                                className="text-[12px] font-medium text-[#7A7A7A] hover:text-[var(--foundation-primary-600)] transition-colors px-3 py-1.5 rounded-lg border border-[#E8E8E8] hover:border-[var(--foundation-primary-300)] whitespace-nowrap"
+                                            >
+                                                기본으로 설정
+                                            </button>
+                                        )}
+                                        <button
+                                            type="button"
+                                            onClick={() => setDeleteTarget(method)}
+                                            className="p-2 rounded-lg text-[#ADADAD] hover:text-[var(--foundation-red-500)] hover:bg-[var(--foundation-red-50)] transition-colors"
+                                            aria-label="삭제"
+                                        >
+                                            <Trash2 className="w-4 h-4" />
+                                        </button>
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+
+                {/* 결제 수단 추가 버튼 */}
+                <button
+                    type="button"
+                    onClick={() => setShowAddModal(true)}
+                    className="w-full flex items-center justify-center gap-2 py-4 rounded-xl border-2 border-dashed border-[#D6D6D6] text-[#9E9E9E] hover:border-[var(--foundation-primary-400)] hover:text-[var(--foundation-primary-600)] hover:bg-[var(--foundation-primary-50)] transition-colors font-semibold text-sm"
+                >
+                    <Plus className="w-4 h-4" />
+                    결제 수단 추가
+                </button>
+
+                {/* 안내 */}
+                <div className="mt-6 bg-[#FAFAFA] rounded-xl border border-[#F0F0F0] px-5 py-4">
+                    <p className="text-[12px] font-bold text-[#5A5A5A] mb-2">결제 수단 안내</p>
+                    <ul className="space-y-1">
+                        {[
+                            "기본 결제 수단은 예매 시 자동으로 선택됩니다.",
+                            "카카오페이, 토스페이는 승인 즉시 결제가 완료됩니다.",
+                            "무통장입금은 가상계좌 발급 후 지정 기한 내 입금해야 예매가 확정됩니다.",
+                            "결제 수단은 최대 3개까지 등록 가능합니다.",
+                        ].map((text) => (
+                            <li key={text} className="flex items-start gap-1.5 text-[12px] text-[#9E9E9E]">
+                                <span className="mt-[5px] w-1 h-1 rounded-full bg-[#ADADAD] flex-shrink-0" />
+                                {text}
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </div>
+
+            {/* 모달 */}
+            {showAddModal && (
+                <AddPaymentModal
+                    onClose={() => setShowAddModal(false)}
+                    onAdd={handleAdd}
+                    existingTypes={existingTypes}
+                />
+            )}
+            {deleteTarget && (
+                <DeleteConfirmModal
+                    method={deleteTarget}
+                    onClose={() => setDeleteTarget(null)}
+                    onConfirm={() => handleDelete(deleteTarget.id)}
+                />
+            )}
+        </div>
+    );
+}

--- a/goorm-gongbang/app/(protected)/my/payments/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/payments/page.tsx
@@ -15,6 +15,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import { ChevronLeft, Plus, Trash2, CreditCard, CheckCircle2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -63,17 +64,19 @@ function PaymentIcon({ type, size = 36 }: { type: PaymentMethodType; size?: numb
                 className="rounded-xl flex-shrink-0 overflow-hidden bg-[#FEE500] flex items-center justify-center"
                 style={{ width: size, height: size }}
             >
-                <img src="/pay/kakao.png" alt="카카오페이" style={{ width: size * 0.75, height: size * 0.75, objectFit: "contain" }} />
+                <Image src="/pay/kakao.png" alt="카카오페이" width={size * 0.75} height={size * 0.75} style={{ objectFit: "contain" }} />
             </div>
         );
     }
     if (type === "tosspay") {
         return (
-            <img
+            <Image
                 src="/pay/toss.png"
                 alt="토스페이"
+                width={size}
+                height={size}
                 className="rounded-xl flex-shrink-0"
-                style={{ width: size, height: size, objectFit: "cover" }}
+                style={{ objectFit: "cover" }}
             />
         );
     }
@@ -98,11 +101,12 @@ type AddModalProps = {
     existingTypes: PaymentMethodType[];
 };
 
+const ADD_OPTIONS: { type: PaymentMethodType; label: string; desc: string }[] = [
+    { type: "kakaopay", label: "카카오페이", desc: "카카오 계정으로 간편 결제" },
+    { type: "tosspay", label: "토스페이", desc: "토스 앱으로 간편 결제" },
+];
+
 function AddPaymentModal({ onClose, onAdd, existingTypes }: AddModalProps) {
-    const OPTIONS: { type: PaymentMethodType; label: string; desc: string }[] = [
-        { type: "kakaopay", label: "카카오페이", desc: "카카오 계정으로 간편 결제" },
-        { type: "tosspay", label: "토스페이", desc: "토스 앱으로 간편 결제" },
-    ];
 
     return (
         <div
@@ -117,7 +121,7 @@ function AddPaymentModal({ onClose, onAdd, existingTypes }: AddModalProps) {
                 <p className="text-xs text-[#9E9E9E] mb-5">추가할 결제 수단을 선택하세요</p>
 
                 <ul className="flex flex-col gap-2">
-                    {OPTIONS.map((opt) => {
+                    {ADD_OPTIONS.map((opt) => {
                         const alreadyAdded = existingTypes.includes(opt.type);
                         return (
                             <li key={opt.type}>

--- a/goorm-gongbang/app/(protected)/my/privacy/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/privacy/page.tsx
@@ -203,7 +203,7 @@ export default function PrivacyPolicyPage() {
                             <div className="bg-[#FAFAFA] rounded-xl p-5 border border-[#F0F0F0]">
                                 <ul className="space-y-1">
                                     <li><span className="font-bold">서비스명:</span> 플레이볼 (Playball)</li>
-                                    <li><span className="font-bold">이메일:</span> <a href="mailto:lab.jehyun@gmail.com" className="text-[var(--foundation-primary-600)] hover:underline">lab.jehyun@gmail.com</a></li>
+                                    <li><span className="font-bold">이메일:</span> <a href="mailto:support@playball.one" className="text-[var(--foundation-primary-600)] hover:underline">support@playball.one</a></li>
                                 </ul>
                             </div>
                         </section>

--- a/goorm-gongbang/app/(protected)/my/support/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/support/page.tsx
@@ -29,38 +29,6 @@ import { InquiryItem, Inquiry } from "@/components/my/InquiryItem";
    }
 =========================== */
 
-const MOCK_INQUIRIES: Inquiry[] = [
-    {
-        id: 1,
-        status: "COMPLETED",
-        statusLabel: "답변 완료",
-        category: "결제/수수료",
-        title: "무통장입금(가상계좌)은 이용 제한이 있나요?",
-        description: "가상계좌 입금을 하려고 하는데, 혹시 미성년자나 특정 연령대에서 이용할 수 없는 제한이 있는지 궁금합니다.",
-        date: "2026.02.09",
-        answer: "무통장입금(가상계좌)는 19세 미만 고객에게만 제공됩니다."
-    },
-    {
-        id: 2,
-        status: "WAITING",
-        statusLabel: "답변 대기",
-        category: "예매/상품",
-        title: "결제 중에 예매 정보를 변경할 수 있나요?",
-        description: "좌석을 선택하고 결제 페이지로 넘어갔는데, 이 상태에서 인원수를 한 명 더 추가하거나 구역을 바꿀 수 있는 방법이 있을까요? 창을 닫으면 좌석이 풀릴까봐 걱정돼서 문의드립니다.",
-        date: "2026.01.09",
-        answer: (
-            <div className="flex flex-col gap-4">
-                <p>결제 단계로 넘어온 이후에는 선택한 예매 정보 변경이 어렵습니다.</p>
-                <ul className="list-disc list-inside flex flex-col gap-1 text-[15px]">
-                    <li>정보를 변경하려면 현재 창을 종료한 뒤 다시 예매해 주시기 바랍니다.</li>
-                    <li>지정석의 경우, ‘취소 후 재예매’ 기능을 통해 가격을 변경하실 수 있습니다.</li>
-                </ul>
-                <p className="text-[#666] font-medium mt-1">※ 단, 취소 후 재예매 서비스는 상품에 따라 제공되지 않을 수 있습니다.</p>
-            </div>
-        )
-    }
-];
-
 export default function SupportPage() {
     const router = useRouter();
     const pathname = usePathname();
@@ -69,7 +37,7 @@ export default function SupportPage() {
     const loadInquiries = useCallback(() => {
         const saved = localStorage.getItem("my-inquiries");
         const localInquiries = saved ? JSON.parse(saved) : [];
-        setInquiries([...localInquiries, ...MOCK_INQUIRIES]);
+        setInquiries(localInquiries);
     }, []);
 
     useEffect(() => {

--- a/goorm-gongbang/app/(protected)/my/terms/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/terms/page.tsx
@@ -120,7 +120,7 @@ export default function TermsPage() {
                         <section className="bg-[#FAFAFA] rounded-xl p-6 border border-[#F0F0F0]">
                             <h2 className="text-base font-bold text-[#1A1A1A] mb-3">부칙</h2>
                             <p className="text-sm">본 약관은 2026년 2월 24일부터 시행됩니다.</p>
-                            <p className="text-sm mt-1">문의: <a href="mailto:lab.jehyun@gmail.com" className="text-[var(--foundation-primary-600)] hover:underline">lab.jehyun@gmail.com</a></p>
+                            <p className="text-sm mt-1">문의: <a href="mailto:support@playball.one" className="text-[var(--foundation-primary-600)] hover:underline">support@playball.one</a></p>
                         </section>
                     </div>
                 </div>

--- a/goorm-gongbang/app/(protected)/my/tickets/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/tickets/page.tsx
@@ -81,6 +81,7 @@ export default function TicketsPage() {
 
   const [selectedTicket, setSelectedTicket] = useState<Ticket | null>(null);
   const [isTicketModalOpen, setIsTicketModalOpen] = useState(false);
+  const [ticketModalKey, setTicketModalKey] = useState(0);
   const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
   const [cancelInfo, setCancelInfo] = useState<{ paymentAmount: number; cancelFee: number } | null>(null);
 
@@ -107,6 +108,7 @@ export default function TicketsPage() {
   const handleOpenTicket = (ticket: Ticket) => {
     setSelectedTicket(ticket);
     setIsTicketModalOpen(true);
+    setTicketModalKey(prev => prev + 1);
   };
 
   const handleDeposit = (ticket: Ticket) => {
@@ -248,12 +250,15 @@ export default function TicketsPage() {
         )}
 
         {/* 티켓 상세 모달 (Layer) */}
-        <TicketDetailModal
-          isOpen={isTicketModalOpen}
-          onClose={() => setIsTicketModalOpen(false)}
-          ticketInfo={selectedTicket}
-          ticketId={selectedTicket ? Number(selectedTicket.id) : undefined}
-        />
+        {isTicketModalOpen && (
+          <TicketDetailModal
+            key={ticketModalKey}
+            isOpen={isTicketModalOpen}
+            onClose={() => setIsTicketModalOpen(false)}
+            ticketInfo={selectedTicket}
+            ticketId={selectedTicket ? Number(selectedTicket.id) : undefined}
+          />
+        )}
 
         {/* 취소 모달 */}
         <CancelTicketModal

--- a/goorm-gongbang/components/my/TicketCard.tsx
+++ b/goorm-gongbang/components/my/TicketCard.tsx
@@ -36,8 +36,7 @@ export function TicketCard({ ticket, onClick, onDeposit, onCancel }: TicketCardP
 
     const canCancel = !isDDay && (ticket.actions ? ticket.actions.canCancel : ticket.status === "RESERVED");
 
-    // 클릭 가능 여부 (입금 대기 상태는 클릭 불가)
-    const isClickable = !isWaiting;
+    const isClickable = true;
 
     return (
         <div

--- a/goorm-gongbang/components/my/TicketDetailModal.tsx
+++ b/goorm-gongbang/components/my/TicketDetailModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { RotateCcw } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
 import { getTicketQr } from "@/lib/services";
@@ -17,7 +17,7 @@ export interface TicketInfo {
     location: string;
     time: string;
     dateStr?: string; // e.g., "2026. 03. 28 (토) 14:00"
-    status?: "PAYMENT_WAITING" | "RESERVED" | "UNDER_REVIEW";
+    status?: "PAYMENT_PENDING" | "PAYMENT_WAITING" | "PAID" | "RESERVED" | "UNDER_REVIEW";
 }
 
 interface TicketDetailModalProps {
@@ -28,53 +28,61 @@ interface TicketDetailModalProps {
 }
 
 export function TicketDetailModal({ isOpen, onClose, ticketInfo, ticketId }: TicketDetailModalProps) {
-    const [mounted, setMounted] = useState(false);
     const [timeLeft, setTimeLeft] = useState(0);
     const [refreshKey, setRefreshKey] = useState(0);
     const [qrData, setQrData] = useState<TicketQrData | null>(null);
     const [qrLoading, setQrLoading] = useState(false);
     const [qrUnavailableMessage, setQrUnavailableMessage] = useState<string | null>(null);
+    const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
+    // QR 데이터 fetch + 닫힐 때 초기화
     useEffect(() => {
-        setMounted(true);
-    }, []);
+        if (!isOpen) {
+            if (timerRef.current) clearInterval(timerRef.current);
+            setQrData(null);
+            setTimeLeft(0);
+            setQrUnavailableMessage(null);
+            setQrLoading(false);
+            return;
+        }
+        if (!ticketId || ticketInfo?.status === "UNDER_REVIEW" || ticketInfo?.status === "PAYMENT_WAITING") return;
 
-    // QR 데이터 fetch
-    useEffect(() => {
-        if (!isOpen || !ticketId || ticketInfo?.status === "UNDER_REVIEW") return;
         setQrData(null);
         setQrUnavailableMessage(null);
+        setTimeLeft(0);
         setQrLoading(true);
+
+        let cancelled = false;
         getTicketQr(ticketId)
             .then((data) => {
+                if (cancelled) return;
                 setQrData(data);
                 const remaining = Math.max(0, Math.floor((new Date(data.expiresAt).getTime() - Date.now()) / 1000));
                 setTimeLeft(remaining);
             })
             .catch((err) => {
+                if (cancelled) return;
                 if (err instanceof ApiError && err.status === 400) {
                     setQrUnavailableMessage(err.message || "아직 입장 가능 시간이 아닙니다.");
                 }
             })
-            .finally(() => setQrLoading(false));
-    }, [isOpen, ticketId, refreshKey]);
+            .finally(() => { if (!cancelled) setQrLoading(false); });
+        return () => { cancelled = true; };
+    }, [isOpen, ticketId, ticketInfo?.status, refreshKey]);
 
     // 카운트다운
     useEffect(() => {
-        if (!isOpen || !qrData || timeLeft <= 0) return;
-        const timer = setInterval(() => {
-            setTimeLeft((prev) => {
-                if (prev <= 1) {
-                    clearInterval(timer);
-                    return 0;
-                }
-                return prev - 1;
-            });
+        if (timerRef.current) clearInterval(timerRef.current);
+        if (!qrData?.qrToken || timeLeft <= 0) return;
+        timerRef.current = setInterval(() => {
+            setTimeLeft((prev) => (prev <= 1 ? 0 : prev - 1));
         }, 1000);
-        return () => clearInterval(timer);
-    }, [isOpen, qrData]);
+        return () => {
+            if (timerRef.current) clearInterval(timerRef.current);
+        };
+    }, [qrData?.qrToken, timeLeft > 0]);
 
-    if (!mounted || !isOpen || !ticketInfo) return null;
+    if (!ticketInfo) return null;
 
     // "2026. 03. 29 (일) 14:00" -> "2026년 3월 29일 14:00" 변환 (단순화)
     const formatFullDate = (dateStr?: string) => {
@@ -149,10 +157,7 @@ export function TicketDetailModal({ isOpen, onClose, ticketInfo, ticketId }: Tic
                         {/* 상단: QR & 유효시간 */}
                         <div className="flex flex-col items-center px-6">
                             {ticketInfo.status === "UNDER_REVIEW" ? (
-                                <div className="w-full flex flex-col items-center py-10 gap-4">
-                                    <div className="w-20 h-20 rounded-full bg-gray-50 flex items-center justify-center">
-                                        <RotateCcw className="text-[#999] w-10 h-10" />
-                                    </div>
+                                <div className="w-full flex flex-col items-center py-6 gap-4">
                                     <p className="text-[#333] text-[15px] font-bold text-center leading-relaxed">
                                         비정상 예매 시도가 감지되어<br />
                                         정밀 확인을 진행하고 있습니다.
@@ -171,10 +176,19 @@ export function TicketDetailModal({ isOpen, onClose, ticketInfo, ticketId }: Tic
                             ) : (
                                 <>
                                     {/* QR 코드 영역 */}
-                                    <div className="w-[190px] h-[190px] mb-4 flex items-center justify-center relative">
+                                    <div className="w-[240px] h-[190px] mb-4 flex items-center justify-center relative">
                                         {qrLoading ? (
                                             <div className="w-full h-full flex items-center justify-center">
                                                 <div className="w-10 h-10 border-4 border-[#E8E8E8] border-t-[var(--foundation-primary-500)] rounded-full animate-spin" />
+                                            </div>
+                                        ) : ticketInfo.status === "PAYMENT_WAITING" ? (
+                                            <div className="w-[240px] flex flex-col items-center justify-center gap-2 text-center">
+                                                <p className="text-[#333] text-[15px] font-bold text-center leading-relaxed">
+                                                    무통장입금이 완료되지 않았습니다.
+                                                </p>
+                                                <p className="text-[#888] text-[13px] text-center">
+                                                    입금 완료 후 티켓을 확인할 수 있습니다.
+                                                </p>
                                             </div>
                                         ) : qrUnavailableMessage ? (
                                             <div className="w-full h-full flex flex-col items-center justify-center gap-2 text-center">
@@ -221,22 +235,20 @@ export function TicketDetailModal({ isOpen, onClose, ticketInfo, ticketId }: Tic
                         </div>
 
                         {/* 하단: 구역/블럭/좌석 */}
-                        {ticketInfo.status !== "UNDER_REVIEW" && (
-                            <div className="px-6 flex flex-col gap-5">
-                                <div className="flex flex-col gap-1.5">
-                                    <span className="text-[14px] font-bold text-[#888]">구역/블럭</span>
-                                    <span className="text-[18px] font-bold text-[#1A1A1A]">
-                                        {ticketInfo.type} {ticketInfo.zone}
-                                    </span>
-                                </div>
-                                <div className="flex flex-col gap-1.5">
-                                    <span className="text-[14px] font-bold text-[#888]">좌석</span>
-                                    <span className="text-[18px] font-bold text-[#1A1A1A]">
-                                        {ticketInfo.seat}
-                                    </span>
-                                </div>
+                        <div className="px-6 flex flex-col gap-5">
+                            <div className="flex flex-col gap-1.5">
+                                <span className="text-[14px] font-bold text-[#888]">구역/블럭</span>
+                                <span className="text-[18px] font-bold text-[#1A1A1A]">
+                                    {ticketInfo.type} {ticketInfo.zone}
+                                </span>
                             </div>
-                        )}
+                            <div className="flex flex-col gap-1.5">
+                                <span className="text-[14px] font-bold text-[#888]">좌석</span>
+                                <span className="text-[18px] font-bold text-[#1A1A1A]">
+                                    {ticketInfo.seat}
+                                </span>
+                            </div>
+                        </div>
 
                     </div>
 

--- a/goorm-gongbang/next.config.ts
+++ b/goorm-gongbang/next.config.ts
@@ -24,6 +24,16 @@ const nextConfig = {
         hostname: "assets.playball.one",
         pathname: "/static/clubs/**",
       },
+      {
+        protocol: "http",
+        hostname: "k.kakaocdn.net",
+        pathname: "/**",
+      },
+      {
+        protocol: "https",
+        hostname: "k.kakaocdn.net",
+        pathname: "/**",
+      },
     ],
   },
 


### PR DESCRIPTION
## 🔧 작업 내용
- 마이페이지 내 상세 하위 경로(결제 내역, 개인정보 처리방침, 고객지원, 이용약관) UI 구현 완료
- 티켓 목록 및 상세 모달에서 좌석 번호와 구역 정보를 확인할 수 있도록 UI 개선
- 카카오 프로필 이미지가 정상적으로 출력되지 않는 문제를 해결하기 위해 `next.config.ts`에 이미지 도메인 허용 설정 추가
## 🧩 구현 상세
- **마이페이지 레이아웃**: 각 하위 항목에 맞는 정적/동적 페이지 구조 설계
- **티켓 상세 정보**: `TicketDetailModal`의 레이아웃을 조정하여 좌석 및 구역 정보를 한눈에 볼 수 있게 배치
- **이미지 최적화**: Next.js의 Image 컴포넌트에서 `k.kakaocdn.net` 도메인의 외부 이미지를 허용하도록 보안 설정 업데이트
### 📌 관련 Jira Issue
- GRGB-269 (마이페이지 UI 상세 구현)
## 🧪 테스트 방법
- 마이페이지(/my)에서 각 메뉴 진입 시 정상적으로 페이지가 노출되는지 확인
- 티켓 상세 모달 오픈 시 좌석 정보가 정상적으로 렌더링되는지 확인
- 카카오 로그인 시 프로필 이미지가 깨지지 않고 잘 로드되는지 확인
## ❗ 참고 사항
- `package-lock.json`은 최신 `dev` 브랜치 병합 및 의존성 업데이트 과정에서 갱신되었습니다.