### PR TITLE
Feat/mypage qa

### DIFF
--- a/goorm-gongbang/app/(auth)/kakao/callback/page.tsx
+++ b/goorm-gongbang/app/(auth)/kakao/callback/page.tsx
@@ -41,8 +41,14 @@ export default function KakaoCallbackPage() {
         if (data?.user) {
           setUser({ id: String(data.user.userId), status: data.user.status });
         }
-        if (data?.onboardingRequired) router.replace("/onboarding/intro");
-        else router.replace("/");
+
+        if (data?.onboardingRequired) {
+          router.replace("/onboarding/intro");
+        } else {
+          const next = sessionStorage.getItem("kakao_redirect_next");
+          sessionStorage.removeItem("kakao_redirect_next");
+          router.replace(next && next.startsWith("/") ? next : "/");
+        }
 
         toast.success("로그인 성공");
       } catch (e) {

--- a/goorm-gongbang/app/(auth)/login/page.tsx
+++ b/goorm-gongbang/app/(auth)/login/page.tsx
@@ -110,6 +110,9 @@ export default function LoginPage() {
         return;
       }
 
+      const next = searchParams.get("next");
+      if (next) sessionStorage.setItem("kakao_redirect_next", next);
+
       window.location.href = loginUrl;
     } catch (e) {
       if (e instanceof ApiError) {

--- a/goorm-gongbang/app/(protected)/layout.tsx
+++ b/goorm-gongbang/app/(protected)/layout.tsx
@@ -16,6 +16,8 @@ export default function ProtectedLayout({
   const bootstrapped = useAuthStore((s) => s.bootstrapped);
   const accessToken = useAuthStore((s) => s.accessToken);
   const user = useAuthStore((s) => s.user);
+  const intentionalLogout = useAuthStore((s) => s.intentionalLogout);
+  const clearLogoutFlag = useAuthStore((s) => s.clearLogoutFlag);
 
   const isLoggedIn = bootstrapped && !!accessToken && !!user;
 
@@ -23,12 +25,16 @@ export default function ProtectedLayout({
     if (!bootstrapped) return;
 
     if (!isLoggedIn) {
-      const query = searchParams.toString();
-      const next = query ? `${pathname}?${query}` : pathname;
-
-      router.replace(`/login?next=${encodeURIComponent(next)}`);
+      if (intentionalLogout) {
+        clearLogoutFlag();
+        router.replace("/login");
+      } else {
+        const query = searchParams.toString();
+        const next = query ? `${pathname}?${query}` : pathname;
+        router.replace(`/login?next=${encodeURIComponent(next)}`);
+      }
     }
-  }, [bootstrapped, isLoggedIn, pathname, searchParams, router]);
+  }, [bootstrapped, isLoggedIn, intentionalLogout, clearLogoutFlag, pathname, searchParams, router]);
 
   if (!bootstrapped) {
     return (

--- a/goorm-gongbang/app/(protected)/my/payments/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/payments/page.tsx
@@ -262,7 +262,7 @@ export default function PaymentsPage() {
     return (
         <div className="min-h-screen bg-[#F5F5F5]">
             {/* ─── 상단 헤더 (breadcrumb) ─── */}
-            <div className="sticky top-0 z-10 bg-white border-b border-[#F0F0F0]">
+            <div className="sticky top-12 z-10 bg-white border-b border-[#F0F0F0]">
                 <div className="max-w-[1200px] mx-auto px-4 h-12 flex items-center justify-end">
                     <nav className="flex items-center gap-1.5 text-xs text-[#9E9E9E]">
                         <button

--- a/goorm-gongbang/app/(protected)/my/preferences/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/preferences/page.tsx
@@ -22,7 +22,7 @@ export default function PreferencesPage() {
     return (
         <div className="min-h-screen bg-[#F5F5F5]">
             {/* ─── 상단 헤더 (breadcrumb) ─── */}
-            <div className="sticky top-0 z-10 bg-white border-b border-[#F0F0F0]">
+            <div className="sticky top-12 z-10 bg-white border-b border-[#F0F0F0]">
                 <div className="max-w-[1200px] mx-auto px-4 h-12 flex items-center justify-end">
                     <nav className="flex items-center gap-1.5 text-xs text-[#9E9E9E]">
                         <button

--- a/goorm-gongbang/app/(protected)/my/profile/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/profile/page.tsx
@@ -22,7 +22,7 @@ export default function ProfileEditPage() {
     return (
         <div className="min-h-screen bg-[#F5F5F5]">
             {/* ─── 상단 헤더 (breadcrumb) ─── */}
-            <div className="sticky top-0 z-10 bg-white border-b border-[#F0F0F0]">
+            <div className="sticky top-12 z-10 bg-white border-b border-[#F0F0F0]">
                 <div className="max-w-[1200px] mx-auto px-4 h-12 flex items-center justify-end">
                     <nav className="flex items-center gap-1.5 text-xs text-[#9E9E9E]">
                         <button

--- a/goorm-gongbang/app/(protected)/my/reservations/[id]/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/reservations/[id]/page.tsx
@@ -8,7 +8,7 @@ import { CancelTicketModal } from "@/components/my/CancelTicketModal";
 import { TicketInfo } from "@/components/my/TicketDetailModal";
 import { RESERVATION_STATUS_MAP } from "../page";
 import { getTicketDetail } from "@/lib/services";
-import { parseFeeRate } from "@/lib/utils";
+import { calculateCancelFee } from "@/lib/utils";
 import type { TicketDetail } from "@/lib/types";
 
 function formatDate(iso: string): string {
@@ -78,11 +78,10 @@ export default function ReservationDetailPage({ params }: { params: Promise<{ id
         dateStr: matchDateStr,
     };
 
-    const cancelFeeAmount = (() => {
-        if (!detail.cancellationPolicy) return 0;
-        const r = parseFeeRate(detail.cancellationPolicy.feeRate);
-        return r > 0 ? Math.round((detail.payment?.totalAmount ?? 0) * r) + 2000 : 0;
-    })();
+    const cancelFeeAmount = calculateCancelFee(
+        detail.payment?.totalAmount ?? 0,
+        detail.cancellationPolicy?.feeRate
+    );
 
     return (
         <div className="min-h-screen bg-[#F5F5F5] font-pretendard pb-20">

--- a/goorm-gongbang/app/(protected)/my/reservations/[id]/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/reservations/[id]/page.tsx
@@ -78,10 +78,16 @@ export default function ReservationDetailPage({ params }: { params: Promise<{ id
         dateStr: matchDateStr,
     };
 
+    const cancelFeeAmount = (() => {
+        if (!detail.cancellationPolicy) return 0;
+        const r = parseFeeRate(detail.cancellationPolicy.feeRate);
+        return r > 0 ? Math.round((detail.payment?.totalAmount ?? 0) * r) + 2000 : 0;
+    })();
+
     return (
         <div className="min-h-screen bg-[#F5F5F5] font-pretendard pb-20">
             {/* 상단 헤더 */}
-            <div className="sticky top-0 z-10 bg-white border-b border-[#F0F0F0]">
+            <div className="sticky top-12 z-10 bg-white border-b border-[#F0F0F0]">
                 <div className="max-w-[1200px] mx-auto px-4 h-12 flex items-center justify-end">
                     <nav className="flex items-center gap-1.5 text-[13px] text-[#9E9E9E]">
                         <button type="button" onClick={() => router.push("/my")} className="hover:text-[#1A1A1A] transition-colors">마이페이지</button>
@@ -262,43 +268,60 @@ export default function ReservationDetailPage({ params }: { params: Promise<{ id
                     )}
 
                     {/* 결제 정보 (일반 예매) */}
-                    {!isCancelled && detail.payment && (
+                    {!isCancelled && detail.status !== "PAYMENT_PENDING" && detail.payment && (
                         <section className="flex flex-col gap-4">
                             <h2 className="text-[18px] font-bold text-[#1A1A1A]">결제 정보</h2>
-                            <div className="bg-white border border-[#E8E8E8] rounded-2xl p-6">
-                                <div className="grid grid-cols-[100px_1fr] items-center pb-5 border-b border-[#F0F0F0]">
+                            <div className="bg-white border border-[#E8E8E8] rounded-2xl p-6 flex flex-col gap-5">
+                                <div className="grid grid-cols-[100px_1fr] items-center">
                                     <span className="text-[14px] text-[#999] font-medium">결제 일시</span>
-                                    <span className="text-[15px] font-medium text-[#1A1A1A]">{formatDate(detail.payment.paidAt)}</span>
+                                    <span className="text-[15px] font-medium text-[#1A1A1A]">
+                                        {detail.status === "PAYMENT_PENDING"
+                                            ? (detail.createdAt ? formatDate(detail.createdAt) : "-")
+                                            : (detail.payment ? formatDate(detail.payment.paidAt) : "-")}
+                                    </span>
                                 </div>
-                                <div className="grid grid-cols-[100px_1fr] items-center pt-5">
+                                <div className="grid grid-cols-[100px_1fr] items-center">
                                     <span className="text-[14px] text-[#999] font-medium">결제 수단</span>
-                                    <span className="text-[15px] font-medium text-[#1A1A1A]">{detail.payment.paymentMethod}</span>
+                                    <span className="text-[15px] font-medium text-[#1A1A1A]">
+                                        {detail.status === "PAYMENT_PENDING"
+                                            ? (detail.virtualAccount ? `무통장입금 (${detail.virtualAccount.bank})` : "-")
+                                            : (detail.payment ? detail.payment.paymentMethod : "-")}
+                                    </span>
                                 </div>
                             </div>
                         </section>
                     )}
 
                     {/* 결제 금액 (일반 예매) */}
-                    {!isCancelled && detail.payment && (
+                    {!isCancelled && (detail.payment || detail.status === "PAYMENT_PENDING") && (
                         <section className="flex flex-col gap-4">
                             <h2 className="text-[18px] font-bold text-[#1A1A1A]">결제 금액</h2>
                             <div className="bg-white border border-[#E8E8E8] rounded-2xl p-6">
-                                <div className="flex justify-between items-center pb-4 border-b border-[#E8E8E8]">
-                                    <span className="text-[18px] font-bold text-[var(--foundation-primary-500)]">총 결제 금액</span>
-                                    <span className="text-[20px] font-bold text-[var(--foundation-primary-500)]">{detail.payment.totalAmount.toLocaleString()} 원</span>
-                                </div>
-                                <div className="flex flex-col gap-2.5 py-5 border-b border-[#E8E8E8]">
-                                    {seatLabels.map((label, idx) => (
-                                        <div key={idx} className="flex justify-between items-center text-[14px]">
-                                            <span className="text-[#333] font-medium">{label}</span>
-                                            <span className="text-[#1A1A1A] font-medium">{(detail.payment!.totalAmount - detail.payment!.serviceFee).toLocaleString()} 원</span>
-                                        </div>
-                                    ))}
-                                    <div className="flex justify-between items-center text-[14px]">
-                                        <span className="text-[#333] font-medium">수수료</span>
-                                        <span className="text-[#1A1A1A] font-medium">{detail.payment.serviceFee.toLocaleString()} 원</span>
-                                    </div>
-                                </div>
+                                {(() => {
+                                    const totalAmount = detail.payment?.totalAmount ?? 0;
+                                    const serviceFee = detail.payment?.serviceFee ?? 0;
+                                    return (
+                                        <>
+                                            <div className="flex justify-between items-center pb-4 border-b border-[#E8E8E8]">
+                                                <span className="text-[18px] font-bold text-[var(--foundation-primary-500)]">총 결제 금액</span>
+                                                <span className="text-[20px] font-bold text-[var(--foundation-primary-500)]">{totalAmount.toLocaleString()} 원</span>
+                                            </div>
+                                            <div className="flex flex-col gap-2.5 py-5 border-b border-[#E8E8E8]">
+                                                {seatLabels.map((label, idx) => (
+                                                    <div key={idx} className="flex justify-between items-center text-[14px]">
+                                                        <span className="text-[#333] font-medium">{label}</span>
+                                                        <span className="text-[#1A1A1A] font-medium">{(totalAmount - serviceFee).toLocaleString()} 원</span>
+                                                    </div>
+                                                ))}
+                                                <div className="flex justify-between items-center text-[14px]">
+                                                    <span className="text-[#333] font-medium">수수료</span>
+                                                    <span className="text-[#1A1A1A] font-medium">{serviceFee.toLocaleString()} 원</span>
+                                                </div>
+                                            </div>
+                                        </>
+                                    );
+                                })()}
+
                                 {detail.cancellationPolicy && (
                                     <>
                                         <div className="grid grid-cols-[100px_1fr] items-center py-5 border-b border-[#F0F0F0]">
@@ -368,10 +391,7 @@ export default function ReservationDetailPage({ params }: { params: Promise<{ id
                 ticketInfo={cancelTicketInfo}
                 ticketId={Number(resolvedParams.id)}
                 paymentAmount={detail.payment?.totalAmount ?? 0}
-                cancelFee={detail.cancellationPolicy
-                    ? Math.round((detail.payment?.totalAmount ?? 0) * parseFeeRate(detail.cancellationPolicy.feeRate))
-                    : 0
-                }
+                cancelFee={cancelFeeAmount}
                 onCancelSuccess={handleCancelSuccess}
             />
         </div>

--- a/goorm-gongbang/app/(protected)/my/reservations/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/reservations/page.tsx
@@ -18,7 +18,7 @@ import { CancelTicketModal } from "@/components/my/CancelTicketModal";
 import { TicketInfo } from "@/components/my/TicketDetailModal";
 import { ReservationItem } from "@/components/my/ReservationItem";
 import { getTicketList, getTicketDetail } from "@/lib/services";
-import { parseFeeRate } from "@/lib/utils";
+import { calculateCancelFee } from "@/lib/utils";
 import type { TicketItem, TicketSummary } from "@/lib/types";
 
 /* ===========================
@@ -193,8 +193,7 @@ export default function ReservationsPage() {
             try {
                 const detail = await getTicketDetail(Number(item.id));
                 const totalAmount = detail.payment?.totalAmount ?? 0;
-                const feeRate = parseFeeRate(detail.cancellationPolicy?.feeRate);
-                const cancelFee = feeRate > 0 ? Math.round(totalAmount * feeRate) + 2000 : 0;
+                const cancelFee = calculateCancelFee(totalAmount, detail.cancellationPolicy?.feeRate);
                 setCancelInfo({ paymentAmount: totalAmount, cancelFee });
                 setIsCancelModalOpen(true);
             } catch (error: any) {

--- a/goorm-gongbang/app/(protected)/my/reservations/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/reservations/page.tsx
@@ -50,7 +50,7 @@ export const RESERVATION_STATUS_MAP: Record<string, string> = {
     PAID: "결제 완료",
     RESERVED: "결제 완료",
     UNDER_REVIEW: "정밀 확인 중",
-    CANCEL_REQUESTED: "취소 요청 중",
+    CANCEL_REQUESTED: "취소를 처리하고 있어요.",
     CANCEL_PROCESSING: "취소 처리 중",
     CANCELLED: "취소 완료",
     REFUND_PROCESSING: "환불 처리 중",
@@ -193,7 +193,8 @@ export default function ReservationsPage() {
             try {
                 const detail = await getTicketDetail(Number(item.id));
                 const totalAmount = detail.payment?.totalAmount ?? 0;
-                const cancelFee = Math.round(totalAmount * parseFeeRate(detail.cancellationPolicy?.feeRate));
+                const feeRate = parseFeeRate(detail.cancellationPolicy?.feeRate);
+                const cancelFee = feeRate > 0 ? Math.round(totalAmount * feeRate) + 2000 : 0;
                 setCancelInfo({ paymentAmount: totalAmount, cancelFee });
                 setIsCancelModalOpen(true);
             } catch (error: any) {
@@ -207,7 +208,7 @@ export default function ReservationsPage() {
     return (
         <div className="min-h-screen bg-[#F5F5F5] font-pretendard">
             {/* ─── 상단 헤더 (breadcrumb) ─── */}
-            <div className="sticky top-0 z-10 bg-white border-b border-[#F0F0F0]">
+            <div className="sticky top-12 z-10 bg-white border-b border-[#F0F0F0]">
                 <div className="max-w-[1200px] mx-auto px-4 h-12 flex items-center justify-end">
                     <nav className="flex items-center gap-1.5 text-[13px] text-[#9E9E9E]">
                         <button
@@ -282,12 +283,13 @@ export default function ReservationsPage() {
                 </div>
 
                 {/* 테이블 */}
-                <div className="bg-white rounded-[12px] border border-[#E8E8E8] overflow-hidden">
-                    <div className="grid grid-cols-[minmax(180px,1fr)_minmax(200px,1fr)_100px_80px_minmax(280px,2fr)_minmax(200px,1fr)] items-center px-6 py-4 bg-[#FAFAFA] border-b border-[#E8E8E8] text-[14px] text-[#666] font-semibold">
+                <div className="overflow-x-auto">
+                <div className="bg-white rounded-[12px] border border-[#E8E8E8] overflow-hidden min-w-[1078px]">
+                    <div className="grid grid-cols-[150px_minmax(200px,1fr)_120px_80px_minmax(280px,2fr)_200px] items-center px-6 py-4 bg-[#FAFAFA] border-b border-[#E8E8E8] text-[14px] text-[#666] font-semibold">
                         <div>경기 일시</div>
                         <div>경기 정보</div>
                         <div>장소</div>
-                        <div>티켓 수</div>
+                        <div className="text-center">티켓 수</div>
                         <div>좌석 정보</div>
                         <div className="pl-4">진행 상황</div>
                     </div>
@@ -309,6 +311,7 @@ export default function ReservationsPage() {
                             ))
                         )}
                     </div>
+                </div>
                 </div>
 
                 {/* Pagination */}

--- a/goorm-gongbang/app/(protected)/my/support/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/support/page.tsx
@@ -47,7 +47,7 @@ export default function SupportPage() {
     return (
         <div className="min-h-screen bg-[#F8F9FA]">
             {/* ─── 상단 헤더 (breadcrumb) ─── */}
-            <div className="bg-white border-b border-[#F0F0F0]">
+            <div className="sticky top-12 z-10 bg-white border-b border-[#F0F0F0]">
                 <div className="max-w-[1240px] mx-auto px-6 h-12 flex items-center justify-end">
                     <nav className="flex items-center gap-1.5 text-xs text-[#999999]">
                         <button
@@ -75,8 +75,8 @@ export default function SupportPage() {
                     이전으로 돌아가기
                 </button>
 
-                <div className="mb-10 flex items-center justify-between">
-                    <h1 className="text-[32px] font-extrabold tracking-tight text-[#1A1A1A]">1:1 문의</h1>
+                <div className="mb-8 flex items-center justify-between">
+                    <h1 className="text-[24px] font-bold text-[#1A1A1A]">1:1 문의</h1>
                     <ActionButton
                         onClick={() => router.push("/my/support/write")}
                         size="lg"

--- a/goorm-gongbang/app/(protected)/my/support/write/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/support/write/page.tsx
@@ -139,7 +139,7 @@ export default function SupportWritePage() {
     return (
         <div className="min-h-screen bg-[#F8F9FA]">
             {/* ─── 상단 헤더 (breadcrumb) ─── */}
-            <div className="bg-white border-b border-[#F0F0F0]">
+            <div className="sticky top-12 z-10 bg-white border-b border-[#F0F0F0]">
                 <div className="max-w-[1240px] mx-auto px-6 h-12 flex items-center justify-end">
                     <nav className="flex items-center gap-1.5 text-xs text-[#999999]">
                         <button

--- a/goorm-gongbang/app/(protected)/my/tickets/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/tickets/page.tsx
@@ -131,7 +131,7 @@ export default function TicketsPage() {
       const totalAmount = detail.payment?.totalAmount ?? 0;
       const feeRate = detail.cancellationPolicy?.feeRate ?? "0";
       const rate = parseFloat(feeRate.replace("%", "")) / 100;
-      const cancelFee = Math.round(totalAmount * rate);
+      const cancelFee = rate > 0 ? Math.round(totalAmount * rate) + 2000 : 0;
       setCancelInfo({ paymentAmount: totalAmount, cancelFee });
       setIsCancelModalOpen(true);
     });
@@ -140,7 +140,7 @@ export default function TicketsPage() {
   return (
     <div className="min-h-screen bg-[#F5F5F5] font-pretendard">
       {/* ─── 상단 헤더 (breadcrumb) ─── */}
-      <div className="sticky top-0 z-10 bg-white border-b border-[#F0F0F0]">
+      <div className="sticky top-12 z-10 bg-white border-b border-[#F0F0F0]">
         <div className="max-w-[1200px] mx-auto px-4 h-12 flex items-center justify-end">
           <nav className="flex items-center gap-1.5 text-xs text-[#9E9E9E]">
             <button

--- a/goorm-gongbang/app/(protected)/my/tickets/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/tickets/page.tsx
@@ -8,6 +8,7 @@ import { TicketDetailModal } from "@/components/my/TicketDetailModal";
 import { CancelTicketModal } from "@/components/my/CancelTicketModal";
 import { TicketCard, Ticket, TicketStatus } from "@/components/my/TicketCard";
 import { getUpcomingTickets, getTicketDetail } from "@/lib/services";
+import { calculateCancelFee } from "@/lib/utils";
 import type { UpcomingTicketItem } from "@/lib/types";
 
 /* UpcomingTicketItem (API) → Ticket (UI) 매핑 */
@@ -129,9 +130,7 @@ export default function TicketsPage() {
     setSelectedTicket(ticket);
     getTicketDetail(Number(ticket.id)).then((detail) => {
       const totalAmount = detail.payment?.totalAmount ?? 0;
-      const feeRate = detail.cancellationPolicy?.feeRate ?? "0";
-      const rate = parseFloat(feeRate.replace("%", "")) / 100;
-      const cancelFee = rate > 0 ? Math.round(totalAmount * rate) + 2000 : 0;
+      const cancelFee = calculateCancelFee(totalAmount, detail.cancellationPolicy?.feeRate);
       setCancelInfo({ paymentAmount: totalAmount, cancelFee });
       setIsCancelModalOpen(true);
     });

--- a/goorm-gongbang/app/(public)/faq/page.tsx
+++ b/goorm-gongbang/app/(public)/faq/page.tsx
@@ -1,15 +1,8 @@
-/* ===========================
-   FAQ (자주 묻는 질문) 페이지
-   Route: /my/faq
-   - 아코디언 스타일의 질문 리스트
-   - 이미지 가이드에 맞춘 스타일링 (Border, 활성화 색상 등)
-=========================== */
-
 "use client";
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { ChevronDown, ChevronUp, ChevronLeft } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const FAQ_DATA = [
@@ -74,37 +67,19 @@ export default function FAQPage() {
 
     return (
         <div className="min-h-screen bg-[#F5F5F5]">
-            {/* ─── 상단 헤더 (breadcrumb) ─── */}
-            <div className="sticky top-0 z-10 bg-white border-b border-[#F0F0F0]">
-                <div className="max-w-[1200px] mx-auto px-4 h-12 flex items-center justify-end">
-                    <nav className="flex items-center gap-1.5 text-xs text-[#9E9E9E]">
-                        <button
-                            type="button"
-                            onClick={() => router.push("/my")}
-                            className="hover:text-[#1A1A1A] transition-colors"
-                        >
-                            마이페이지
-                        </button>
-                        <span>&gt;</span>
-                        <span className="text-[#1A1A1A] font-medium">FAQ</span>
-                    </nav>
-                </div>
-            </div>
-
-            {/* ─── 본문 ─── */}
-            <div className="max-w-[1200px] mx-auto px-4 py-5">
-                {/* 이전으로 돌아가기 */}
+            <div className="max-w-[1200px] mx-auto px-4 py-8">
                 <button
                     type="button"
                     onClick={() => router.back()}
-                    className="mb-4 text-sm text-[#9E9E9E] hover:text-[#1A1A1A] transition-colors"
+                    className="mb-8 text-[13px] font-medium text-[#7A7A7A] hover:text-[#1A1A1A] transition-colors flex items-center gap-1"
                 >
-                    ← 이전으로 돌아가기
+                    <ChevronLeft className="w-4 h-4" />
+                    이전으로 돌아가기
                 </button>
 
                 <div className="mb-8 ml-2">
                     <h1 className="flex items-baseline gap-3">
-                        <span className="text-[32px] font-black tracking-tight text-[#1A1A1A]">FAQ</span>
+                        <span className="text-[24px] font-bold text-[#1A1A1A]">FAQ</span>
                         <span className="text-[15px] font-medium text-[#9E9E9E]">자주 묻는 질문</span>
                     </h1>
                 </div>

--- a/goorm-gongbang/app/(public)/notices/page.tsx
+++ b/goorm-gongbang/app/(public)/notices/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { ChevronRight, ChevronLeft, ChevronDown, ChevronUp } from "lucide-react";
+import { ChevronLeft, ChevronDown, ChevronUp } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const NOTICE_DATA = [
@@ -296,26 +296,7 @@ export default function NoticesPage() {
 
     return (
         <div className="min-h-screen bg-[#F5F5F5]">
-            {/* ─── 상단 헤더 (breadcrumb) ─── */}
-            <div className="sticky top-0 z-10 bg-white border-b border-[#F0F0F0]">
-                <div className="max-w-[1200px] mx-auto px-4 h-12 flex items-center justify-end">
-                    <nav className="flex items-center gap-1.5 text-xs text-[#9E9E9E]">
-                        <button
-                            type="button"
-                            onClick={() => router.push("/my")}
-                            className="hover:text-[#1A1A1A] transition-colors"
-                        >
-                            마이페이지
-                        </button>
-                        <span>&gt;</span>
-                        <span className="text-[#1A1A1A] font-medium">공지사항</span>
-                    </nav>
-                </div>
-            </div>
-
-            {/* ─── 본문 ─── */}
             <div className="max-w-[1200px] mx-auto px-4 py-8">
-                {/* 이전으로 돌아가기 */}
                 <button
                     type="button"
                     onClick={() => router.back()}
@@ -327,7 +308,7 @@ export default function NoticesPage() {
 
                 <div className="mb-8 ml-2">
                     <h1 className="flex items-baseline gap-3">
-                        <span className="text-[32px] font-black tracking-tight text-[#1A1A1A]">공지사항</span>
+                        <span className="text-[24px] font-bold text-[#1A1A1A]">공지사항</span>
                         <span className="text-[15px] font-medium text-[#9E9E9E]">총 {NOTICE_DATA.length}건</span>
                     </h1>
                 </div>

--- a/goorm-gongbang/app/(public)/privacy/page.tsx
+++ b/goorm-gongbang/app/(public)/privacy/page.tsx
@@ -1,11 +1,3 @@
-/* ===========================
-   개인정보 처리방침 페이지
-   Route: /my/privacy
-   - 브레드크럼: 마이페이지 > 개인정보 처리방침
-   - 이전으로 돌아가기 버튼 포함
-   - 개인정보 처리방침.md 내용 반영
-=========================== */
-
 "use client";
 
 import { useRouter } from "next/navigation";
@@ -16,26 +8,7 @@ export default function PrivacyPolicyPage() {
 
     return (
         <div className="min-h-screen bg-[#F5F5F5]">
-            {/* ─── 상단 헤더 (breadcrumb) ─── */}
-            <div className="sticky top-0 z-10 bg-white border-b border-[#F0F0F0]">
-                <div className="max-w-[1200px] mx-auto px-4 h-12 flex items-center justify-end">
-                    <nav className="flex items-center gap-1.5 text-xs text-[#9E9E9E]">
-                        <button
-                            type="button"
-                            onClick={() => router.push("/my")}
-                            className="hover:text-[#1A1A1A] transition-colors"
-                        >
-                            마이페이지
-                        </button>
-                        <span>&gt;</span>
-                        <span className="text-[#1A1A1A] font-medium">개인정보 처리방침</span>
-                    </nav>
-                </div>
-            </div>
-
-            {/* ─── 본문 ─── */}
             <div className="max-w-[1200px] mx-auto px-4 py-5">
-                {/* 이전으로 돌아가기 */}
                 <button
                     type="button"
                     onClick={() => router.back()}

--- a/goorm-gongbang/app/(public)/refund/page.tsx
+++ b/goorm-gongbang/app/(public)/refund/page.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { ChevronLeft } from "lucide-react";
+
+export default function RefundPolicyPage() {
+    const router = useRouter();
+
+    return (
+        <div className="min-h-screen bg-[#F5F5F5]">
+            <div className="max-w-[1200px] mx-auto px-4 py-5">
+                <button
+                    type="button"
+                    onClick={() => router.back()}
+                    className="mb-8 text-[13px] font-medium text-[#7A7A7A] hover:text-[#1A1A1A] transition-colors flex items-center gap-1"
+                >
+                    <ChevronLeft className="w-4 h-4" />
+                    이전으로 돌아가기
+                </button>
+
+                <div className="bg-white rounded-xl border border-[#E8E8E8] px-6 py-8 md:px-10">
+                    <h1 className="text-2xl font-bold text-[#1A1A1A] mb-8">취소 · 환불 정책</h1>
+
+                    <div className="space-y-10 text-[15px] leading-7 text-[#3D3D3D]">
+
+                        {/* 취소 가능 기간 */}
+                        <section>
+                            <h2 className="text-lg font-bold text-[#1A1A1A] mb-4">1. 취소 가능 기간</h2>
+                            <p className="mb-4">취소 가능 여부는 경기 당일 기준으로 판단합니다. 경기 당일은 취소·환불이 불가하며, 전일(D-1)까지만 취소 가능합니다.</p>
+
+                            <div className="overflow-x-auto">
+                                <table className="w-full border-collapse border border-[#F0F0F0] text-sm">
+                                    <thead>
+                                        <tr className="bg-[#FAFAFA]">
+                                            <th className="border border-[#F0F0F0] px-4 py-3 text-left font-bold text-[#1A1A1A]">취소 시점</th>
+                                            <th className="border border-[#F0F0F0] px-4 py-3 text-left font-bold text-[#1A1A1A]">취소 수수료</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td className="border border-[#F0F0F0] px-4 py-3">예매일 포함 경기 7일 전까지</td>
+                                            <td className="border border-[#F0F0F0] px-4 py-3 text-[var(--foundation-primary-600)] font-medium">없음 (전액 환불)</td>
+                                        </tr>
+                                        <tr>
+                                            <td className="border border-[#F0F0F0] px-4 py-3">경기 6일 전 ~ 1일 전</td>
+                                            <td className="border border-[#F0F0F0] px-4 py-3">티켓 금액의 10% + 예매 대행 수수료</td>
+                                        </tr>
+                                        <tr>
+                                            <td className="border border-[#F0F0F0] px-4 py-3">경기 당일</td>
+                                            <td className="border border-[#F0F0F0] px-4 py-3 text-[var(--foundation-red-500)] font-medium">취소 불가</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+
+                            <p className="mt-4 text-sm text-[#7A7A7A]">
+                                ※ &quot;경기 N일 전&quot; 기준은 취소 요청 시간이 아닌 <strong className="text-[#3D3D3D]">취소 요청 날짜(자정 기준 0시)</strong>로 판단합니다.<br />
+                                ※ 예매 대행 수수료는 예매 시 고지된 수수료 금액을 그대로 적용합니다.
+                            </p>
+                        </section>
+
+                        {/* 결제 수단별 환불 처리 */}
+                        <section>
+                            <h2 className="text-lg font-bold text-[#1A1A1A] mb-4">2. 결제 수단별 환불 처리</h2>
+
+                            <div className="space-y-4">
+                                <div className="bg-[#FAFAFA] rounded-xl p-5 border border-[#F0F0F0]">
+                                    <h3 className="font-bold text-[#1A1A1A] mb-2">간편결제 (카카오페이 / 토스페이)</h3>
+                                    <ul className="list-disc pl-5 space-y-1 text-sm">
+                                        <li>취소 요청 승인 즉시 환불 처리</li>
+                                        <li>실제 계좌/카드 반영은 카드사·PG 정책에 따라 1~3 영업일 소요될 수 있음</li>
+                                    </ul>
+                                </div>
+
+                                <div className="bg-[#FAFAFA] rounded-xl p-5 border border-[#F0F0F0]">
+                                    <h3 className="font-bold text-[#1A1A1A] mb-2">무통장 입금</h3>
+                                    <ul className="list-disc pl-5 space-y-1 text-sm">
+                                        <li>취소 요청 승인 후 <strong>영업일 3일 이내</strong> 등록된 계좌로 환불금 입금</li>
+                                        <li>환불 계좌는 취소 요청 시점에 직접 입력</li>
+                                        <li>처리 결과는 마이페이지 &gt; 티켓 관리에서 확인 가능</li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </section>
+
+                        {/* 무통장 입금 기한 및 자동 취소 */}
+                        <section>
+                            <h2 className="text-lg font-bold text-[#1A1A1A] mb-4">3. 무통장 입금 기한 및 자동 취소</h2>
+
+                            <div className="space-y-4">
+                                <div>
+                                    <h3 className="font-bold text-[#1A1A1A] mb-2">입금 기한</h3>
+                                    <ul className="list-disc pl-5 space-y-1">
+                                        <li><strong>일반 예매</strong>: 예매 완료 익일(+1일) 23시 59분까지</li>
+                                        <li><strong>경기 당일 예매</strong>: 경기 시작 3시간 전까지 (이후 무통장 입금 결제 불가)</li>
+                                    </ul>
+                                </div>
+
+                                <div>
+                                    <h3 className="font-bold text-[#1A1A1A] mb-2">미입금 자동 취소</h3>
+                                    <ul className="list-disc pl-5 space-y-1">
+                                        <li>입금 기한 초과 시 주문 상태가 <strong>자동 취소</strong>로 전환됩니다.</li>
+                                        <li>자동 취소 시 수수료 없이 전액 환불 처리 (입금 미완료 상태이므로)</li>
+                                        <li>자동 취소 전 알림이 발송됩니다.</li>
+                                    </ul>
+                                </div>
+
+                                <p className="text-sm text-[#7A7A7A]">
+                                    ※ 입금 후 잔액 반영까지 약 20분~1시간 소요될 수 있습니다. 반영 전 상태는 마이페이지에서 &quot;결제 대기&quot;로 표시됩니다.
+                                </p>
+                            </div>
+                        </section>
+
+                        {/* 취소 불가 케이스 */}
+                        <section>
+                            <h2 className="text-lg font-bold text-[#1A1A1A] mb-4">4. 취소 불가 케이스</h2>
+
+                            <div className="overflow-x-auto">
+                                <table className="w-full border-collapse border border-[#F0F0F0] text-sm">
+                                    <thead>
+                                        <tr className="bg-[#FAFAFA]">
+                                            <th className="border border-[#F0F0F0] px-4 py-3 text-left font-bold text-[#1A1A1A]">케이스</th>
+                                            <th className="border border-[#F0F0F0] px-4 py-3 text-left font-bold text-[#1A1A1A]">사유</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td className="border border-[#F0F0F0] px-4 py-3">경기 당일 취소 요청</td>
+                                            <td className="border border-[#F0F0F0] px-4 py-3">당일 취소 정책</td>
+                                        </tr>
+                                        <tr>
+                                            <td className="border border-[#F0F0F0] px-4 py-3">이미 사용된 티켓 (QR 인증 완료)</td>
+                                            <td className="border border-[#F0F0F0] px-4 py-3">입장 처리 완료</td>
+                                        </tr>
+                                        <tr>
+                                            <td className="border border-[#F0F0F0] px-4 py-3">취소 처리 진행 중인 건</td>
+                                            <td className="border border-[#F0F0F0] px-4 py-3">중복 요청 방지</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </section>
+
+                        {/* 부분 취소 정책 */}
+                        <section>
+                            <h2 className="text-lg font-bold text-[#1A1A1A] mb-4">5. 부분 취소 정책</h2>
+                            <ul className="list-disc pl-5 space-y-2">
+                                <li>동일 주문 내 일부 매수만 선택적 취소는 <strong>지원하지 않습니다.</strong></li>
+                                <li>취소는 <strong>주문 단위 전체 취소</strong>만 가능합니다.</li>
+                                <li>2매 이상 예매 후 일부만 취소하려는 경우 → 전체 취소 후 재예매를 이용해 주세요.</li>
+                            </ul>
+                        </section>
+
+                        <section className="bg-[#FAFAFA] rounded-xl p-6 border border-[#F0F0F0]">
+                            <h2 className="text-base font-bold text-[#1A1A1A] mb-2">문의</h2>
+                            <p className="text-sm">취소 및 환불 관련 문의는 마이페이지 &gt; 1:1 문의를 통해 접수해 주세요.</p>
+                            <p className="text-sm mt-1">이메일: <a href="mailto:support@playball.one" className="text-[var(--foundation-primary-600)] hover:underline">support@playball.one</a></p>
+                        </section>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/goorm-gongbang/app/(public)/terms/page.tsx
+++ b/goorm-gongbang/app/(public)/terms/page.tsx
@@ -1,11 +1,3 @@
-/* ===========================
-   이용 약관 페이지
-   Route: /my/terms
-   - 브레드크럼: 마이페이지 > 이용 약관
-   - 이전으로 돌아가기 버튼 포함
-   - 이용 약관.md 내용 반영
-=========================== */
-
 "use client";
 
 import { useRouter } from "next/navigation";
@@ -16,26 +8,7 @@ export default function TermsPage() {
 
     return (
         <div className="min-h-screen bg-[#F5F5F5]">
-            {/* ─── 상단 헤더 (breadcrumb) ─── */}
-            <div className="sticky top-0 z-10 bg-white border-b border-[#F0F0F0]">
-                <div className="max-w-[1200px] mx-auto px-4 h-12 flex items-center justify-end">
-                    <nav className="flex items-center gap-1.5 text-xs text-[#9E9E9E]">
-                        <button
-                            type="button"
-                            onClick={() => router.push("/my")}
-                            className="hover:text-[#1A1A1A] transition-colors"
-                        >
-                            마이페이지
-                        </button>
-                        <span>&gt;</span>
-                        <span className="text-[#1A1A1A] font-medium">이용 약관</span>
-                    </nav>
-                </div>
-            </div>
-
-            {/* ─── 본문 ─── */}
             <div className="max-w-[1200px] mx-auto px-4 py-5">
-                {/* 이전으로 돌아가기 */}
                 <button
                     type="button"
                     onClick={() => router.back()}

--- a/goorm-gongbang/app/layout.tsx
+++ b/goorm-gongbang/app/layout.tsx
@@ -34,7 +34,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <Providers>
           <Header />
-            <main className="overflow-x-hidden overflow-y-hidden">
+            <main className="overflow-x-clip">
               {children}
             </main>
             <ConditionalFooter />

--- a/goorm-gongbang/components/layout/ConditionalFooter.tsx
+++ b/goorm-gongbang/components/layout/ConditionalFooter.tsx
@@ -10,7 +10,13 @@ export function ConditionalFooter() {
   const showFooter =
     pathname === "/" ||
     pathname.startsWith("/matches/") ||
-    pathname.startsWith("/clubs/");
+    pathname.startsWith("/clubs/") ||
+    pathname.startsWith("/my") ||
+    pathname === "/notices" ||
+    pathname === "/faq" ||
+    pathname === "/refund" ||
+    pathname === "/privacy" ||
+    pathname === "/terms";
 
   if (!showFooter) return null;
 

--- a/goorm-gongbang/components/layout/Footer.tsx
+++ b/goorm-gongbang/components/layout/Footer.tsx
@@ -76,16 +76,10 @@ export function Footer() {
                                         홈
                                     </Link>
                                     <Link
-                                        href="/"
+                                        href="/my"
                                         className="text-sm font-medium leading-5 text-[var(--foundation-neutral-200)] hover:underline"
                                     >
                                         마이페이지
-                                    </Link>
-                                    <Link
-                                        href="/"
-                                        className="text-sm font-medium leading-5 text-[var(--foundation-neutral-200)] hover:underline"
-                                    >
-                                        공지사항
                                     </Link>
                                 </div>
                             </div>
@@ -96,19 +90,19 @@ export function Footer() {
                                 </div>
                                 <div className="flex flex-col gap-3">
                                     <Link
-                                        href="/"
+                                        href="/refund"
                                         className="text-sm font-medium leading-5 text-[var(--foundation-neutral-200)] hover:underline"
                                     >
                                         취소 환불 정책
                                     </Link>
                                     <Link
-                                        href="/"
+                                        href="/privacy"
                                         className="text-sm font-medium leading-5 text-[var(--foundation-neutral-200)] hover:underline"
                                     >
                                         개인 정보 처리 방침
                                     </Link>
                                     <Link
-                                        href="/"
+                                        href="/terms"
                                         className="text-sm font-medium leading-5 text-[var(--foundation-neutral-200)] hover:underline"
                                     >
                                         이용약관
@@ -122,29 +116,31 @@ export function Footer() {
                                 </div>
                                 <div className="flex flex-col gap-3">
                                     <Link
-                                        href="/"
+                                        href="/notices"
                                         className="text-sm font-medium leading-5 text-[var(--foundation-neutral-200)] hover:underline"
                                     >
                                         공지사항
                                     </Link>
                                     <Link
-                                        href="/"
+                                        href="/faq"
                                         className="text-sm font-medium leading-5 text-[var(--foundation-neutral-200)] hover:underline"
                                     >
                                         FAQ
                                     </Link>
                                     <Link
-                                        href="/"
+                                        href="/my/support"
                                         className="text-sm font-medium leading-5 text-[var(--foundation-neutral-200)] hover:underline"
                                     >
                                         1:1 문의
                                     </Link>
-                                    <Link
-                                        href="/"
+                                    <a
+                                        href="https://walla.my/a/playballPartnership"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
                                         className="text-sm font-medium leading-5 text-[var(--foundation-neutral-200)] hover:underline"
                                     >
-                                        제휴/입점 문의
-                                    </Link>
+                                        제휴 문의
+                                    </a>
                                 </div>
                             </div>
                         </div>

--- a/goorm-gongbang/components/my/DeleteAccountModal.tsx
+++ b/goorm-gongbang/components/my/DeleteAccountModal.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import { deleteAccount } from "@/lib/services";
+
+interface DeleteAccountModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onDeleteSuccess: () => void;
+}
+
+export function DeleteAccountModal({ isOpen, onClose, onDeleteSuccess }: DeleteAccountModalProps) {
+    const [checked1, setChecked1] = useState(false);
+    const [checked2, setChecked2] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    if (!isOpen) return null;
+
+    const canDelete = checked1 && checked2;
+
+    const handleClose = () => {
+        setChecked1(false);
+        setChecked2(false);
+        onClose();
+    };
+
+    const handleDelete = async () => {
+        if (!canDelete || isSubmitting) return;
+        setIsSubmitting(true);
+        try {
+            await deleteAccount();
+            onDeleteSuccess();
+        } catch {
+            // 에러 처리는 서비스 레이어에서
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <div className="fixed inset-0 z-[9999] flex items-center justify-center p-4">
+            {/* Dimmed Background */}
+            <div
+                className="absolute inset-0 bg-black/40 animate-in fade-in duration-200"
+                onClick={handleClose}
+            />
+
+            {/* Modal Body */}
+            <div className="relative w-full max-w-[600px] bg-white rounded-xl px-8 py-10 shadow-xl animate-in zoom-in-95 fade-in duration-200">
+                <h3 className="text-[22px] font-bold text-[#1A1A1A] mb-6">
+                    계정을 삭제하시겠어요?
+                </h3>
+
+                {/* 안내 박스 */}
+                <div className="bg-[#F5F5F5] rounded-xl px-6 py-5 mb-6 text-[14px] text-[#3D3D3D] leading-relaxed flex flex-col gap-1">
+                    <p>회원 탈퇴 시 모든 계정 정보와 이용 기록이 삭제되며 복구할 수 없습니다.</p>
+                    <p>작성한 데이터, 저장된 일정 및 맞춤 정보도 함께 삭제됩니다.</p>
+                    <p>탈퇴 후 동일한 계정으로 재가입은 가능하지만, 이전 정보는 복원되지 않습니다.</p>
+                    <p className="font-bold">탈퇴 후 30일 이내 재가입이 제한됩니다.</p>
+                </div>
+
+                {/* 체크박스 */}
+                <div className="flex flex-col gap-3 mb-8">
+                    <label className="flex items-start gap-3 cursor-pointer">
+                        <input
+                            type="checkbox"
+                            checked={checked1}
+                            onChange={(e) => setChecked1(e.target.checked)}
+                            className="mt-0.5 w-5 h-5 accent-[var(--foundation-primary-500)] cursor-pointer flex-shrink-0"
+                        />
+                        <span className="text-[14px] text-[#3D3D3D]">
+                            회원 탈퇴 시 계정 및 모든 데이터가 삭제되며 복구할 수 없음을 확인했습니다.
+                        </span>
+                    </label>
+                    <label className="flex items-start gap-3 cursor-pointer">
+                        <input
+                            type="checkbox"
+                            checked={checked2}
+                            onChange={(e) => setChecked2(e.target.checked)}
+                            className="mt-0.5 w-5 h-5 accent-[var(--foundation-primary-500)] cursor-pointer flex-shrink-0"
+                        />
+                        <span className="text-[14px] text-[#3D3D3D]">
+                            이용약관 및 개인정보 처리방침에 따른 탈퇴 정책을 확인했습니다.
+                        </span>
+                    </label>
+                </div>
+
+                {/* 버튼 */}
+                <div className="flex gap-3">
+                    <button
+                        type="button"
+                        onClick={handleClose}
+                        className="flex-1 py-4 rounded-[12px] bg-[#E8E8E8] text-[#1A1A1A] text-[16px] font-bold hover:bg-[#D4D4D4] transition-colors active:scale-[0.99]"
+                    >
+                        취소
+                    </button>
+                    <button
+                        type="button"
+                        onClick={handleDelete}
+                        disabled={!canDelete || isSubmitting}
+                        className="flex-1 py-4 rounded-[12px] bg-[var(--foundation-red-500)] text-white text-[16px] font-bold hover:bg-[#E63946] transition-colors active:scale-[0.99] disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                        {isSubmitting ? "탈퇴 처리 중..." : "계정 삭제하기"}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/goorm-gongbang/components/my/DeleteAccountModal.tsx
+++ b/goorm-gongbang/components/my/DeleteAccountModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
 import { deleteAccount } from "@/lib/services";
 
 interface DeleteAccountModalProps {
@@ -30,8 +31,8 @@ export function DeleteAccountModal({ isOpen, onClose, onDeleteSuccess }: DeleteA
         try {
             await deleteAccount();
             onDeleteSuccess();
-        } catch {
-            // 에러 처리는 서비스 레이어에서
+        } catch (error: any) {
+            toast.error(error?.message || "회원 탈퇴 처리 중 오류가 발생했습니다.");
         } finally {
             setIsSubmitting(false);
         }

--- a/goorm-gongbang/components/my/MyPageLayout.tsx
+++ b/goorm-gongbang/components/my/MyPageLayout.tsx
@@ -20,6 +20,7 @@ import { cn } from "@/lib/utils";
 import { ChevronRight } from "lucide-react";
 import { getMyPageProfile } from "@/lib/services";
 import type { MyPageProfileData } from "@/lib/types";
+import { DeleteAccountModal } from "./DeleteAccountModal";
 
 
 /* ===========================
@@ -49,11 +50,12 @@ const SECTIONS: Section[] = [
     {
         title: "일반",
         items: [
-            { label: "공지사항", href: "/my/notices" },
-            { label: "FAQ", href: "/my/faq" },
+            { label: "공지사항", href: "/notices" },
+            { label: "FAQ", href: "/faq" },
             { label: "1:1 문의", href: "/my/support" },
-            { label: "이용약관", href: "/my/terms" },
-            { label: "개인정보 처리방침", href: "/my/privacy" },
+            { label: "이용약관", href: "/terms" },
+            { label: "취소·환불 정책", href: "/refund" },
+            { label: "개인정보 처리방침", href: "/privacy" },
         ],
     },
 ];
@@ -80,6 +82,7 @@ export function MyPageLayout({ children }: Props) {
     const isLoggedIn = bootstrapped && !!accessToken && !!user;
 
     const [profileData, setProfileData] = useState<MyPageProfileData | null>(null);
+    const [showDeleteModal, setShowDeleteModal] = useState(false);
 
     // Guard
     useEffect(() => {
@@ -97,7 +100,7 @@ export function MyPageLayout({ children }: Props) {
     // 로그아웃
     const handleLogout = () => {
         logoutStore();
-        router.replace("/login");
+        router.replace("/");
     };
 
     // 로딩 중
@@ -253,7 +256,7 @@ export function MyPageLayout({ children }: Props) {
                     {/* 회원 탈퇴 */}
                     <button
                         type="button"
-                        onClick={() => {/* 추후 구현 */ }}
+                        onClick={() => setShowDeleteModal(true)}
                         className="w-full flex items-center py-3.5 text-[var(--foundation-red-500)] text-sm font-normal hover:opacity-80 transition-opacity"
                     >
                         회원 탈퇴
@@ -267,6 +270,16 @@ export function MyPageLayout({ children }: Props) {
                     </div>
                 )}
             </div>
+
+            {/* 회원 탈퇴 모달 */}
+            <DeleteAccountModal
+                isOpen={showDeleteModal}
+                onClose={() => setShowDeleteModal(false)}
+                onDeleteSuccess={() => {
+                    logoutStore();
+                    router.replace("/");
+                }}
+            />
         </div>
     );
 }

--- a/goorm-gongbang/components/my/ReservationItem.tsx
+++ b/goorm-gongbang/components/my/ReservationItem.tsx
@@ -50,14 +50,14 @@ export function ReservationItem({ item, isLast, onActionClick, isLoading }: Rese
             onClick={() => {
                 router.push(`/my/reservations/${item.id}`);
             }}
-            className={`grid grid-cols-[minmax(180px,1fr)_minmax(200px,1fr)_100px_80px_minmax(280px,2fr)_minmax(200px,1fr)] items-center px-6 py-[18px] text-[14px] text-[#1A1A1A] font-medium transition-colors hover:bg-gray-50 cursor-pointer
+            className={`grid grid-cols-[150px_minmax(200px,1fr)_120px_80px_minmax(280px,2fr)_200px] items-center px-6 py-[18px] text-[14px] text-[#1A1A1A] font-medium transition-colors hover:bg-gray-50 cursor-pointer
                 ${!isLast ? 'border-b border-[#F0F0F0]' : ''}
             `}
         >
             <div className="tracking-tight">{item.date}</div>
             <div>{item.matchTitle}</div>
             <div className="text-[#666]">{item.location}</div>
-            <div className="text-[#666]">{item.count}</div>
+            <div className="text-[#666] text-center">{item.count}</div>
             <div className="truncate pr-4">{item.seat}</div>
 
             {/* 진행 상황 및 액션 영역 */}

--- a/goorm-gongbang/lib/services/mypage.service.ts
+++ b/goorm-gongbang/lib/services/mypage.service.ts
@@ -141,3 +141,16 @@ export const getAccountInfo = async (): Promise<AccountInfo> => {
     throw err;
   }
 };
+
+/* 회원 탈퇴 */
+export const deleteAccount = async (): Promise<void> => {
+  try {
+    await auth.delete(`${API_BASE_URL}/auth/account`);
+  } catch (err) {
+    if (err instanceof ApiError) {
+      if (err.status === 403) throw new Error("탈퇴 권한이 없습니다.");
+      if (err.status === 409) throw new Error("이미 탈퇴 처리된 계정입니다.");
+    }
+    throw err;
+  }
+};

--- a/goorm-gongbang/lib/types/mypage.types.ts
+++ b/goorm-gongbang/lib/types/mypage.types.ts
@@ -137,6 +137,9 @@ export type VirtualAccount = {
   accountNumber: string;
   holder: string;
   depositDeadline: string;
+  totalAmount?: number;
+  serviceFee?: number;
+  paymentMethod?: string;
 };
 
 export type TicketCancellation = {
@@ -148,6 +151,7 @@ export type TicketCancellation = {
 export type TicketDetail = {
   ticketId: number;
   status: string;
+  createdAt: string;
   match: TicketMatch;
   seats: TicketSeat[];
   payment: TicketPayment | null;

--- a/goorm-gongbang/lib/utils.ts
+++ b/goorm-gongbang/lib/utils.ts
@@ -14,3 +14,19 @@ export function parseFeeRate(feeRate: string | null | undefined): number {
   const parsed = parseFloat(cleaned);
   return isNaN(parsed) ? 0 : parsed / 100;
 }
+
+/** 취소 수수료 고정 금액 (원) */
+export const CANCEL_FIXED_FEE = 2000;
+
+/**
+ * 취소 수수료를 계산합니다.
+ * totalAmount가 0이거나 feeRate가 0이면 0을 반환합니다.
+ */
+export function calculateCancelFee(
+  totalAmount: number,
+  feeRate: string | null | undefined
+): number {
+  if (totalAmount <= 0) return 0;
+  const rate = parseFeeRate(feeRate);
+  return rate > 0 ? Math.round(totalAmount * rate) + CANCEL_FIXED_FEE : 0;
+}

--- a/goorm-gongbang/stores/authStore.ts
+++ b/goorm-gongbang/stores/authStore.ts
@@ -14,11 +14,13 @@ type AuthState = {
   accessToken: string | null; // accessToken
   user: User | null; // 로그인 된 사용자
   bootstrapped: boolean; // Provider에서 초기 인증 복구 절차 여부 플래그
+  intentionalLogout: boolean; // 명시적 로그아웃 여부 (next redirect 방지용)
 
   setBootstrapped: (v: boolean) => void;
   setAccessToken: (t: string | null) => void;
   setUser: (u: User | null) => void;
   logout: () => void;
+  clearLogoutFlag: () => void;
 };
 
 /* Zustand store을 만드는 함수 */
@@ -28,12 +30,14 @@ export const useAuthStore = create<AuthState>()(
       accessToken: null,
       user: null,
       bootstrapped: false,
+      intentionalLogout: false,
 
       /* 액션 함수들 동작 방식 */
       setBootstrapped: (v) => set({ bootstrapped: v }), // 완료시 True로 변경
       setAccessToken: (t) => set({ accessToken: t }), // refresh 성공 시 호출
       setUser: (u) => set({ user: u }), // refresh 성공 시 호출
-      logout: () => set({ accessToken: null, user: null }), // 로그아웃 시 초기화
+      logout: () => set({ accessToken: null, user: null, intentionalLogout: true }), // 로그아웃 시 초기화
+      clearLogoutFlag: () => set({ intentionalLogout: false }),
     }),
     {
       name: "auth-storage", // localStorage 키 이름


### PR DESCRIPTION
## 🔧 작업 내용
- **무엇을 개발했는지**
  - 회원 탈퇴 기능 추가 (탈퇴 API 연동 및 모달 UI 구현)
  - 공지사항, FAQ, 약관 등의 정적 페이지를 로그인 없이 접근 가능한 Public 라우트로 이동
  - 의도적 로그아웃 상태를 관리하는 `intentionalLogout` 플래그를 추가하여 인증 스토어 관리

- **어떤 문제를 해결했는지**
  - 권한이 불필요한 정책 페이지가 보호된 라우팅(`/my`) 내에 위치하던 구조적 오류를 해결했습니다.
  - 사용자의 명시적 로그아웃과 토큰 만료 등 예기치 않은 세션 종료를 구분하지 못해 발생하던 로그인 콜백 라우팅 꼬임 문제를 해결했습니다.

- **왜 이런 방식으로 구현했는지**
  - 마이페이지 레이아웃 구조를 단순화하고, 정책 확인 목적으로 접근하는 신규 사용자들이 블로킹되지 않도록 인증 미들웨어 계층의 책임을 분리했습니다.
  - 상태 스토어(Zustand)에 로그아웃 플래그를 두어 컴포넌트 마운트 시 불필요한 리다이렉트나 API 중복 호출을 막고자 했습니다.

## 🧩 구현 상세 (선택)
- **핵심 로직 설명**
  - 탈퇴 시 `auth.delete`로 토큰을 무효화한 뒤 에러 상황(권한 없음, 이미 탈퇴됨)을 클라이언트에서 분기 처리하여 유저에게 일관된 피드백을 전달합니다.
- **구조 및 설계**
  - 기존 마이페이지 사이드바에 있던 정책/약관 메뉴를 `app/(public)/` 하위로 이동시키고, `MyPageLayout`의 Navigation Href를 수정하여 UX 일관성을 유지했습니다.
  - 예약 내역 페이지(`ReservationItem`)의 그리드 비율을 개선하고, `VirtualAccount`, `TicketDetail` 등 프론트엔드 비즈니스 로직에 새롭게 요구되는 필드(`createdAt`, `totalAmount` 등)를 타입으로 명시했습니다.

### 📌 관련 Jira Issue
- GRGB-XX *(발행하신 지라 티켓 번호로 변경해주세요)*

## 🧪 테스트 방법 (선택)
- **테스트 대상**: 비로그인 정책 페이지 접근, 회원 탈퇴 모달 동작, 마이페이지 로그아웃 흐름
- **체크 포인트**:
  1. 비로그인 상태에서 `localhost:3000/notices`, `/terms` 접근 시 정상 렌더링 확인
  2. 마이페이지 화면 하단 '회원 탈퇴' 버튼 정상 렌더링 및 모달 호출 확인
  3. 명시적으로 로그아웃 진행 후 카카오 로그인 등의 재진입 시 화면 깜빡임이나 라우팅 꼬임 여부 확인

## ❗ 참고 사항
- **리뷰 시 유의할 점**: Public 라우트로 빠진 부분과 기존 Protected 라우트에 남아있는 마이페이지 컴포넌트 간의 CSS 충돌 여부를 한 번 더 확인 부탁드립니다.
- **후속 작업 예정**: 정책 문서(서비스 이용약관 등)의 실제 API 데이터 연동 (현재는 정적 페이지 분리만 완료)

