### PR TITLE
fix: Faro 초기화 호출 추가

### DIFF
--- a/goorm-gongbang/app/providers.tsx
+++ b/goorm-gongbang/app/providers.tsx
@@ -15,6 +15,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { useAuthStore } from "@/stores/authStore";
 import { refreshAccessToken, getMe } from "@/lib/services";
 import { getBotToken } from "@/lib/client/bot-token";
+import { initFaro } from "@/lib/client/faro";
 
 function isOnboardingPath(pathname: string) {
   return pathname === "/onboarding" || pathname.startsWith("/onboarding/");
@@ -43,6 +44,10 @@ export default function Providers({ children }: { children: React.ReactNode }) {
       getBotToken();
       botTokenInitialized.current = true;
     }
+  }, []);
+
+  useEffect(() => {
+    initFaro();
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## 변경 사항
- 앱 시작 시 Faro를 1회 초기화하도록 Providers에 initFaro() 호출 추가

## 배경
- 사용자 행동 분석 대시보드가 No data였고, 코드 확인 결과 initFaro()가 어디에서도 호출되지 않아 브라우저 이벤트가 전송되지 않는 상태였음

## 기대 효과
- page_view, match_click, checkout_start, payment_start, payment_success, *_fail 이벤트가 실제 전송 가능 상태가 됨