### PR TITLE
fix(vqa): VQA 화면 반응형 / 인증 실패 모달 / 판정 로직 보정

### DIFF
--- a/goorm-gongbang/lib/telemetry/components/VQAChallenge.tsx
+++ b/goorm-gongbang/lib/telemetry/components/VQAChallenge.tsx
@@ -400,7 +400,7 @@ export function VQAChallenge({
         finalGlove.x - roundSetup.landingPoint.x,
         finalGlove.y - roundSetup.landingPoint.y,
       );
-      const resolvedPositionOk = distance <= CATCH_BALL_CONFIG.catchRadius;
+      const resolvedPositionOk = distance <= CATCH_BALL_CONFIG.catchPocketRadius;
       const elapsedFromPitch = dropTimestamp - pitchStartMs;
       const timingStart = roundSetup.timingWindowStartMs;
       const timingEnd = roundSetup.timingWindowStartMs + CATCH_BALL_CONFIG.timingWindowMs;
@@ -637,13 +637,34 @@ export function VQAChallenge({
   const gaugeThumbSize = 14;
   const indicatorTopInset = 3;
   const indicatorBottomInset = 7;
+  const indicatorTravelRange =
+    VERTICAL_INDICATOR_TRACK.height - gaugeThumbSize - indicatorTopInset - indicatorBottomInset;
   const gaugeThumbTop = clamp(
-    indicatorTopInset +
-    (1 - indicatorProgress) *
-    (VERTICAL_INDICATOR_TRACK.height - gaugeThumbSize - indicatorTopInset - indicatorBottomInset),
+    indicatorTopInset + (1 - indicatorProgress) * indicatorTravelRange,
     indicatorTopInset,
     VERTICAL_INDICATOR_TRACK.height - gaugeThumbSize - indicatorBottomInset,
   );
+  // Green bar position derived from actual timing window — makes visual zone match judgment exactly.
+  // barTop: thumb top position when timing window closes (p_end → smaller y = higher position)
+  // barHeight: thumb traversal range during timing window + thumb size
+  const indicatorBarTop = roundSetup
+    ? Math.round(
+        indicatorTopInset +
+          (1 -
+            Math.min(
+              (roundSetup.timingWindowStartMs + CATCH_BALL_CONFIG.timingWindowMs) /
+                roundSetup.indicatorDurationMs,
+              1,
+            )) *
+            indicatorTravelRange,
+      )
+    : indicatorTopInset;
+  const indicatorBarHeight = roundSetup
+    ? Math.round(
+        gaugeThumbSize +
+          (CATCH_BALL_CONFIG.timingWindowMs / roundSetup.indicatorDurationMs) * indicatorTravelRange,
+      )
+    : 44;
   const countdownOverlayLabel =
     countdownLabel === 'READY' ? 'Ready' : countdownLabel === 'GO' ? 'Start!' : null;
   const playfieldTimeLabel = formatCountdown(remainingTime);
@@ -682,9 +703,11 @@ export function VQAChallenge({
         : [state.message];
   const errorConfirmLabel = '확인';
   const terminalErrorCardClass =
-    state.status === 'error' && state.reason === 'blocked' ? 'max-w-[703px] px-11 py-8' : 'max-w-[463px] px-9 py-8';
+    state.status === 'error' && state.reason === 'blocked' ? 'max-w-[703px] px-11 py-8' : 'max-w-[540px] px-9 py-8';
   const terminalErrorCopyClass =
-    state.status === 'error' && state.reason === 'blocked' ? 'max-w-[615px]' : 'max-w-[360px]';
+    state.status === 'error' && state.reason === 'blocked' ? 'max-w-[615px]' : 'max-w-[460px]';
+  const terminalErrorBodyFontClass =
+    state.status === 'error' && state.reason === 'blocked' ? 'text-[24px]' : 'text-[20px]';
   const handleErrorConfirm = () => {
     if (errorAccent === 'red') {
       onCancel();
@@ -702,9 +725,16 @@ export function VQAChallenge({
     draggingRef.current = true;
   };
 
-  const handlePointerUp = () => {
+  const handlePointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
     if (!draggingRef.current) {
       return;
+    }
+
+    if (event.type === 'pointerup' && playRef.current) {
+      const rect = playRef.current.getBoundingClientRect();
+      const finalX = clamp(event.clientX - rect.left, MOVEMENT_ZONE.x, MOVEMENT_ZONE.x + MOVEMENT_ZONE.width);
+      const finalY = clamp(event.clientY - rect.top, MOVEMENT_ZONE.y, MOVEMENT_ZONE.y + MOVEMENT_ZONE.height);
+      gloveRef.current = { x: finalX, y: finalY };
     }
 
     draggingRef.current = false;
@@ -740,8 +770,9 @@ export function VQAChallenge({
   }, []);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[linear-gradient(180deg,rgba(0,0,0,0.9)_0%,rgba(3,41,53,0.5)_100%)] p-4 backdrop-blur-[5px]">
-      <div className="w-full max-w-[996px] rounded-2xl border-2 border-[var(--foundation-primary-400)] bg-[var(--foundation-neutral-white)] px-10 pb-10 pt-5 shadow-[0_0_20px_rgba(0,214,161,0.1)]">
+    <div className="fixed inset-0 z-50 overflow-auto bg-[linear-gradient(180deg,rgba(0,0,0,0.9)_0%,rgba(3,41,53,0.5)_100%)] backdrop-blur-[5px]">
+      <div className="flex min-h-full items-center justify-center p-4">
+      <div className="w-full min-w-[790px] max-w-[996px] rounded-2xl border-2 border-[var(--foundation-primary-400)] bg-[var(--foundation-neutral-white)] px-10 pb-10 pt-5 shadow-[0_0_20px_rgba(0,214,161,0.1)]">
         <div className="flex items-center justify-between gap-4">
           <div className="flex min-w-0 items-center gap-6">
             <p className="shrink-0 text-[20px] font-semibold leading-[1.5] text-[var(--foundation-neutral-240)] font-['Pretendard']">
@@ -821,11 +852,11 @@ export function VQAChallenge({
                   {errorTitle}
                 </h3>
                 <div className={`mx-auto mt-3 space-y-1 ${terminalErrorCopyClass}`}>
-                  <p className="text-[24px] font-semibold leading-[1.5] text-[var(--foundation-neutral-240)] font-['Pretendard']">
+                  <p className={`${terminalErrorBodyFontClass} font-semibold leading-[1.5] text-[var(--foundation-neutral-240)] font-['Pretendard']`}>
                     {errorDescription[0]}
                   </p>
                   {errorDescription[1] && (
-                    <p className="text-[24px] font-medium leading-[1.5] text-[var(--foundation-neutral-240)] font-['Pretendard']">
+                    <p className={`${terminalErrorBodyFontClass} font-medium leading-[1.5] text-[var(--foundation-neutral-240)] font-['Pretendard']`}>
                       {errorDescription[1]}
                     </p>
                   )}
@@ -845,8 +876,8 @@ export function VQAChallenge({
         )}
 
         {isLoadedChallengeState(state) && (
-          <div className="mt-4 flex items-start gap-4">
-            <div className="relative h-[458px] w-[708px] overflow-hidden rounded-2xl bg-white">
+          <div className="mt-4 flex flex-col gap-4 lg:flex-row lg:items-start">
+            <div className="relative w-fit overflow-hidden rounded-2xl bg-white">
               <div
                 ref={playRef}
                 className="relative h-full w-full touch-none overflow-hidden rounded-2xl"
@@ -887,7 +918,10 @@ export function VQAChallenge({
                       height: VERTICAL_INDICATOR_TRACK.height,
                     }}
                   >
-                    <div className="absolute left-1/2 top-[3px] h-[44px] w-[20px] -translate-x-1/2 rounded-[4px] border border-[var(--foundation-primary-100)] bg-[linear-gradient(180deg,var(--foundation-primary-700)_0%,var(--foundation-primary-500)_100%)]" />
+                    <div
+                      className="absolute left-1/2 w-[20px] -translate-x-1/2 rounded-[4px] border border-[var(--foundation-primary-100)] bg-[linear-gradient(180deg,var(--foundation-primary-700)_0%,var(--foundation-primary-500)_100%)]"
+                      style={{ top: indicatorBarTop, height: indicatorBarHeight }}
+                    />
                     <div
                       className="absolute left-1/2 h-[14px] w-[14px] -translate-x-1/2 rounded-full border border-[var(--foundation-primary-600)] bg-white"
                       style={{ top: gaugeThumbTop }}
@@ -1031,7 +1065,7 @@ export function VQAChallenge({
               </div>
             </div>
 
-            <div className="flex h-[458px] w-[188px] flex-col gap-6">
+            <div className="flex w-full flex-col gap-4 lg:h-[460px] lg:w-[188px] lg:gap-6">
               <div className="flex flex-col gap-2">
                 <div className="rounded-[10px] bg-[var(--foundation-primary-10)] py-1 text-center text-sm font-medium leading-[1.5] text-[var(--foundation-primary-600)] font-['Pretendard']">
                   남은 횟수
@@ -1084,6 +1118,7 @@ export function VQAChallenge({
             </div>
           </div>
         )}
+      </div>
       </div>
     </div>
   );

--- a/goorm-gongbang/lib/telemetry/components/vqa/catchBallConfig.ts
+++ b/goorm-gongbang/lib/telemetry/components/vqa/catchBallConfig.ts
@@ -14,6 +14,7 @@ export const CATCH_BALL_CONFIG = {
   timingTargetJitterMs: 0,
   timingAlignOffsetMs: 20,
   catchRadius: 48,
+  catchPocketRadius: 32,
   safetyMargin: 18,
   sampleEveryMs: 20,
   gloveWidth: 92,


### PR DESCRIPTION
## 개요

VQA(플레이볼 보안 인증) 화면에서 발견된 3가지 문제를 단일 커밋으로 수정합니다.

---

## 작업 1 — VQA 화면 반응형 대응 + 최소 크기 제한 + 우측 패널 하단 이동

### 배경
브라우저 창 크기 및 줌(cmd+/cmd-)에 따라 플레이 영역이 지나치게 축소되면, 글러브 이동 거리가 비정상적으로 짧아져 보안 난이도가 저하됩니다.

### 변경 내용

#### 레이아웃 구조 변경 (`VQAChallenge.tsx`)
- **외부 모달 래퍼**: `overflow-auto` 적용 + `flex min-h-full items-center justify-center p-4` 내부 centering wrapper 추가
  - 줌/소형 뷰포트 상황에서 모달이 스크롤 가능해져 레이아웃이 잘리지 않음
- **카드**: `min-w-[790px]` 추가 (플레이 영역 710px + 좌우 패딩 80px)
  - 뷰포트가 좁아도 카드가 790px 미만으로 줄어들지 않아 플레이 영역 보장
- **콘텐츠 영역**: `flex flex-col gap-4 lg:flex-row lg:items-start`
  - `< 1024px` 뷰포트: 플레이 영역 위 / 정보 패널 아래 (수직 스택)
  - `≥ 1024px` 뷰포트: 좌측 플레이 영역 + 우측 정보 패널 (기존 데스크톱 구조 유지)
- **플레이 영역 컨테이너**: 고정 `h-[458px] w-[708px]` 제거 → `w-fit` 적용
  - 내부 `playRef` div가 여전히 `style={{ width: 710, height: 460 }}` 고정이므로 게임 좌표계 변경 없음
- **우측 정보 패널**: `flex w-full flex-col gap-4 lg:h-[460px] lg:w-[188px] lg:gap-6`
  - 좁은 화면에서 전체 너비 열 레이아웃, 넓은 화면에서 기존 188px 고정 패널 유지

#### 반응형 기준 정책
| 뷰포트 | 레이아웃 |
|--------|---------|
| ≥ 1024px | 플레이 영역(좌) + 정보 패널(우) 병렬 |
| < 1024px | 플레이 영역(상) → 정보 패널(하) 수직 스택 |
| < 790px | 카드 min-width 초과 → 외부 overflow-auto 스크롤 |

#### 최소/최대 크기 정책
- **플레이 영역**: 항상 710 × 460px 고정 (게임 좌표계 불변, catchRadius/MOVEMENT_ZONE 영향 없음)
- **카드 최소 너비**: `min-w-[790px]`
- **카드 최대 너비**: `max-w-[996px]` 유지

---

## 작업 2 — 인증 실패 모달 문구 레이아웃 고정 (3줄 → 2줄)

### 배경
`max_attempts` 에러 상태에서 본문 문구 "경기 상세 페이지에서 다시 예매를 진행해 주세요."가 `text-[24px]` + `max-w-[360px]` 조합에서 약 500px 폭 요구로 인해 3줄로 꺾히는 문제.

### 원인 분석
```
text-[24px] 기준 해당 문장 폭 ≈ 500px
기존 copy 영역 max-w: 360px → 반드시 줄바꿈 발생 → 3줄
```

### 변경 내용 (`VQAChallenge.tsx`)
- `terminalErrorCardClass` (non-blocked): `max-w-[463px]` → `max-w-[540px]`
- `terminalErrorCopyClass` (non-blocked): `max-w-[360px]` → `max-w-[460px]`
- `terminalErrorBodyFontClass` 변수 신규 추가:
  - blocked: `text-[24px]` (기존 유지)
  - non-blocked (max_attempts 등): `text-[20px]`

#### 수치 검증
`text-[20px]` Pretendard 기준 "경기 상세 페이지에서 다시 예매를 진행해 주세요." ≈ **414px**  
→ `max-w-[460px]` 내에 46px 여유로 1줄 수용 ✓

> `blocked` 케이스(비정상 패턴 감지)는 `max-w-[703px]` / `max-w-[615px]` / `text-[24px]` 그대로 유지.

---

## 작업 3 — VQA 성공 판정 로직 보정

### 버그 1: 인디케이터 시각 범위 ≠ 실제 타이밍 판정 범위

#### 원인
인디케이터 초록 바가 정적 값 `top: 3px, height: 44px` 로 고정되어 있어, 엄지(thumb)가 시각적으로 바에 닿는 시점(`indicatorProgress ≈ 0.699`)과 실제 타이밍 윈도우 시작(`timingWindowStartMs / indicatorDurationMs ≈ 0.763~0.812`) 사이에 **100~250ms 간격** 발생.

→ 사용자가 바에 진입하자마자 드롭하면 타이밍 체크가 아직 열리지 않아 TIMING 실패.

```
pitch=1450ms: 시각 진입 1209ms / 실제 시작 1320ms  →  +111ms 오차
pitch=1900ms: 시각 진입 1524ms / 실제 시작 1770ms  →  +246ms 오차
```

#### 수정 (`VQAChallenge.tsx`)
- `indicatorTravelRange` 상수 분리 (기존 인라인 계산 정리)
- `indicatorBarTop`, `indicatorBarHeight`를 `roundSetup.timingWindowStartMs` / `roundSetup.indicatorDurationMs` 기반으로 동적 계산

```
barTop = indicatorTopInset + (1 - p_end) * travelRange
barHeight = gaugeThumbSize + (timingWindowMs / indicatorDurationMs) * travelRange

pitch=1600ms 예시:
  기존: top=3, height=44  (bottom=47)
  수정: top=12, height=37  (bottom=49)
  → 엄지가 바에 진입하는 시점 = 타이밍 윈도우 열리는 시점과 일치
```

- `roundSetup` 없는 경우 fallback: `top=3, height=44`
- 그린 바 JSX: Tailwind 고정 클래스 → `style={{ top: indicatorBarTop, height: indicatorBarHeight }}`

---

### 버그 2: catchRadius 과대로 인한 과도하게 쉬운 포지션 판정

#### 원인
```
catchRadius = 48px
glove half-width = 46px, glove half-height = 34px
→ 볼 중심이 글러브 외곽 최대 2px(수평) / 14px(수직) 바깥이어도 SUCCESS 판정
```

#### 수정 (`catchBallConfig.ts`, `VQAChallenge.tsx`)
- `catchBallConfig.ts`에 `catchPocketRadius: 32` 신규 상수 추가
  - `catchRadius: 48`은 **MOVEMENT_ZONE 계산용**으로 그대로 유지
  - `catchPocketRadius: 32`는 **성공 판정 전용** 반경
- `evaluateDrop`: `CATCH_BALL_CONFIG.catchRadius` → `CATCH_BALL_CONFIG.catchPocketRadius`

```
catchPocketRadius=32 기준:
  글러브 수평(half=46): 볼 중심이 글러브 내부 약 30% 여유 확보 필요
  글러브 수직(half=34): 볼 중심이 글러브 내부 2px 여유 확보 필요
  → 글러브 끝 접촉만으로는 실패, 실질적 포착 범위에 들어와야 성공
```

---

### 버그 3: pointerUp 시점 좌표 미반영

#### 원인
`handlePointerUp`이 이벤트 파라미터를 받지 않아, `pointerMove`의 마지막 캡처 좌표로만 판정. 빠른 드롭 시 수 px 오차 발생 가능.

#### 수정 (`VQAChallenge.tsx`)
- `handlePointerUp(event: React.PointerEvent<HTMLDivElement>)` 시그니처 추가
- `event.type === 'pointerup'`일 때만 `getBoundingClientRect()` 로 최종 좌표 갱신 후 판정
- `pointerLeave` 시에는 기존 `gloveRef.current` 유지 (이미 이탈한 포인터 좌표 불신뢰)

---

## 변경 파일 요약

| 파일 | 변경 |
|------|------|
| `VQAChallenge.tsx` | 반응형 레이아웃 구조 / 인증 실패 모달 문구 폭 / 인디케이터 동적 바 / catchPocketRadius 적용 / pointerUp 좌표 보정 |
| `catchBallConfig.ts` | `catchPocketRadius: 32` 상수 추가 |

## 테스트 포인트
- [ ] 1024px 이상 뷰포트: 플레이 영역 좌 + 패널 우 정상 표시
- [ ] 1024px 미만 뷰포트: 패널이 플레이 영역 아래로 이동
- [ ] cmd+- 줌아웃 후 플레이 영역 710px 이상 유지 및 스크롤 가능
- [ ] `max_attempts` 에러: 본문 2줄 렌더링 확인
- [ ] 인디케이터 바 중앙에 엄지 위치 시 드롭 → 성공 판정
- [ ] 엄지가 바에 막 진입 직전 드롭 → 실패 판정
- [ ] 글러브 끝에 볼이 아슬하게 닿은 위치 → 실패 판정
- [ ] 글러브 포켓(중심 32px 이내) → 성공 판정

🤖 Generated with [Claude Code](https://claude.com/claude-code)