### PR TITLE
fix(my): 회원탈퇴 모달에 티켓 환불 불가 안내 문구 추가

### DIFF
--- a/goorm-gongbang/components/my/DeleteAccountModal.tsx
+++ b/goorm-gongbang/components/my/DeleteAccountModal.tsx
@@ -59,6 +59,7 @@ export function DeleteAccountModal({ isOpen, onClose, onDeleteSuccess }: DeleteA
                     <p>작성한 데이터, 저장된 일정 및 맞춤 정보도 함께 삭제됩니다.</p>
                     <p>탈퇴 후 동일한 계정으로 재가입은 가능하지만, 이전 정보는 복원되지 않습니다.</p>
                     <p className="font-bold">탈퇴 후 30일 이내 재가입이 제한됩니다.</p>
+                    <p className="font-bold">결제한 티켓은 환불되지 않습니다.</p>
                 </div>
 
                 {/* 체크박스 */}


### PR DESCRIPTION
## 🔧 작업 내용
- 회원탈퇴 모달 안내 박스에 결제한 티켓은 환불되지 않는다는 문구 추가
- 탈퇴 전 사용자가 티켓 환불 불가 정책을 인지할 수 있도록 개선

## 🧩 구현 상세 (선택)
- 기존 bold 안내 문구 스타일과 동일하게 `font-bold` 적용

### 📌 관련 Jira Issue
- GRGB-XX

## 🧪 테스트 방법 (선택)
- 마이페이지 > 회원탈퇴 진입
- 모달 안내 박스에 `결제한 티켓은 환불되지 않습니다.` 문구 노출 확인

## ❗ 참고 사항
- 없음