### PR TITLE
[feat](ui): 회원 탈퇴 기능 정상화 및 전반적인 레이아웃·컴포넌트 UI 폴리싱

### DIFF
--- a/goorm-gongbang/app/(protected)/pay/[matchId]/page.tsx
+++ b/goorm-gongbang/app/(protected)/pay/[matchId]/page.tsx
@@ -502,20 +502,6 @@ export default function Page() {
                             </div>
 
                             <div className="min-w-0 flex items-center gap-2">
-                                <div
-                                    data-logo="LG"
-                                    data-mode="Color"
-                                    data-size="xsmall"
-                                    className="w-7 h-7 sm:w-8 sm:h-8 bg-white inline-flex flex-col justify-center items-center overflow-hidden shrink-0"
-                                >
-                                    <img
-                                        className="h-full w-full object-cover"
-                                        src={resolveLogoSrc("lg-twins.png")}
-                                        alt={"홈 구단 로고"}
-                                    />
-
-                                </div>
-
                                 <div className="min-w-0 text-[var(--foundation-neutral-400)] text-sm sm:text-base font-medium leading-5 sm:leading-6 truncate">
                                     {match?.stadium.koName ?? "-"}
                                 </div>

--- a/goorm-gongbang/app/(public)/clubs/[clubId]/page.tsx
+++ b/goorm-gongbang/app/(public)/clubs/[clubId]/page.tsx
@@ -464,7 +464,7 @@ export default function ClubDetailPage() {
                       key={dateKey}
                       className={cn(
                         "min-h-[160px] sm:min-h-[180px] lg:min-h-[200px]",
-                        "border border-slate-200 rounded-lg flex flex-col items-center transition-all overflow-hidden",
+                        "border border-slate-200/50 rounded-lg flex flex-col items-center transition-all overflow-hidden",
                         isHoverable && "hover:border-[var(--foundation-primary-300)]",
                         (!match || match.saleStatus === "ENDED") && "bg-[var(--background-grey)]",
 

--- a/goorm-gongbang/app/page.tsx
+++ b/goorm-gongbang/app/page.tsx
@@ -234,7 +234,7 @@ export default function Home() {
               </div>
 
               {/* MatchCard list */}
-              <div className="w-full flex flex-col items-center gap-3">
+              <div className="w-full flex flex-col items-center gap-3 min-h-[608px]">
                 {loadingMatches ? (
                   <div className="w-full flex flex-col items-center gap-3">
                     {Array.from({ length: 5 }).map((_, i) => (
@@ -242,7 +242,7 @@ export default function Home() {
                     ))}
                   </div>
                 ) : matchCards.length === 0 ? (
-                  <div className="w-full max-w-[1074px] rounded-2xl border border-[var(--foundation-neutral-880)] bg-[var(--foundation-neutral-white)] px-6 py-12 text-center">
+                  <div className="w-full max-w-[1074px] rounded-2xl bg-[var(--foundation-neutral-white)] px-6 py-12 text-center">
                     <p className="text-base font-medium text-[var(--foundation-neutral-400)]">
                       선택한 날짜에는 예정된 경기가 없습니다.
                     </p>

--- a/goorm-gongbang/components/club-detail/ClubMatchCard.tsx
+++ b/goorm-gongbang/components/club-detail/ClubMatchCard.tsx
@@ -28,7 +28,7 @@ export function ClubMatchCard({ match, config }: MatchCardProps) {
   const CardContent = (
     <div
       className={cn(
-        "w-full h-full flex flex-col items-center gap-2 sm:gap-3 group transition-opacity",
+        "w-full h-full flex flex-col items-center gap-1 group transition-opacity",
         isEnded && "bg-[var(--background-grey)]",
         !isClickable && "cursor-default",
       )}
@@ -47,7 +47,7 @@ export function ClubMatchCard({ match, config }: MatchCardProps) {
         />
       </div>
       <div className={cn(
-        "text-[11px] sm:text-[12px] font-black text-slate-900 text-center break-words leading-tight",
+        "mt-2 text-xs sm:text-sm font-medium text-slate-900 text-center break-words leading-tight",
         isEnded
               ? "text-[var(--text-info-n600)]"
               : "text-slate-900",
@@ -57,7 +57,7 @@ export function ClubMatchCard({ match, config }: MatchCardProps) {
       </div>
       <div
         className={cn(
-          "mt-auto text-[10px] font-bold w-full py-1.5 transition-all text-center",
+          "text-xs sm:text-sm font-medium w-full py-1.5 transition-all text-center",
           config.color,
         )}
       >

--- a/goorm-gongbang/components/common/MatchCard.tsx
+++ b/goorm-gongbang/components/common/MatchCard.tsx
@@ -70,8 +70,9 @@ export function MatchCard({
                     className={cn(
                         "w-full h-28 overflow-hidden bg-[var(--foundation-neutral-white)] rounded-2xl",
                         "px-4 sm:px-6 lg:px-9",
-                        "outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-880)]",
+                        "outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-880)]/50",
                         "flex items-center",
+                        "hover:outline-[var(--foundation-neutral-880)]",
                         "hover:shadow-[0px_0px_12px_0px_rgba(0,0,0,0.08)]"
                     )}
                 >

--- a/goorm-gongbang/components/common/TeamInfoCard.tsx
+++ b/goorm-gongbang/components/common/TeamInfoCard.tsx
@@ -50,7 +50,7 @@ export function TeamInfoCard({
             onClick={onClick}
             className={cn(
                 "group relative rounded-2xl outline outline-1 outline-offset-[-1px]",
-                "outline-[var(--foundation-neutral-880)]",
+                "outline-[var(--foundation-neutral-880)]/50",
                 "self-stretch px-4 py-3 inline-flex flex-col justify-start items-start gap-1.5",
                 onClick && "cursor-pointer",
                 className
@@ -85,7 +85,7 @@ export function TeamInfoCard({
             {/* Team name */}
             <div className="self-stretch flex flex-col justify-center items-center">
                 <div className="self-stretch inline-flex justify-center items-center">
-                    <div className="text-center justify-center text-[var(--foundation-neutral-20)] text-xs font-medium font-['Pretendard'] leading-4">
+                    <div className="text-center justify-center text-[var(--foundation-neutral-20)] mb-2 font-medium font-['Pretendard'] leading-5">
                         {teamName}
                     </div>
                 </div>
@@ -100,7 +100,7 @@ export function TeamInfoCard({
                     (onClick ?? onButtonClick)?.();
                 }}
                 className={cn(
-                    "cursor-pointer self-stretch h-6 min-w-14 p-2 rounded-md outline outline-1 outline-offset-[-1px] outline-[var(--foundation-primary-500)] inline-flex justify-center items-center",
+                    "cursor-pointer self-stretch h-8 min-w-14 p-2 rounded-md outline outline-1 outline-offset-[-1px] outline-[var(--foundation-primary-500)] inline-flex justify-center items-center",
                     "group-hover:bg-[var(--foundation-primary-10)]",
                     buttonDisabled && "opacity-50 cursor-not-allowed"
                 )}

--- a/goorm-gongbang/components/layout/Footer.tsx
+++ b/goorm-gongbang/components/layout/Footer.tsx
@@ -62,8 +62,8 @@ export function Footer() {
                         </div>
                     </div>
 
-                    <div className="flex flex-col gap-8 lg:h-44 lg:gap-20">
-                        <div className="flex flex-col gap-8 sm:flex-row sm:justify-end sm:gap-16">
+                    <div className="flex flex-col gap-8">
+                        <div className="flex flex-col gap-8 sm:flex-row sm:flex-wrap sm:gap-8 lg:gap-16">
                             <div className="flex flex-col gap-6">
                                 <div className="text-base font-semibold leading-6 text-[var(--foundation-primary-500)]">
                                     바로 가기

--- a/goorm-gongbang/components/my/DeleteAccountModal.tsx
+++ b/goorm-gongbang/components/my/DeleteAccountModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { toast } from "sonner";
 import { deleteAccount } from "@/lib/services";
+import { Checkbox } from "@/components/ui/checkbox";
 
 interface DeleteAccountModalProps {
     isOpen: boolean;
@@ -63,22 +64,22 @@ export function DeleteAccountModal({ isOpen, onClose, onDeleteSuccess }: DeleteA
                 {/* 체크박스 */}
                 <div className="flex flex-col gap-3 mb-8">
                     <label className="flex items-start gap-3 cursor-pointer">
-                        <input
-                            type="checkbox"
+                        <Checkbox
+                            id="check1"
                             checked={checked1}
-                            onChange={(e) => setChecked1(e.target.checked)}
-                            className="mt-0.5 w-5 h-5 accent-[var(--foundation-primary-500)] cursor-pointer flex-shrink-0"
+                            onCheckedChange={(v) => setChecked1(!!v)}
+                            className="mt-0.5 flex-shrink-0 data-[state=checked]:bg-[var(--foundation-primary-500)] data-[state=checked]:border-[var(--foundation-primary-500)]"
                         />
                         <span className="text-[14px] text-[#3D3D3D]">
                             회원 탈퇴 시 계정 및 모든 데이터가 삭제되며 복구할 수 없음을 확인했습니다.
                         </span>
                     </label>
                     <label className="flex items-start gap-3 cursor-pointer">
-                        <input
-                            type="checkbox"
+                        <Checkbox
+                            id="check2"
                             checked={checked2}
-                            onChange={(e) => setChecked2(e.target.checked)}
-                            className="mt-0.5 w-5 h-5 accent-[var(--foundation-primary-500)] cursor-pointer flex-shrink-0"
+                            onCheckedChange={(v) => setChecked2(!!v)}
+                            className="mt-0.5 flex-shrink-0 data-[state=checked]:bg-[var(--foundation-primary-500)] data-[state=checked]:border-[var(--foundation-primary-500)]"
                         />
                         <span className="text-[14px] text-[#3D3D3D]">
                             이용약관 및 개인정보 처리방침에 따른 탈퇴 정책을 확인했습니다.

--- a/goorm-gongbang/lib/services/mypage.service.ts
+++ b/goorm-gongbang/lib/services/mypage.service.ts
@@ -145,7 +145,7 @@ export const getAccountInfo = async (): Promise<AccountInfo> => {
 /* 회원 탈퇴 */
 export const deleteAccount = async (): Promise<void> => {
   try {
-    await auth.delete(`${API_BASE_URL}/auth/account`);
+    await auth.post(`${API_BASE_URL}/withdraw`);
   } catch (err) {
     if (err instanceof ApiError) {
       if (err.status === 403) throw new Error("탈퇴 권한이 없습니다.");


### PR DESCRIPTION
## 🔧 작업 내용
- 회원 탈퇴 API 요청 경로 및 메서드를 최신 스펙에 맞게 수정했습니다.
- 회원 탈퇴 모달의 네이티브 체크박스 입력을 디자인 일관성을 위해 Shadcn Checkbox 컴포넌트로 교체했습니다.
- 메인, 클럽 상세 페이지, 공통 카드 컴포넌트들의 가독성을 높이고 카드 아웃라인 부자연스러움을 완화했습니다.
- 하단 Footer 영역의 불필요한 고정 폭/높이를 제거해 반응형 레이아웃 붕괴 문제를 해결했습니다.

## 🧩 구현 상세
- **API 연동**: `mypage.service.ts`의 탈퇴 호출을 `DELETE /auth/account`에서 `POST /withdraw`로 변경했습니다.
- **카드 UI 개선**: 
  - `MatchCard` 및 `TeamInfoCard` 등의 `outline` 색상에 투명도(`/50`)를 주어 자연스럽게 보이도록 했습니다.
  - 마우스 호버 시 강조(`hover:outline`)되는 이펙트를 추가했습니다.
- **상태별 레이아웃 보완**: 홈 화면 스켈레톤, 경기 없는 빈 상태 영역 등에 `min-h`를 부여하여 화면이 위아래로 크게 덜컹거리는 현상을 수정했습니다.
- **Footer**: `h-44` 높이 제한을 해제하고 창 크기가 줄어들었을 때 요소들이 적절하게 줄바꿈(`flex-wrap`)되게 구성했습니다.

### 📌 관련 Jira Issue
- GRGB-XX (이슈 번호가 있다면 기입해 주세요)

## 🧪 테스트 방법
- `/my/privacy` 등에서 탈퇴 페이지 진입 후 체크박스 디자인 확인
- 실 접속 또는 스켈레톤 로딩 시 카드가 나타나는 위치의 높이가 자연스럽게 유지되는지 확인
- 화면 너비를 줄였다 늘렸을 때 하단 Footer 요소가 서로 겹치거나 잘리지 않는지 확인

## ❗ 참고 사항
- 탈퇴 API 엔드포인트 변경은 백엔드 명세 변경에 맞춰 선반영되었습니다. 정상 처리 여부는 백엔드 배포 상황에 따라 테스트가 필요할 수 있습니다.
