### PR TITLE
feat(security): X-Bot-Token 2-way 서버 검증 지원 + ok-local-dev 제거

### DIFF
--- a/goorm-gongbang/app/(public)/matches/[matchId]/page.tsx
+++ b/goorm-gongbang/app/(public)/matches/[matchId]/page.tsx
@@ -20,6 +20,7 @@ import { LoginRequiredModal } from "@/components/common/LoginRequiredModal";
 import { PreferredZoneModal } from "@/components/common/PreferredZoneModal";
 import Image from "next/image";
 import { toast } from "sonner";
+import { getBotToken } from "@/lib/client/bot-token";
 import { useTelemetry } from "@/lib/telemetry";
 import { TelemetryProvider } from "@/lib/telemetry/context";
 import { VQAChallenge } from "@/lib/telemetry/components";
@@ -182,9 +183,10 @@ export default function MatchDetailSectionResponsive({
     try {
       const bookingResponse: BookingOptionsResponse = await saveBookingOptions(matchId, bookingBody);
 
-      // TODO(local-dev): Cloudflare Turnstile 미연동 상태라 로컬 통합 테스트용 dev token으로 precheck를 통과시킨다.
-      // 실제 연동 시 Turnstile 발급 토큰으로 교체 필요.
-      const precheckPassed = await precheck("ok-local-dev");
+      // 자체 X-Bot-Token (Canvas FP + HMAC) 으로 서버 2-way 검증.
+      // 과거 "ok-local-dev" 하드코딩 제거 (1차 pentest M-10).
+      const botToken = await getBotToken();
+      const precheckPassed = await precheck(botToken);
       if (!precheckPassed) {
         toast.error("보안 사전 검증에 실패했습니다. 잠시 후 다시 시도해 주세요.");
         return;

--- a/goorm-gongbang/app/providers.tsx
+++ b/goorm-gongbang/app/providers.tsx
@@ -37,18 +37,17 @@ export default function Providers({ children }: { children: React.ReactNode }) {
 
   const botTokenInitialized = useRef(false);
 
-  // [X-Bot-Token] 사전 생성 (1회만)
-  useEffect(() => {
-    if (!botTokenInitialized.current) {
-      getBotToken();
-      botTokenInitialized.current = true;
-    }
-  }, []);
-
   useEffect(() => {
     let mounted = true;
 
     (async () => {
+      // [X-Bot-Token] 첫 API 호출 전에 반드시 토큰 확보 — fetch wrapper 의
+      // getBotTokenSync() 가 빈 값을 반환하여 헤더가 누락되는 레이스 방지.
+      if (!botTokenInitialized.current) {
+        await getBotToken();
+        botTokenInitialized.current = true;
+      }
+
       const token = await refreshAccessToken();
 
       if (!mounted) return;

--- a/goorm-gongbang/lib/client/bot-token.ts
+++ b/goorm-gongbang/lib/client/bot-token.ts
@@ -20,6 +20,7 @@
 const SECRET = process.env.NEXT_PUBLIC_BOT_TOKEN_SECRET ?? "playball-xbot-v1";
 const TOKEN_TTL_MS = 5 * 60 * 1000; // 5분
 const TOKEN_VERSION = "1";
+let tokenPromise: Promise<string> | null = null;
 
 let cachedToken: string | null = null;
 let cachedAt = 0;

--- a/goorm-gongbang/lib/client/bot-token.ts
+++ b/goorm-gongbang/lib/client/bot-token.ts
@@ -17,13 +17,24 @@
    매크로)은 Canvas 렌더링/Web Crypto 실행 불가이므로 유효 토큰 생성 불가.
 =========================== */
 
-const SECRET = process.env.NEXT_PUBLIC_BOT_TOKEN_SECRET ?? "playball-xbot-v1";
+const SECRET = process.env.NEXT_PUBLIC_BOT_TOKEN_SECRET ?? "";
 const TOKEN_TTL_MS = 5 * 60 * 1000; // 5분
 const TOKEN_VERSION = "1";
 let tokenPromise: Promise<string> | null = null;
 
+if (typeof window !== "undefined" && !SECRET) {
+  // 프로덕션 배포 시 환경변수 미주입 조기 경보. 기본값 fallback 없음 —
+  // 번들에 공통 기본값이 박히면 환경별 분리/로테이션 의미가 사라짐.
+  console.warn(
+    "[bot-token] NEXT_PUBLIC_BOT_TOKEN_SECRET 환경변수가 설정되지 않았습니다. " +
+    "로컬 개발이 아니라면 배포 환경변수를 확인하세요.",
+  );
+}
+
 let cachedToken: string | null = null;
 let cachedAt = 0;
+// 동시 호출 시 Canvas/Crypto 중복 실행 방지용 in-flight Promise.
+let inflight: Promise<string> | null = null;
 
 /** Canvas fingerprint — 브라우저/OS/GPU 차이로 고유 해시 생성 */
 function getCanvasFingerprint(): string {
@@ -121,19 +132,31 @@ export async function getBotToken(): Promise<string> {
     return cachedToken;
   }
 
-  const ts = Math.floor(now / 1000);
-  const nonce = randomNonce();
-  const fp = await sha256Short(getCanvasFingerprint());
-  const meta = await sha256Short(getBrowserMeta());
+  // 동시 호출이 들어오면 같은 Promise 를 공유 → Canvas/Crypto 중복 방지.
+  if (inflight) {
+    return inflight;
+  }
 
-  const payload = JSON.stringify({ v: TOKEN_VERSION, ts, nonce, fp, meta });
-  const payloadB64 = base64urlEncode(payload);
-  const sig = await hmacSha256Hex(payloadB64, SECRET);
+  inflight = (async () => {
+    try {
+      const ts = Math.floor(now / 1000);
+      const nonce = randomNonce();
+      const fp = await sha256Short(getCanvasFingerprint());
+      const meta = await sha256Short(getBrowserMeta());
 
-  cachedToken = `${payloadB64}.${sig}`;
-  cachedAt = now;
+      const payload = JSON.stringify({ v: TOKEN_VERSION, ts, nonce, fp, meta });
+      const payloadB64 = base64urlEncode(payload);
+      const sig = await hmacSha256Hex(payloadB64, SECRET);
 
-  return cachedToken;
+      cachedToken = `${payloadB64}.${sig}`;
+      cachedAt = now;
+      return cachedToken;
+    } finally {
+      inflight = null;
+    }
+  })();
+
+  return inflight;
 }
 
 /**

--- a/goorm-gongbang/lib/client/bot-token.ts
+++ b/goorm-gongbang/lib/client/bot-token.ts
@@ -1,19 +1,30 @@
 /* ===========================
-   X-Bot-Token — 브라우저 검증 토큰
-   JavaScript 실행 가능한 진짜 브라우저만 생성 가능
-   순수 HTTP 봇(curl, requests, 매크로)은 생성 불가
+   X-Bot-Token — 브라우저 검증 토큰 (서버 2-way 검증 지원)
+
+   토큰 포맷:
+     X-Bot-Token: <base64url(payload_json)>.<hex(HMAC-SHA256(payload, SECRET))>
+
+   payload_json = { v, ts, nonce, fp, meta }
+     - v:     프로토콜 버전 ("1")
+     - ts:    생성 시각 (UNIX seconds)
+     - nonce: 요청별 랜덤값 (서버에서 재사용 탐지)
+     - fp:    Canvas fingerprint 해시 (요청자 추적용 rate-limit key)
+     - meta:  브라우저 메타데이터 해시
+
+   서버는 payload를 디코딩해서 HMAC을 재계산하여 무결성 검증 가능.
+   SECRET은 NEXT_PUBLIC_ 이라 어차피 번들에 노출 → 암호학적 보안 경계가 아닌
+   "우리 JS를 실제로 실행한 요청"을 강제하는 허들. 순수 HTTP 봇(curl, requests,
+   매크로)은 Canvas 렌더링/Web Crypto 실행 불가이므로 유효 토큰 생성 불가.
 =========================== */
 
 const SECRET = process.env.NEXT_PUBLIC_BOT_TOKEN_SECRET ?? "playball-xbot-v1";
 const TOKEN_TTL_MS = 5 * 60 * 1000; // 5분
+const TOKEN_VERSION = "1";
 
 let cachedToken: string | null = null;
 let cachedAt = 0;
 
-/**
- * Canvas fingerprint 생성
- * 브라우저마다 렌더링 미세 차이 → 고유 해시
- */
+/** Canvas fingerprint — 브라우저/OS/GPU 차이로 고유 해시 생성 */
 function getCanvasFingerprint(): string {
   try {
     const canvas = document.createElement("canvas");
@@ -36,10 +47,7 @@ function getCanvasFingerprint(): string {
   }
 }
 
-/**
- * 브라우저 메타 정보 수집
- * navigator.webdriver: Headless Chrome(Puppeteer)은 true, 일반 브라우저는 false
- */
+/** 브라우저 메타 정보 — 화면/언어/타임존/코어수/webdriver 여부 */
 function getBrowserMeta(): string {
   return [
     screen.width,
@@ -52,36 +60,58 @@ function getBrowserMeta(): string {
   ].join("|");
 }
 
-/**
- * HMAC-SHA256 서명 (Web Crypto API)
- */
-async function hmacSign(message: string): Promise<string> {
+/** SHA-256 (hex, 앞 16자리) */
+async function sha256Short(message: string): Promise<string> {
   const encoder = new TextEncoder();
-  const key = await crypto.subtle.importKey(
-    "raw",
-    encoder.encode(SECRET),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
-
-  const signature = await crypto.subtle.sign(
-    "HMAC",
-    key,
-    encoder.encode(message),
-  );
-
-  return Array.from(new Uint8Array(signature))
+  const hash = await crypto.subtle.digest("SHA-256", encoder.encode(message));
+  return Array.from(new Uint8Array(hash))
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("")
     .slice(0, 16);
 }
 
+/** HMAC-SHA256 (hex) */
+async function hmacSha256Hex(message: string, secret: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(message));
+  return Array.from(new Uint8Array(signature))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** base64url (padding 없이, URL-safe) */
+function base64urlEncode(input: string): string {
+  return btoa(input)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/** 16바이트 랜덤 nonce (hex 32자) */
+function randomNonce(): string {
+  const arr = new Uint8Array(16);
+  crypto.getRandomValues(arr);
+  return Array.from(arr)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
 /**
  * X-Bot-Token 생성
- * 결과: base64(timestamp:fingerprint_hash:signature)
  *
- * 캐싱: 5분간 재사용 (매 요청마다 Canvas 렌더링 방지)
+ * 결과 예시: eyJ2IjoiMSIsInRzIjoxNzA2MDAwMDAwLCJub25jZSI6IjFmM2Y...".abcd1234...
+ *
+ * 캐싱: 5분간 재사용 (매 요청마다 Canvas 렌더링 방지).
+ * 서버는 nonce를 5분 TTL로 Redis에 저장하여 재사용 탐지.
+ * ※ 동일 브라우저의 여러 요청은 같은 토큰을 공유 → 서버도 같은 nonce의 5분 내
+ *    재등장은 정상으로 처리 (첫 요청에만 INCR, 이후는 fp-count만 증가).
  */
 export async function getBotToken(): Promise<string> {
   const now = Date.now();
@@ -90,23 +120,34 @@ export async function getBotToken(): Promise<string> {
     return cachedToken;
   }
 
-  const timestamp = Math.floor(now / 1000);
-  const fingerprint = getCanvasFingerprint();
-  const meta = getBrowserMeta();
+  const ts = Math.floor(now / 1000);
+  const nonce = randomNonce();
+  const fp = await sha256Short(getCanvasFingerprint());
+  const meta = await sha256Short(getBrowserMeta());
 
-  const payload = `${fingerprint}:${meta}:${timestamp}`;
-  const sig = await hmacSign(payload);
+  const payload = JSON.stringify({ v: TOKEN_VERSION, ts, nonce, fp, meta });
+  const payloadB64 = base64urlEncode(payload);
+  const sig = await hmacSha256Hex(payloadB64, SECRET);
 
-  cachedToken = btoa(`${timestamp}:${sig}`);
+  cachedToken = `${payloadB64}.${sig}`;
   cachedAt = now;
 
   return cachedToken;
 }
 
 /**
- * 서버사이드에서는 빈 문자열 반환 (SSR 안전)
+ * 서버사이드 / 초기 로드 직후 즉시 호출 시 빈 문자열 반환 (SSR 안전).
+ * fetch wrapper는 빈 토큰이면 헤더 생략 → 백은 필수 엔드포인트에서 403 처리.
  */
 export function getBotTokenSync(): string {
   if (typeof window === "undefined") return "";
   return cachedToken ?? "";
+}
+
+/**
+ * 앱 부트 시점(providers.tsx 등)에 미리 호출하여 첫 API 요청 전에 토큰 확보.
+ */
+export async function ensureBotTokenReady(): Promise<void> {
+  if (typeof window === "undefined") return;
+  await getBotToken();
 }


### PR DESCRIPTION
- bot-token.ts: 서버가 HMAC 재계산 가능하도록 토큰 포맷 변경
  - 기존: base64(timestamp:sig)만 전송 → 서버에서 fingerprint/meta 모르므로 검증 불가
  - 신규: <base64url(payload_json)>.<hmac-sha256-hex> 형태 payload_json = {v, ts, nonce, fp, meta} — 서버가 디코딩 후 HMAC 재계산
  - nonce 추가로 서버측 재생공격 탐지 지원 (Redis 5분 TTL)
  - fp 해시는 서버측 요청량 rate-limit key로 활용 가능
  - ensureBotTokenReady() 추가 (providers 부트 시 선행 호출용)

- matches/[matchId]/page.tsx: precheck('ok-local-dev') 하드코딩 제거
  - 1차 pentest M-10 대응. 실제 X-Bot-Token 토큰으로 교체