### PR TITLE
fix(support): 1:1 문의 휴대폰 번호 유효성 검증 및 UI 개선

### DIFF
--- a/goorm-gongbang/app/(protected)/my/support/write/page.tsx
+++ b/goorm-gongbang/app/(protected)/my/support/write/page.tsx
@@ -56,6 +56,9 @@ export default function SupportWritePage() {
     const [writerName, setWriterName] = useState("");
     const [writerEmail, setWriterEmail] = useState("");
     const [phoneNumber, setPhoneNumber] = useState("");
+    const [phoneTouched, setPhoneTouched] = useState(false);
+    const [phoneFocused, setPhoneFocused] = useState(false);
+
 
     useEffect(() => {
         const fetchUserData = async () => {
@@ -72,6 +75,7 @@ export default function SupportWritePage() {
     const onlyDigits = (v: string) => v.replace(/\D/g, "");
     const phoneDigits = onlyDigits(phoneNumber);
     const isPhoneValid = phoneNumber.length === 0 || (/^01[0-9]\d{7,8}$/.test(phoneDigits) && phoneDigits.length === 11);
+    const showPhoneError = phoneTouched && !phoneFocused && !isPhoneValid;
     const formatPhone = (value: string) => {
         const digits = value.replace(/\D/g, "").slice(0, 11); // 숫자만, 최대 11자리
         if (digits.length < 4) return digits;
@@ -269,18 +273,22 @@ export default function SupportWritePage() {
                             </div>
                             <div className="flex flex-col gap-2 md:col-span-2">
                                 <Label className="text-sm font-semibold text-[#666] ml-1">휴대폰 번호</Label>
-                                <Input
+                                <input
+                                    type="text"
+                                    inputMode="numeric"
+                                    placeholder="010-0000-0000"
                                     value={phoneNumber}
                                     onChange={(e) => setPhoneNumber(formatPhone(e.target.value))}
-                                    placeholder="010-0000-0000"
+                                    onFocus={() => { setPhoneTouched(true); setPhoneFocused(true); }}
+                                    onBlur={() => setPhoneFocused(false)}
                                     className={cn(
-                                        "h-14 rounded-[12px] px-4 text-[15px] focus-visible:ring-0 transition-all",
-                                        !isPhoneValid
-                                            ? "border-red-400 focus-visible:border-red-400"
-                                            : "border-[#E0E0E0] focus-visible:border-[var(--foundation-primary-500)]"
+                                        "h-14 w-full px-4 py-2 bg-[var(--foundation-neutral-white)] rounded-[12px] outline outline-1 outline-offset-[-1px] text-sm font-medium font-['Pretendard'] leading-5 placeholder:opacity-80",
+                                        showPhoneError
+                                            ? "outline-red-400"
+                                            : "outline-[var(--foundation-neutral-900)]"
                                     )}
                                 />
-                                {!isPhoneValid && (
+                                {showPhoneError && (
                                     <p className="text-xs text-red-400 ml-1">010-****-**** 형식으로 입력해주세요</p>
                                 )}
                             </div>


### PR DESCRIPTION
## 🔧 작업 내용

1:1 문의 작성 페이지 휴대폰 번호 입력 필드 유효성 검증 및 UI 개선

**해결한 문제:**
- 휴대폰 번호 형식 검증 없이 잘못된 번호가 제출되던 문제
- 입력 중 에러가 즉시 표시되어 UX가 불편한 문제

## 🧩 구현 상세

- 주문 페이지와 동일하게 `010-****-****` (11자리) 형식만 허용
- focus out(blur) 시에만 에러 테두리 및 안내 메시지 표시
- 포커스 중엔 에러 숨김, 재입력 시 에러 초기화
- 빈값은 선택 필드로 유지 (미입력 시 제출 가능)

### 📌 관련 Jira Issue
- GRGB-XX

## 🧪 테스트 방법

| 시나리오 | 기대 결과 |
|---|---|
| `111` 입력 후 focus out | 빨간 테두리 + 에러 메시지 표시 |
| 에러 상태에서 다시 클릭 | 에러 숨김 |
| `010-1234-5678` 입력 후 focus out | 에러 없음 |
| 휴대폰 번호 미입력 후 제출 | 정상 제출 가능 |

## ❗ 참고 사항
- shadcn `Input` 컴포넌트는 외부 className으로 border 색상 override가 안 되어 일반 `<input>` 태그로 교체했습니다.
