### PR TITLE
fix(GBGB-363-fe-qa-1) - 2026.04.14 16:44 기준 QA 1차 수정 완료

### DIFF
--- a/goorm-gongbang/app/(protected)/pay/[matchId]/page.tsx
+++ b/goorm-gongbang/app/(protected)/pay/[matchId]/page.tsx
@@ -309,6 +309,16 @@ export default function Page() {
 
     const hasMatchMeta = formatMatchAt(match?.matchAt) && matchTitle && match?.stadium.koName;
 
+    const [touched, setTouched] = useState({
+        email: false,
+        phone: false,
+        birth: false,
+    });
+    const showEmailError = touched.email && email.trim().length > 0 && !isEmailValid;
+    const showPhoneError = touched.phone && phoneDigits.length > 0 && !isPhoneValid;
+    const showBirthError = touched.birth && birthDigits.length > 0 && !isBirthValid;
+
+
     const handleSubmitPayment = async () => {
         if (!canSubmitPayment || !matchId || !createdOrderId || isCreatingOrder) return;
 
@@ -526,8 +536,8 @@ export default function Page() {
             </div>
 
             <div className="w-full flex justify-center px-4 sm:px-6 md:px-8 xl:px-12 py-8">
-                <div className="w-full max-w-[1440px] flex flex-col xl:flex-row justify-start items-start gap-8 xl:gap-14">
-                    <div className="w-full xl:min-w-[760px] xl:max-w-[1000px] xl:shrink-0 inline-flex flex-col justify-start items-start gap-8">
+                <div className="w-full max-w-[1440px] grid grid-cols-1 gap-8 xl:grid-cols-[minmax(0,1fr)_384px] xl:gap-14">
+                    <div className="min-w-0 inline-flex flex-col justify-start items-start gap-8">
                         {step === "ticket" ? (
                             <>
                                 <div className="self-stretch flex flex-col justify-start items-start gap-4">
@@ -633,13 +643,23 @@ export default function Page() {
                                                 <div className="justify-center text-[var(--foundation-neutral-240)] text-sm font-medium font-['Pretendard'] leading-5">이메일</div>
                                             </div>
 
-                                            <input
-                                                type="text"
-                                                placeholder="이메일 입력"
-                                                value={email}
-                                                onChange={(e) => setEmail(e.target.value)}
-                                                className="flex-1 h-10 px-4 py-2 bg-[var(--foundation-neutral-white)] rounded-md outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-900)] text-sm font-medium font-['Pretendard'] leading-5 placeholder:opacity-80"
-                                            />
+                                            <div className="flex-1">
+                                                <input
+                                                    type="text"
+                                                    placeholder="이메일 입력"
+                                                    value={email}
+                                                    onChange={(e) => setEmail(e.target.value)}
+                                                    onBlur={() => setTouched((prev) => ({ ...prev, email: true }))}
+                                                    aria-invalid={showEmailError}
+                                                    aria-describedby={showEmailError ? "email-error" : undefined}
+                                                    className="h-10 w-full px-4 py-2 bg-[var(--foundation-neutral-white)] rounded-md outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-900)] text-sm font-medium font-['Pretendard'] leading-5 placeholder:opacity-80 aria-invalid:outline-[var(--foundation-red-500)] aria-invalid:ring-1 aria-invalid:ring-[var(--foundation-red-500)]"
+                                                />
+                                                {showEmailError && (
+                                                    <p id="email-error" className="mt-1 text-xs font-medium leading-4 text-[var(--foundation-red-500)]">
+                                                        유효하지 않은 입력값입니다
+                                                    </p>
+                                                )}
+                                            </div>
                                         </div>
 
                                         <div className="self-stretch inline-flex justify-start items-center gap-2">
@@ -647,14 +667,26 @@ export default function Page() {
                                                 <div className="justify-center text-[var(--foundation-neutral-240)] text-sm font-medium font-['Pretendard'] leading-5">연락처</div>
                                             </div>
 
-                                            <input
-                                                type="text"
-                                                inputMode="numeric"
-                                                placeholder="연락처 입력"
-                                                value={number}
-                                                onChange={(e) => setNumber(formatPhone(e.target.value))}
-                                                className="flex-1 h-10 px-4 py-2 bg-[var(--foundation-neutral-white)] rounded-md outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-900)] text-sm font-medium font-['Pretendard'] leading-5 placeholder:opacity-80"
-                                            />
+                                            <div className="flex-1">
+                                                <input
+                                                    type="text"
+                                                    inputMode="numeric"
+                                                    placeholder="연락처 입력"
+                                                    value={number}
+                                                    onChange={(e) => setNumber(formatPhone(e.target.value))}
+                                                    onBlur={() => setTouched((prev) => ({ ...prev, phone: true }))}
+                                                    aria-invalid={showPhoneError}
+                                                    aria-describedby={showPhoneError ? "phone-error" : undefined}
+                                                    className="h-10 w-full px-4 py-2 bg-[var(--foundation-neutral-white)] rounded-md outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-900)] text-sm font-medium font-['Pretendard'] leading-5 placeholder:opacity-80 aria-invalid:outline-[var(--foundation-red-500)] aria-invalid:ring-1 aria-invalid:ring-[var(--foundation-red-500)]"
+                                                />
+
+                                                {showPhoneError && (
+                                                    <p id="phone-error" className="mt-1 text-xs font-medium leading-4 text-[var(--foundation-red-500)]">
+                                                        유효하지 않은 입력값입니다
+                                                    </p>
+                                                )}
+                                            </div>
+
                                         </div>
 
                                         <div className="self-stretch inline-flex justify-start items-center gap-2">
@@ -662,13 +694,25 @@ export default function Page() {
                                                 <div className="justify-center whitespace-nowrap text-[var(--foundation-neutral-240)] text-sm font-medium font-['Pretendard'] leading-5">생년월일</div>
                                             </div>
 
-                                            <input
-                                                type="text"
-                                                placeholder="생년월일 입력 (YYMMDD)"
-                                                value={birth}
-                                                onChange={(e) => setBirth(formatBirth6(e.target.value))}
-                                                className="flex-1 h-10 px-4 py-2 bg-[var(--foundation-neutral-white)] rounded-md outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-900)] text-sm font-medium font-['Pretendard'] leading-5 placeholder:opacity-80"
-                                            />
+                                            <div className="flex-1">
+                                                <input
+                                                    type="text"
+                                                    placeholder="생년월일 입력 (YYMMDD)"
+                                                    value={birth}
+                                                    onChange={(e) => setBirth(formatBirth6(e.target.value))}
+                                                    onBlur={() => setTouched((prev) => ({ ...prev, birth: true }))}
+                                                    aria-invalid={showBirthError}
+                                                    aria-describedby={showBirthError ? "birth-error" : undefined}
+                                                    className="h-10 w-full px-4 py-2 bg-[var(--foundation-neutral-white)] rounded-md outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-900)] text-sm font-medium font-['Pretendard'] leading-5 placeholder:opacity-80 aria-invalid:outline-[var(--foundation-red-500)] aria-invalid:ring-1 aria-invalid:ring-[var(--foundation-red-500)]"
+                                                />
+
+                                                {showBirthError && (
+                                                    <p id="birth-error" className="mt-1 text-xs font-medium leading-4 text-[var(--foundation-red-500)]">
+                                                        유효하지 않은 입력값입니다
+                                                    </p>
+                                                )}
+                                            </div>
+
                                         </div>
                                     </div>
                                 </div>
@@ -1160,7 +1204,7 @@ export default function Page() {
                             </div>
                         )}
                     </div>
-                    <div className="w-full xl:w-96 xl:shrink-0 self-stretch shadow-[0px_1px_3px_0px_rgba(0,0,0,0.05)] inline-flex flex-col justify-start items-start gap-4 overflow-hidden">
+                    <div className="min-w-0 w-full xl:w-auto xl:shrink-0 self-stretch shadow-[0px_1px_3px_0px_rgba(0,0,0,0.05)] inline-flex flex-col justify-start items-start gap-4 overflow-hidden">
                         <div className="self-stretch inline-flex justify-end items-center gap-2">
                             <div className="flex-1 justify-center text-[var(--foundation-neutral-240)] text-xl font-bold font-['Pretendard'] leading-7">MY 예매 정보</div>
                             <div className="text-right justify-center text-[var(--foundation-neutral-240)] text-sm font-medium font-['Pretendard'] leading-5">남은 결제 시간</div>

--- a/goorm-gongbang/app/(protected)/recommend/[matchId]/page.tsx
+++ b/goorm-gongbang/app/(protected)/recommend/[matchId]/page.tsx
@@ -1090,22 +1090,24 @@ function RecommendPageContent({ matchId }: { matchId: number | null }) {
           </div>
 
           <div className="flex w-full shrink-0 flex-col items-end gap-6 lg:w-[360px] xl:w-[400px] 2xl:w-[460px]">
-            <div className="w-full rounded-2xl bg-[var(--foundation-neutral-white)] px-6 py-4 outline outline-1 outline-offset-[-1px] outline-[var(--stroke-interactive-neutral-default)]">
-              <div className="flex h-8 w-full items-center justify-between">
-                <div className="text-base font-semibold leading-6 text-black">
-                  사용자 선호 구역 추천
+            {recommendationEnabled && (
+              <div className="w-full rounded-2xl bg-[var(--foundation-neutral-white)] px-6 py-4 outline outline-1 outline-offset-[-1px] outline-[var(--stroke-interactive-neutral-default)]">
+                <div className="flex h-8 w-full items-center justify-between">
+                  <div className="text-base font-semibold leading-6 text-black">
+                    사용자 선호 구역 추천
+                  </div>
+                  <Toggle
+                    checked={isPreferredRecommendOn}
+                    onCheckedChange={(next) => {
+                      setIsPreferredRecommendOn(next);
+                      setHoveredRecommendBlock(null);
+                      setHoveredSeatBlocks([]);
+                      resetManualSeatSelection();
+                    }}
+                  />
                 </div>
-                <Toggle
-                  checked={isPreferredRecommendOn}
-                  onCheckedChange={(next) => {
-                    setIsPreferredRecommendOn(next);
-                    setHoveredRecommendBlock(null);
-                    setHoveredSeatBlocks([]);
-                    resetManualSeatSelection();
-                  }}
-                />
               </div>
-            </div>
+            )}
 
             {isProtectedSeatAccessBlocked ? (
               <div className="flex w-full flex-col items-start gap-4 self-stretch">

--- a/goorm-gongbang/components/common/SeatPreferenceRecommendCard.tsx
+++ b/goorm-gongbang/components/common/SeatPreferenceRecommendCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { Toggle } from "@/components/common/Toggle";
 import { DropDown } from "@/components/common/DropDown";
@@ -30,6 +30,43 @@ export function SeatPreferenceRecommendCard({
 }: Props) {
 
   const [isNearbySeatInfoOpen, setIsNearbySeatInfoOpen] = useState(false);
+  const nearbySeatInfoButtonRef = useRef<HTMLButtonElement | null>(null);
+  const [nearbySeatInfoPosition, setNearbySeatInfoPosition] = useState({ left: 0, top: 0, width: 520 });
+
+  const updateNearbySeatInfoPosition = useCallback(() => {
+    const button = nearbySeatInfoButtonRef.current;
+    if (!button) return;
+
+    const viewportPadding = 16;
+    const tooltipWidth = Math.min(
+      520,
+      Math.max(0, window.innerWidth - viewportPadding * 2),
+    );
+    const rect = button.getBoundingClientRect();
+    const left = Math.min(
+      Math.max(rect.left, viewportPadding),
+      window.innerWidth - tooltipWidth - viewportPadding,
+    );
+
+    setNearbySeatInfoPosition({
+      left,
+      top: rect.bottom + 8,
+      width: tooltipWidth,
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!isNearbySeatInfoOpen) return;
+
+    updateNearbySeatInfoPosition();
+    window.addEventListener("resize", updateNearbySeatInfoPosition);
+    window.addEventListener("scroll", updateNearbySeatInfoPosition, true);
+
+    return () => {
+      window.removeEventListener("resize", updateNearbySeatInfoPosition);
+      window.removeEventListener("scroll", updateNearbySeatInfoPosition, true);
+    };
+  }, [isNearbySeatInfoOpen, updateNearbySeatInfoPosition]);
 
   return (
     <div
@@ -41,7 +78,7 @@ export function SeatPreferenceRecommendCard({
       <div className="inline-flex h-8 w-full items-center justify-between">
         <div className="flex items-center justify-center gap-2">
           <div className="text-base font-semibold leading-6 text-[var(--foundation-neutral-black)] font-['Pretendard']">
-            사용자 선호 좌석 추천
+            사용자 선호 구역 추천
             <div className="text-xs font-normal leading-4 text-[var(--text-info-n600)] font-['Pretendard']">
               {enabled ? (
                 "설정한 선호 조건에 맞는 구역을 먼저 보여드려요"
@@ -82,8 +119,12 @@ export function SeatPreferenceRecommendCard({
               </div>
 
               <button
+                ref={nearbySeatInfoButtonRef}
                 type="button"
-                onMouseEnter={() => setIsNearbySeatInfoOpen(true)}
+                onMouseEnter={() => {
+                  updateNearbySeatInfoPosition();
+                  setIsNearbySeatInfoOpen(true);
+                }}
                 onMouseLeave={() => setIsNearbySeatInfoOpen(false)}
                 className="relative h-4 w-4 cursor-pointer overflow-visible"
                 aria-expanded={isNearbySeatInfoOpen}
@@ -94,7 +135,8 @@ export function SeatPreferenceRecommendCard({
                 {isNearbySeatInfoOpen && (
                   <div
                     id="nearby-seat-info"
-                    className="absolute left-0 top-full z-20 mt-2 inline-flex w-[520px] flex-col items-start gap-2 rounded-lg bg-white p-3 shadow-[2px_3px_10px_0px_rgba(0,0,0,0.10)] outline outline-1 outline-offset-[-1px] outline-[var(--stroke-interactive-neutral-default)]"
+                    style={nearbySeatInfoPosition}
+                    className="fixed z-50 inline-flex flex-col items-start gap-2 rounded-lg bg-white p-3 text-left shadow-[2px_3px_10px_0px_rgba(0,0,0,0.10)] outline outline-1 outline-offset-[-1px] outline-[var(--stroke-interactive-neutral-default)]"
                   >
                     <div className="text-sm font-semibold leading-5 text-[var(--foundation-neutral-240)] font-['Pretendard']">
                       인근 좌석 추천이란?


### PR DESCRIPTION
fix(GBGB-363-fe-qa-1)
- 2026.04.14 16:44 기준 QA 1차 수정 완료

🔧 작업 내용
- 사용자 선호 구역 추천 툴팁이 화면/부모 영역에 잘리지 않도록 위치 계산 방식 수정
- 추천 OFF 상태로 recommend 페이지 진입 시 사용자 선호 구역 추천 토글 숨김 처리
- pay 페이지 주문서/결제 영역의 가로 해상도 대응을 위해 레이아웃 폭 조정

🧩 구현 상세 (선택)
- 툴팁을 fixed 위치 기반으로 렌더링하고 viewport 내부에 머물도록 좌표와 폭을 보정
- recommend 페이지 진입 시 recommendationEnabled 값이 false인 경우 토글 영역 미노출
- pay 페이지의 좌/우 영역을 고정 min-width 기반 flex 구조에서 grid 기반 구조로 조정

📌 관련 Jira Issue
GBGB-363-fe-qa-1

🧪 테스트 방법(선택)
- SeatPreferenceRecommendCard 툴팁 hover 시 화면에서 잘리지 않는지 확인
- matches 페이지에서 사용자 선호 구역 추천 OFF 후 recommend 페이지 진입 시 토글 영역이 보이지 않는지 확인
- pay 페이지에서 주문서/결제 영역이 다양한 해상도에서 가로로 잘리지 않는지 확인
- `npm.cmd run lint -- components/common/SeatPreferenceRecommendCard.tsx`

❗ 참고 사항
- 기존 match/recommend/pay 흐름의 API 호출 구조는 유지하고 UI 노출 조건 및 레이아웃 중심으로 수정

Fixes: GBGB-363
