### PR TITLE
fix(GBGB-377-fe-qa-2) - 2026.04.15 21:58 기준 QA 2차 수정 완료

### DIFF
--- a/goorm-gongbang/app/(auth)/login/page.tsx
+++ b/goorm-gongbang/app/(auth)/login/page.tsx
@@ -133,6 +133,10 @@ export default function LoginPage() {
     }
   };
 
+  if (!bootstrapped || isLoggedIn) {
+    return null;
+  }
+  
   return (
     <main className="min-h-screen bg-white">
       <div className="mx-auto flex min-h-screen w-full items-center justify-center px-4 py-10 sm:px-6">

--- a/goorm-gongbang/app/(protected)/pay/[matchId]/bank-account/page.tsx
+++ b/goorm-gongbang/app/(protected)/pay/[matchId]/bank-account/page.tsx
@@ -181,7 +181,7 @@ export default function BankAccountPage() {
                                     예금주
                                 </div>
                                 <div className="flex-1 text-lg font-semibold leading-6 text-[var(--foundation-neutral-240)]">
-                                    주식회사 구름공방
+                                    {searchParams.get("holder")}
                                 </div>
                             </div>
                         </div>

--- a/goorm-gongbang/app/(protected)/pay/[matchId]/bank-account/page.tsx
+++ b/goorm-gongbang/app/(protected)/pay/[matchId]/bank-account/page.tsx
@@ -172,7 +172,7 @@ export default function BankAccountPage() {
                                     입금 계좌
                                 </div>
                                 <div className="flex-1 text-lg font-semibold leading-6 text-[var(--foundation-neutral-240)]">
-                                    신한 110-123-456789
+                                    {searchParams.get("bank")} {searchParams.get("accountNumber")}
                                 </div>
                             </div>
 

--- a/goorm-gongbang/app/(protected)/pay/[matchId]/bank-account/page.tsx
+++ b/goorm-gongbang/app/(protected)/pay/[matchId]/bank-account/page.tsx
@@ -117,8 +117,10 @@ export default function BankAccountPage() {
 
     const [showCopiedToast, setShowCopiedToast] = useState(false);
     const handleCopy = () => {
-        navigator.clipboard.writeText(stadiumAddress);
-        setShowCopiedToast(true);
+        if (stadiumAddress) {
+            navigator.clipboard.writeText(stadiumAddress);
+            setShowCopiedToast(true);
+        }
     };
 
     useEffect(() => {
@@ -205,9 +207,10 @@ export default function BankAccountPage() {
 
                                     <div
                                         className="cursor-pointer mt-0.5 inline-flex items-center gap-1 text-xs leading-4 text-[var(--foundation-neutral-600)]"
+                                        onClick={handleCopy}
                                     >
                                         <span className="underline">{stadiumAddress || "-"}</span>
-                                        <Copy className="h-4 w-4" strokeWidth={1.5} onClick={handleCopy} />
+                                        <Copy className="h-4 w-4" strokeWidth={1.5} />
                                     </div>
                                 </div>
                             </div>
@@ -258,22 +261,12 @@ export default function BankAccountPage() {
                                 <div className="h-px bg-[var(--stroke-interactive-neutral-default)]" />
 
                                 <div className="flex flex-col gap-0.5">
-                                    {/* {seatRows.map((seat) => (
-                                        <div key={seat.label} className="flex justify-between gap-4">
-                                            <div className="text-sm font-medium text-[var(--foundation-neutral-240)]">
-                                                {seat.label || "-"}
-                                            </div>
-                                            <div className="text-sm font-medium text-[var(--foundation-neutral-240)]">
-                                                1개
-                                            </div>
-                                        </div>
-                                    ))} */}
                                     <div className="flex justify-between gap-4">
                                         <div className="text-sm font-medium text-[var(--foundation-neutral-240)]">
                                             티켓 금액
                                         </div>
                                         <div className="text-sm font-medium text-[var(--foundation-neutral-240)]">
-                                            {won(totalAmount - fee) || 0}
+                                            {won(totalAmount - fee)}
                                         </div>
                                     </div>
 

--- a/goorm-gongbang/app/(protected)/pay/[matchId]/bank-account/page.tsx
+++ b/goorm-gongbang/app/(protected)/pay/[matchId]/bank-account/page.tsx
@@ -1,11 +1,11 @@
 "use client";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
-import { Check, ExternalLink } from "lucide-react";
+import { Check, Copy, ExternalLink } from "lucide-react";
 import { PrimaryButton, SecondaryButton } from "@/components/common/Button";
 import { RefundPolicyModal } from "@/components/common/RefundPolicyModal";
 import { useSearchParams } from "next/navigation";
-
+import { AddressCopiedToast } from "@/components/common/match-detail/tabs/AddressCopiedToast";
 
 export default function BankAccountPage() {
     const [isRefundModalOpen, setIsRefundModalOpen] = useState(false);
@@ -29,22 +29,34 @@ export default function BankAccountPage() {
         }
     })();
 
-
-    const naverMapUrl = `https://map.naver.com/p/search/${encodeURIComponent(stadiumAddress)}`;
-
     const formatMatchAt = (value?: string) => {
         if (!value) return "-";
+
         const date = new Date(value);
-        return new Intl.DateTimeFormat("ko-KR", {
+        if (Number.isNaN(date.getTime())) return "-";
+
+        const dateText = new Intl.DateTimeFormat("ko-KR", {
             year: "numeric",
             month: "long",
             day: "numeric",
+            timeZone: "Asia/Seoul",
+        }).format(date);
+
+        const weekdayText = new Intl.DateTimeFormat("ko-KR", {
             weekday: "short",
+            timeZone: "Asia/Seoul",
+        }).format(date);
+
+        const timeText = new Intl.DateTimeFormat("ko-KR", {
             hour: "2-digit",
             minute: "2-digit",
             hour12: false,
+            timeZone: "Asia/Seoul",
         }).format(date);
+
+        return `${dateText} (${weekdayText}) ${timeText}`;
     };
+
 
     const formatCancelDeadline = (value?: string) => {
         if (!value) return "-";
@@ -78,19 +90,46 @@ export default function BankAccountPage() {
         cancelDeadline.setDate(cancelDeadline.getDate() + 1);
         cancelDeadline.setHours(23, 59, 0, 0);
 
-        return new Intl.DateTimeFormat("ko-KR", {
+        const dateText = new Intl.DateTimeFormat("ko-KR", {
             year: "numeric",
             month: "long",
             day: "numeric",
+            timeZone: "Asia/Seoul",
+        }).format(cancelDeadline);
+
+        const weekdayText = new Intl.DateTimeFormat("ko-KR", {
             weekday: "short",
+            timeZone: "Asia/Seoul",
+        }).format(cancelDeadline);
+
+        const timeText = new Intl.DateTimeFormat("ko-KR", {
             hour: "2-digit",
             minute: "2-digit",
             hour12: false,
             timeZone: "Asia/Seoul",
         }).format(cancelDeadline);
+
+        return `${dateText} (${weekdayText}) ${timeText}`;
     };
 
+
     const won = (n: number) => `${n.toLocaleString("ko-KR")} 원`;
+
+    const [showCopiedToast, setShowCopiedToast] = useState(false);
+    const handleCopy = () => {
+        navigator.clipboard.writeText(stadiumAddress);
+        setShowCopiedToast(true);
+    };
+
+    useEffect(() => {
+        if (!showCopiedToast) return;
+
+        const timer = setTimeout(() => {
+            setShowCopiedToast(false);
+        }, 2000);
+
+        return () => clearTimeout(timer);
+    }, [showCopiedToast]);
 
     return (
         <div className="min-h-screen bg-[var(--foundation-neutral-980)] px-4 py-8">
@@ -133,7 +172,7 @@ export default function BankAccountPage() {
                                     입금 계좌
                                 </div>
                                 <div className="flex-1 text-lg font-semibold leading-6 text-[var(--foundation-neutral-240)]">
-                                    국민 000-0000-0000-00
+                                    신한 110-123-456789
                                 </div>
                             </div>
 
@@ -142,7 +181,7 @@ export default function BankAccountPage() {
                                     예금주
                                 </div>
                                 <div className="flex-1 text-lg font-semibold leading-6 text-[var(--foundation-neutral-240)]">
-                                    윤정빈
+                                    주식회사 구름공방
                                 </div>
                             </div>
                         </div>
@@ -164,15 +203,12 @@ export default function BankAccountPage() {
                                         {stadiumName || "-"}
                                     </div>
 
-                                    <a
-                                        href={naverMapUrl}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className="mt-0.5 inline-flex items-center gap-1 text-xs leading-4 text-[var(--foundation-neutral-600)]"
+                                    <div
+                                        className="cursor-pointer mt-0.5 inline-flex items-center gap-1 text-xs leading-4 text-[var(--foundation-neutral-600)]"
                                     >
                                         <span className="underline">{stadiumAddress || "-"}</span>
-                                        <ExternalLink className="h-4 w-4" strokeWidth={1.5} />
-                                    </a>
+                                        <Copy className="h-4 w-4" strokeWidth={1.5} onClick={handleCopy} />
+                                    </div>
                                 </div>
                             </div>
 
@@ -222,7 +258,7 @@ export default function BankAccountPage() {
                                 <div className="h-px bg-[var(--stroke-interactive-neutral-default)]" />
 
                                 <div className="flex flex-col gap-0.5">
-                                    {seatRows.map((seat) => (
+                                    {/* {seatRows.map((seat) => (
                                         <div key={seat.label} className="flex justify-between gap-4">
                                             <div className="text-sm font-medium text-[var(--foundation-neutral-240)]">
                                                 {seat.label || "-"}
@@ -231,7 +267,15 @@ export default function BankAccountPage() {
                                                 1개
                                             </div>
                                         </div>
-                                    ))}
+                                    ))} */}
+                                    <div className="flex justify-between gap-4">
+                                        <div className="text-sm font-medium text-[var(--foundation-neutral-240)]">
+                                            티켓 금액
+                                        </div>
+                                        <div className="text-sm font-medium text-[var(--foundation-neutral-240)]">
+                                            {won(totalAmount - fee) || 0}
+                                        </div>
+                                    </div>
 
                                     <div className="flex justify-between">
                                         <div className="text-sm font-medium leading-5 text-[var(--foundation-neutral-240)]">
@@ -296,6 +340,7 @@ export default function BankAccountPage() {
                     </div>
                 </div>
             </div>
+            {showCopiedToast && <AddressCopiedToast />}
         </div>
     );
 }

--- a/goorm-gongbang/app/(protected)/pay/[matchId]/page.tsx
+++ b/goorm-gongbang/app/(protected)/pay/[matchId]/page.tsx
@@ -309,6 +309,16 @@ export default function Page() {
 
     const hasMatchMeta = formatMatchAt(match?.matchAt) && matchTitle && match?.stadium.koName;
 
+    const [touched, setTouched] = useState({
+        email: false,
+        phone: false,
+        birth: false,
+    });
+    const showEmailError = touched.email && email.trim().length > 0 && !isEmailValid;
+    const showPhoneError = touched.phone && phoneDigits.length > 0 && !isPhoneValid;
+    const showBirthError = touched.birth && birthDigits.length > 0 && !isBirthValid;
+
+
     const handleSubmitPayment = async () => {
         if (!canSubmitPayment || !matchId || !createdOrderId || isCreatingOrder) return;
 
@@ -526,8 +536,8 @@ export default function Page() {
             </div>
 
             <div className="w-full flex justify-center px-4 sm:px-6 md:px-8 xl:px-12 py-8">
-                <div className="w-full max-w-[1440px] flex flex-col xl:flex-row justify-start items-start gap-8 xl:gap-14">
-                    <div className="w-full xl:min-w-[760px] xl:max-w-[1000px] xl:shrink-0 inline-flex flex-col justify-start items-start gap-8">
+                <div className="w-full max-w-[1440px] grid grid-cols-1 gap-8 xl:grid-cols-[minmax(0,1fr)_384px] xl:gap-14">
+                    <div className="min-w-0 inline-flex flex-col justify-start items-start gap-8">
                         {step === "ticket" ? (
                             <>
                                 <div className="self-stretch flex flex-col justify-start items-start gap-4">
@@ -633,13 +643,23 @@ export default function Page() {
                                                 <div className="justify-center text-[var(--foundation-neutral-240)] text-sm font-medium font-['Pretendard'] leading-5">이메일</div>
                                             </div>
 
-                                            <input
-                                                type="text"
-                                                placeholder="이메일 입력"
-                                                value={email}
-                                                onChange={(e) => setEmail(e.target.value)}
-                                                className="flex-1 h-10 px-4 py-2 bg-[var(--foundation-neutral-white)] rounded-md outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-900)] text-sm font-medium font-['Pretendard'] leading-5 placeholder:opacity-80"
-                                            />
+                                            <div className="flex-1">
+                                                <input
+                                                    type="text"
+                                                    placeholder="이메일 입력"
+                                                    value={email}
+                                                    onChange={(e) => setEmail(e.target.value)}
+                                                    onBlur={() => setTouched((prev) => ({ ...prev, email: true }))}
+                                                    aria-invalid={showEmailError}
+                                                    aria-describedby={showEmailError ? "email-error" : undefined}
+                                                    className="h-10 w-full px-4 py-2 bg-[var(--foundation-neutral-white)] rounded-md outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-900)] text-sm font-medium font-['Pretendard'] leading-5 placeholder:opacity-80 aria-invalid:outline-[var(--foundation-red-500)] aria-invalid:ring-1 aria-invalid:ring-[var(--foundation-red-500)]"
+                                                />
+                                                {showEmailError && (
+                                                    <p id="email-error" className="mt-1 text-xs font-medium leading-4 text-[var(--foundation-red-500)]">
+                                                        유효하지 않은 입력값입니다
+                                                    </p>
+                                                )}
+                                            </div>
                                         </div>
 
                                         <div className="self-stretch inline-flex justify-start items-center gap-2">
@@ -647,14 +667,26 @@ export default function Page() {
                                                 <div className="justify-center text-[var(--foundation-neutral-240)] text-sm font-medium font-['Pretendard'] leading-5">연락처</div>
                                             </div>
 
-                                            <input
-                                                type="text"
-                                                inputMode="numeric"
-                                                placeholder="연락처 입력"
-                                                value={number}
-                                                onChange={(e) => setNumber(formatPhone(e.target.value))}
-                                                className="flex-1 h-10 px-4 py-2 bg-[var(--foundation-neutral-white)] rounded-md outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-900)] text-sm font-medium font-['Pretendard'] leading-5 placeholder:opacity-80"
-                                            />
+                                            <div className="flex-1">
+                                                <input
+                                                    type="text"
+                                                    inputMode="numeric"
+                                                    placeholder="연락처 입력"
+                                                    value={number}
+                                                    onChange={(e) => setNumber(formatPhone(e.target.value))}
+                                                    onBlur={() => setTouched((prev) => ({ ...prev, phone: true }))}
+                                                    aria-invalid={showPhoneError}
+                                                    aria-describedby={showPhoneError ? "phone-error" : undefined}
+                                                    className="h-10 w-full px-4 py-2 bg-[var(--foundation-neutral-white)] rounded-md outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-900)] text-sm font-medium font-['Pretendard'] leading-5 placeholder:opacity-80 aria-invalid:outline-[var(--foundation-red-500)] aria-invalid:ring-1 aria-invalid:ring-[var(--foundation-red-500)]"
+                                                />
+
+                                                {showPhoneError && (
+                                                    <p id="phone-error" className="mt-1 text-xs font-medium leading-4 text-[var(--foundation-red-500)]">
+                                                        유효하지 않은 입력값입니다
+                                                    </p>
+                                                )}
+                                            </div>
+
                                         </div>
 
                                         <div className="self-stretch inline-flex justify-start items-center gap-2">
@@ -662,13 +694,25 @@ export default function Page() {
                                                 <div className="justify-center whitespace-nowrap text-[var(--foundation-neutral-240)] text-sm font-medium font-['Pretendard'] leading-5">생년월일</div>
                                             </div>
 
-                                            <input
-                                                type="text"
-                                                placeholder="생년월일 입력 (YYMMDD)"
-                                                value={birth}
-                                                onChange={(e) => setBirth(formatBirth6(e.target.value))}
-                                                className="flex-1 h-10 px-4 py-2 bg-[var(--foundation-neutral-white)] rounded-md outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-900)] text-sm font-medium font-['Pretendard'] leading-5 placeholder:opacity-80"
-                                            />
+                                            <div className="flex-1">
+                                                <input
+                                                    type="text"
+                                                    placeholder="생년월일 입력 (YYMMDD)"
+                                                    value={birth}
+                                                    onChange={(e) => setBirth(formatBirth6(e.target.value))}
+                                                    onBlur={() => setTouched((prev) => ({ ...prev, birth: true }))}
+                                                    aria-invalid={showBirthError}
+                                                    aria-describedby={showBirthError ? "birth-error" : undefined}
+                                                    className="h-10 w-full px-4 py-2 bg-[var(--foundation-neutral-white)] rounded-md outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-900)] text-sm font-medium font-['Pretendard'] leading-5 placeholder:opacity-80 aria-invalid:outline-[var(--foundation-red-500)] aria-invalid:ring-1 aria-invalid:ring-[var(--foundation-red-500)]"
+                                                />
+
+                                                {showBirthError && (
+                                                    <p id="birth-error" className="mt-1 text-xs font-medium leading-4 text-[var(--foundation-red-500)]">
+                                                        유효하지 않은 입력값입니다
+                                                    </p>
+                                                )}
+                                            </div>
+
                                         </div>
                                     </div>
                                 </div>
@@ -1160,7 +1204,7 @@ export default function Page() {
                             </div>
                         )}
                     </div>
-                    <div className="w-full xl:w-96 xl:shrink-0 self-stretch shadow-[0px_1px_3px_0px_rgba(0,0,0,0.05)] inline-flex flex-col justify-start items-start gap-4 overflow-hidden">
+                    <div className="min-w-0 w-full xl:w-auto xl:shrink-0 self-stretch shadow-[0px_1px_3px_0px_rgba(0,0,0,0.05)] inline-flex flex-col justify-start items-start gap-4 overflow-hidden">
                         <div className="self-stretch inline-flex justify-end items-center gap-2">
                             <div className="flex-1 justify-center text-[var(--foundation-neutral-240)] text-xl font-bold font-['Pretendard'] leading-7">MY 예매 정보</div>
                             <div className="text-right justify-center text-[var(--foundation-neutral-240)] text-sm font-medium font-['Pretendard'] leading-5">남은 결제 시간</div>

--- a/goorm-gongbang/app/(protected)/pay/[matchId]/page.tsx
+++ b/goorm-gongbang/app/(protected)/pay/[matchId]/page.tsx
@@ -625,8 +625,8 @@ export default function Page() {
                                     </div>
 
                                     <div className="self-stretch p-4 bg-[var(--background-white)] rounded-[10px] outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-940)] grid grid-cols-1 sm:grid-cols-2 gap-3">
-                                        <div className="self-stretch inline-flex justify-start items-center gap-2">
-                                            <div className="w-16 self-stretch flex justify-start items-center gap-2">
+                                        <div className="self-stretch inline-flex justify-start items-start gap-2">
+                                            <div className="w-16 h-10 flex justify-start items-center gap-2">
                                                 <div className="justify-center text-[var(--foundation-neutral-240)] text-base font-medium font-['Pretendard'] leading-6">이름</div>
                                             </div>
                                             <input
@@ -638,9 +638,11 @@ export default function Page() {
                                             />
                                         </div>
 
-                                        <div className="self-stretch inline-flex justify-start items-center gap-2">
-                                            <div className="w-16 self-stretch flex justify-start items-center gap-2">
-                                                <div className="justify-center text-[var(--foundation-neutral-240)] text-sm font-medium font-['Pretendard'] leading-5">이메일</div>
+                                        <div className="self-stretch inline-flex justify-start items-start gap-2">
+                                            <div className="w-16 h-10 flex justify-start items-center gap-2">
+                                                <div className="justify-center text-[var(--foundation-neutral-240)] text-sm font-medium font-['Pretendard'] leading-5">
+                                                    이메일
+                                                </div>
                                             </div>
 
                                             <div className="flex-1">
@@ -651,20 +653,26 @@ export default function Page() {
                                                     onChange={(e) => setEmail(e.target.value)}
                                                     onBlur={() => setTouched((prev) => ({ ...prev, email: true }))}
                                                     aria-invalid={showEmailError}
-                                                    aria-describedby={showEmailError ? "email-error" : undefined}
+                                                    aria-describedby="email-error"
                                                     className="h-10 w-full px-4 py-2 bg-[var(--foundation-neutral-white)] rounded-md outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-900)] text-sm font-medium font-['Pretendard'] leading-5 placeholder:opacity-80 aria-invalid:outline-[var(--foundation-red-500)] aria-invalid:ring-1 aria-invalid:ring-[var(--foundation-red-500)]"
                                                 />
-                                                {showEmailError && (
-                                                    <p id="email-error" className="mt-1 text-xs font-medium leading-4 text-[var(--foundation-red-500)]">
-                                                        유효하지 않은 입력값입니다
-                                                    </p>
-                                                )}
+
+                                                <p
+                                                    id="email-error"
+                                                    className={`mt-1 min-h-4 text-xs font-medium leading-4 text-[var(--foundation-red-500)] ${showEmailError ? "visible" : "invisible"
+                                                        }`}
+                                                >
+                                                    유효하지 않은 입력값입니다
+                                                </p>
                                             </div>
                                         </div>
 
-                                        <div className="self-stretch inline-flex justify-start items-center gap-2">
-                                            <div className="w-16 self-stretch flex justify-start items-center gap-2">
-                                                <div className="justify-center text-[var(--foundation-neutral-240)] text-sm font-medium font-['Pretendard'] leading-5">연락처</div>
+
+                                        <div className="self-stretch inline-flex justify-start items-start gap-2">
+                                            <div className="w-16 h-10 flex justify-start items-center gap-2">
+                                                <div className="justify-center text-[var(--foundation-neutral-240)] text-sm font-medium font-['Pretendard'] leading-5">
+                                                    연락처
+                                                </div>
                                             </div>
 
                                             <div className="flex-1">
@@ -676,22 +684,26 @@ export default function Page() {
                                                     onChange={(e) => setNumber(formatPhone(e.target.value))}
                                                     onBlur={() => setTouched((prev) => ({ ...prev, phone: true }))}
                                                     aria-invalid={showPhoneError}
-                                                    aria-describedby={showPhoneError ? "phone-error" : undefined}
+                                                    aria-describedby="phone-error"
                                                     className="h-10 w-full px-4 py-2 bg-[var(--foundation-neutral-white)] rounded-md outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-900)] text-sm font-medium font-['Pretendard'] leading-5 placeholder:opacity-80 aria-invalid:outline-[var(--foundation-red-500)] aria-invalid:ring-1 aria-invalid:ring-[var(--foundation-red-500)]"
                                                 />
 
-                                                {showPhoneError && (
-                                                    <p id="phone-error" className="mt-1 text-xs font-medium leading-4 text-[var(--foundation-red-500)]">
-                                                        유효하지 않은 입력값입니다
-                                                    </p>
-                                                )}
+                                                <p
+                                                    id="phone-error"
+                                                    className={`mt-1 min-h-4 text-xs font-medium leading-4 text-[var(--foundation-red-500)] ${showPhoneError ? "visible" : "invisible"
+                                                        }`}
+                                                >
+                                                    유효하지 않은 입력값입니다
+                                                </p>
                                             </div>
-
                                         </div>
 
-                                        <div className="self-stretch inline-flex justify-start items-center gap-2">
-                                            <div className="w-16 self-stretch flex justify-start items-center gap-2">
-                                                <div className="justify-center whitespace-nowrap text-[var(--foundation-neutral-240)] text-sm font-medium font-['Pretendard'] leading-5">생년월일</div>
+
+                                        <div className="self-stretch inline-flex justify-start items-start gap-2">
+                                            <div className="w-16 h-10 flex justify-start items-center gap-2">
+                                                <div className="justify-center whitespace-nowrap text-[var(--foundation-neutral-240)] text-sm font-medium font-['Pretendard'] leading-5">
+                                                    생년월일
+                                                </div>
                                             </div>
 
                                             <div className="flex-1">
@@ -702,18 +714,20 @@ export default function Page() {
                                                     onChange={(e) => setBirth(formatBirth6(e.target.value))}
                                                     onBlur={() => setTouched((prev) => ({ ...prev, birth: true }))}
                                                     aria-invalid={showBirthError}
-                                                    aria-describedby={showBirthError ? "birth-error" : undefined}
+                                                    aria-describedby="birth-error"
                                                     className="h-10 w-full px-4 py-2 bg-[var(--foundation-neutral-white)] rounded-md outline outline-1 outline-offset-[-1px] outline-[var(--foundation-neutral-900)] text-sm font-medium font-['Pretendard'] leading-5 placeholder:opacity-80 aria-invalid:outline-[var(--foundation-red-500)] aria-invalid:ring-1 aria-invalid:ring-[var(--foundation-red-500)]"
                                                 />
 
-                                                {showBirthError && (
-                                                    <p id="birth-error" className="mt-1 text-xs font-medium leading-4 text-[var(--foundation-red-500)]">
-                                                        유효하지 않은 입력값입니다
-                                                    </p>
-                                                )}
+                                                <p
+                                                    id="birth-error"
+                                                    className={`mt-1 min-h-4 text-xs font-medium leading-4 text-[var(--foundation-red-500)] ${showBirthError ? "visible" : "invisible"
+                                                        }`}
+                                                >
+                                                    유효하지 않은 입력값입니다
+                                                </p>
                                             </div>
-
                                         </div>
+
                                     </div>
                                 </div>
 
@@ -1204,7 +1218,7 @@ export default function Page() {
                             </div>
                         )}
                     </div>
-                    <div className="min-w-0 w-full xl:w-auto xl:shrink-0 self-stretch shadow-[0px_1px_3px_0px_rgba(0,0,0,0.05)] inline-flex flex-col justify-start items-start gap-4 overflow-hidden">
+                    <div className="min-w-0 w-full xl:w-auto xl:shrink-0 self-stretch inline-flex flex-col justify-start items-start gap-4 overflow-hidden">
                         <div className="self-stretch inline-flex justify-end items-center gap-2">
                             <div className="flex-1 justify-center text-[var(--foundation-neutral-240)] text-xl font-bold font-['Pretendard'] leading-7">MY 예매 정보</div>
                             <div className="text-right justify-center text-[var(--foundation-neutral-240)] text-sm font-medium font-['Pretendard'] leading-5">남은 결제 시간</div>

--- a/goorm-gongbang/app/(protected)/recommend/[matchId]/page.tsx
+++ b/goorm-gongbang/app/(protected)/recommend/[matchId]/page.tsx
@@ -1090,22 +1090,24 @@ function RecommendPageContent({ matchId }: { matchId: number | null }) {
           </div>
 
           <div className="flex w-full shrink-0 flex-col items-end gap-6 lg:w-[360px] xl:w-[400px] 2xl:w-[460px]">
-            <div className="w-full rounded-2xl bg-[var(--foundation-neutral-white)] px-6 py-4 outline outline-1 outline-offset-[-1px] outline-[var(--stroke-interactive-neutral-default)]">
-              <div className="flex h-8 w-full items-center justify-between">
-                <div className="text-base font-semibold leading-6 text-black">
-                  사용자 선호 구역 추천
+            {recommendationEnabled && (
+              <div className="w-full rounded-2xl bg-[var(--foundation-neutral-white)] px-6 py-4 outline outline-1 outline-offset-[-1px] outline-[var(--stroke-interactive-neutral-default)]">
+                <div className="flex h-8 w-full items-center justify-between">
+                  <div className="text-base font-semibold leading-6 text-black">
+                    사용자 선호 구역 추천
+                  </div>
+                  <Toggle
+                    checked={isPreferredRecommendOn}
+                    onCheckedChange={(next) => {
+                      setIsPreferredRecommendOn(next);
+                      setHoveredRecommendBlock(null);
+                      setHoveredSeatBlocks([]);
+                      resetManualSeatSelection();
+                    }}
+                  />
                 </div>
-                <Toggle
-                  checked={isPreferredRecommendOn}
-                  onCheckedChange={(next) => {
-                    setIsPreferredRecommendOn(next);
-                    setHoveredRecommendBlock(null);
-                    setHoveredSeatBlocks([]);
-                    resetManualSeatSelection();
-                  }}
-                />
               </div>
-            </div>
+            )}
 
             {isProtectedSeatAccessBlocked ? (
               <div className="flex w-full flex-col items-start gap-4 self-stretch">

--- a/goorm-gongbang/app/(protected)/recommend/[matchId]/page.tsx
+++ b/goorm-gongbang/app/(protected)/recommend/[matchId]/page.tsx
@@ -117,7 +117,8 @@ function getPriceTextBySeatLabel(seatLabel: string) {
 }
 
 const getSeatColor = (sectionName: string): SeatRecommendItem["color"] => {
-  if (sectionName.includes("익사이팅존")) return "gray";
+  if (sectionName.includes("익사이팅존")) return "exiting";
+  if (sectionName.includes("테라존(중앙 프리미엄석)")) return "tera";
   if (sectionName.includes("블루석")) return "blue";
   if (sectionName.includes("오렌지석")) return "orange";
   if (sectionName.includes("레드석")) return "red";

--- a/goorm-gongbang/app/(public)/clubs/[clubId]/page.tsx
+++ b/goorm-gongbang/app/(public)/clubs/[clubId]/page.tsx
@@ -290,7 +290,7 @@ export default function ClubDetailPage() {
           <div className="flex flex-col justify-end h-full gap-6 sm:gap-8 flex-1 w-full lg:min-w-0 lg:ml-4 xl:ml-10 mb-2">
             <div
               className={cn(
-                " font-semibold tracking-wider text-xs sm:text-sm text-center lg:text-left",
+                "px-3 sm:px-4 font-semibold tracking-wider text-xs sm:text-sm text-center lg:text-left",
                 accentTextClass,
               )}
             >

--- a/goorm-gongbang/components/common/DropDown.tsx
+++ b/goorm-gongbang/components/common/DropDown.tsx
@@ -82,8 +82,6 @@ export function DropDown({
                     contentClassName
                 )}
             >
-                <div className="self-stretch h-px my-1 border border-[var(--foundation-neutral-880)]" />
-
                 {options.map((n) => {
                     const selected = n === safeValue;
                     return (

--- a/goorm-gongbang/components/common/SeatPreferenceRecommendCard.tsx
+++ b/goorm-gongbang/components/common/SeatPreferenceRecommendCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { Toggle } from "@/components/common/Toggle";
 import { DropDown } from "@/components/common/DropDown";
@@ -30,6 +30,43 @@ export function SeatPreferenceRecommendCard({
 }: Props) {
 
   const [isNearbySeatInfoOpen, setIsNearbySeatInfoOpen] = useState(false);
+  const nearbySeatInfoButtonRef = useRef<HTMLButtonElement | null>(null);
+  const [nearbySeatInfoPosition, setNearbySeatInfoPosition] = useState({ left: 0, top: 0, width: 520 });
+
+  const updateNearbySeatInfoPosition = useCallback(() => {
+    const button = nearbySeatInfoButtonRef.current;
+    if (!button) return;
+
+    const viewportPadding = 16;
+    const tooltipWidth = Math.min(
+      520,
+      Math.max(0, window.innerWidth - viewportPadding * 2),
+    );
+    const rect = button.getBoundingClientRect();
+    const left = Math.min(
+      Math.max(rect.left, viewportPadding),
+      window.innerWidth - tooltipWidth - viewportPadding,
+    );
+
+    setNearbySeatInfoPosition({
+      left,
+      top: rect.bottom + 8,
+      width: tooltipWidth,
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!isNearbySeatInfoOpen) return;
+
+    updateNearbySeatInfoPosition();
+    window.addEventListener("resize", updateNearbySeatInfoPosition);
+    window.addEventListener("scroll", updateNearbySeatInfoPosition, true);
+
+    return () => {
+      window.removeEventListener("resize", updateNearbySeatInfoPosition);
+      window.removeEventListener("scroll", updateNearbySeatInfoPosition, true);
+    };
+  }, [isNearbySeatInfoOpen, updateNearbySeatInfoPosition]);
 
   return (
     <div
@@ -41,7 +78,7 @@ export function SeatPreferenceRecommendCard({
       <div className="inline-flex h-8 w-full items-center justify-between">
         <div className="flex items-center justify-center gap-2">
           <div className="text-base font-semibold leading-6 text-[var(--foundation-neutral-black)] font-['Pretendard']">
-            사용자 선호 좌석 추천
+            사용자 선호 구역 추천
             <div className="text-xs font-normal leading-4 text-[var(--text-info-n600)] font-['Pretendard']">
               {enabled ? (
                 "설정한 선호 조건에 맞는 구역을 먼저 보여드려요"
@@ -82,8 +119,12 @@ export function SeatPreferenceRecommendCard({
               </div>
 
               <button
+                ref={nearbySeatInfoButtonRef}
                 type="button"
-                onMouseEnter={() => setIsNearbySeatInfoOpen(true)}
+                onMouseEnter={() => {
+                  updateNearbySeatInfoPosition();
+                  setIsNearbySeatInfoOpen(true);
+                }}
                 onMouseLeave={() => setIsNearbySeatInfoOpen(false)}
                 className="relative h-4 w-4 cursor-pointer overflow-visible"
                 aria-expanded={isNearbySeatInfoOpen}
@@ -94,7 +135,8 @@ export function SeatPreferenceRecommendCard({
                 {isNearbySeatInfoOpen && (
                   <div
                     id="nearby-seat-info"
-                    className="absolute left-0 top-full z-20 mt-2 inline-flex w-[520px] flex-col items-start gap-2 rounded-lg bg-white p-3 shadow-[2px_3px_10px_0px_rgba(0,0,0,0.10)] outline outline-1 outline-offset-[-1px] outline-[var(--stroke-interactive-neutral-default)]"
+                    style={nearbySeatInfoPosition}
+                    className="fixed z-50 inline-flex flex-col items-start gap-2 rounded-lg bg-white p-3 text-left shadow-[2px_3px_10px_0px_rgba(0,0,0,0.10)] outline outline-1 outline-offset-[-1px] outline-[var(--stroke-interactive-neutral-default)]"
                   >
                     <div className="text-sm font-semibold leading-5 text-[var(--foundation-neutral-240)] font-['Pretendard']">
                       인근 좌석 추천이란?

--- a/goorm-gongbang/components/common/SeatPreferenceRecommendCard.tsx
+++ b/goorm-gongbang/components/common/SeatPreferenceRecommendCard.tsx
@@ -71,7 +71,7 @@ export function SeatPreferenceRecommendCard({
   return (
     <div
       className={cn(
-        "inline-flex w-full flex-col items-start justify-start gap-4 rounded-2xl bg-[var(--foundation-neutral-white)] py-4",
+        "inline-flex w-full flex-col items-start justify-start gap-4 border-t border-[var(--foundation-neutral-900)] bg-[var(--foundation-neutral-white)] py-4",
         className,
       )}
     >

--- a/goorm-gongbang/components/common/SeatRecommendSummaryCard.tsx
+++ b/goorm-gongbang/components/common/SeatRecommendSummaryCard.tsx
@@ -2,7 +2,7 @@
 
 import { cn } from "@/lib/utils";
 
-type SeatColor = "orange" | "red" | "navy" | "green" | "gray" | "purple" | "blue";
+type SeatColor = "exiting" | "tera" |  "orange" | "red" | "navy" | "green" | "gray" | "purple" | "blue";
 
 export type SeatRecommendItem = {
     id: string;
@@ -25,6 +25,10 @@ type Props = {
 };
 
 const badgeClassMap: Record<SeatColor, string> = {
+    exiting:
+        "bg-neutral-500 outline-zinc-500",
+    tera:
+        "bg-blue-700 outline-blue-500",
     orange:
         "bg-[var(--foundation-orange-500)] outline-[var(--foundation-orange-400)]",
     red:

--- a/goorm-gongbang/components/common/match-detail/tabs/AddressCopiedToast.tsx
+++ b/goorm-gongbang/components/common/match-detail/tabs/AddressCopiedToast.tsx
@@ -10,7 +10,7 @@ export function AddressCopiedToast({
     message = "\uC8FC\uC18C\uAC00 \uBCF5\uC0AC\uB418\uC5C8\uC2B5\uB2C8\uB2E4.",
 }: Props) {
     return (
-        <div className="fixed bottom-6 left-1/2 z-50 -translate-x-1/2">
+        <div className="fixed top-6 left-1/2 z-50 -translate-x-1/2">
             <div className="inline-flex flex-col items-start justify-start gap-5 rounded-2xl bg-[var(--background-white)] p-4 outline outline-1 outline-offset-[-1px] outline-[var(--foundation-primary-500)]">
                 <div className="inline-flex items-center justify-start gap-4 rounded-lg px-3">
                     <div className="flex h-6 w-6 items-center justify-start">


### PR DESCRIPTION
fix(GBGB-377-fe-qa-2)
- 2026.04.15 21:58 기준 QA 2차 수정 완료

🔧 작업 내용
- 로그인 상태에서 /login 접근 시 로그인 페이지가 잠깐 노출되는 현상 수정
- 구단 상세 페이지 시즌/성적 영역 정렬 개선
- 좌석 추천 카드 상단 구분선 스타일 반영
- 무통장 입금 선택 불가 조건 확인 및 disabled 상태 표현 개선
- 주소 복사 토스트 노출 위치 조정
- 무통장 입금 완료 페이지 경기 시간/입금 기한 요일 표기 형식 개선

🧩 구현 상세 (선택)
- 인증 복구 완료 전 로그인 UI가 렌더링되지 않도록 로그인 페이지 렌더 가드 추가
- 시즌 텍스트와 성적 지표 영역의 좌측 padding 기준 통일
- 카드 상단에 border 스타일을 적용해 디자인 시안의 구분선 반영
- 경기 시작 3시간 이내 무통장 입금 제한 조건에 맞춰 라디오 버튼 상태를 명확히 처리
- 주소 복사 토스트를 화면 상단 기준으로 표시
- 날짜 포맷을 날짜/요일/시간 단위로 분리해 `2026년 4월 15일 (수) 21:58` 형식으로 표시

📌 관련 Jira Issue
GBGB-377-fe-qa-2

🧪 테스트 방법(선택)
- 로그인된 상태에서 `/login` 직접 접근 시 로그인 화면이 노출되지 않고 리다이렉트되는지 확인
- 구단 상세 페이지에서 시즌 텍스트와 순위/승률 영역 정렬 확인
- 좌석 추천 카드 상단 구분선 표시 확인
- 결제 페이지에서 무통장 입금 라디오 버튼의 선택 가능/불가 상태 확인
- 주소 복사 클릭 시 토스트가 화면 상단에 표시되는지 확인
- 무통장 입금 완료 페이지에서 경기 시간과 입금 기한 요일이 괄호로 표시되는지 확인

❗ 참고 사항
- 무통장 입금은 경기 시작 3시간 이내에는 선택이 제한됩니다.
- 일부 항목은 QA 피드백 기준으로 UI 표시 방식만 조정했습니다.

Fixes: GBGB-377-fe-qa-2
