### PR TITLE
fix(vqa): 스크롤 락 overflow:hidden → body position:fixed 교체

### DIFF
--- a/goorm-gongbang/lib/telemetry/components/VQAChallenge.tsx
+++ b/goorm-gongbang/lib/telemetry/components/VQAChallenge.tsx
@@ -759,20 +759,27 @@ export function VQAChallenge({
 
   /* ADD BY CKH - body scroll lock */
   useEffect(() => {
-    const originalHtmlOverflow = document.documentElement.style.overflow;
-    const originalBodyOverflow = document.body.style.overflow;
+    const scrollY = window.scrollY;
+    const originalPosition = document.body.style.position;
+    const originalTop = document.body.style.top;
+    const originalWidth = document.body.style.width;
     const originalTouchAction = document.body.style.touchAction;
 
-    // html에도 설정해야 body→viewport 전파를 막아 fixed 오버레이의 overflow-auto 수평 스크롤이 동작함.
-    document.documentElement.style.overflow = "hidden";
-    document.body.style.overflow = "hidden";
+    // overflow 대신 position:fixed로 스크롤 락.
+    // overflow:hidden은 html/body→viewport 전파 or html containing block 변경으로
+    // fixed 오버레이 내부 overflow:auto 수평 스크롤을 깨뜨리는 부작용이 있음.
+    document.body.style.position = "fixed";
+    document.body.style.top = `-${scrollY}px`;
+    document.body.style.width = "100%";
     document.body.style.touchAction = "none";
     setPortalReady(true);
 
     return () => {
-      document.documentElement.style.overflow = originalHtmlOverflow;
-      document.body.style.overflow = originalBodyOverflow;
+      document.body.style.position = originalPosition;
+      document.body.style.top = originalTop;
+      document.body.style.width = originalWidth;
       document.body.style.touchAction = originalTouchAction;
+      window.scrollTo(0, scrollY);
     };
   }, []);
 


### PR DESCRIPTION
## Summary

- `html{overflow:hidden}` 설정이 브라우저에 따라 `fixed` 요소의 containing block을 viewport → html로 바꿔, 오버레이 내부 `overflow:auto` 수평 스크롤을 무력화하는 부작용 수정
- `overflow` 속성을 일절 건드리지 않는 `body{position:fixed}` 스크롤 락 방식으로 교체 → 배경 스크롤 방지 유지 + fixed 오버레이 수평 스크롤 정상 동작

## Test plan

- [ ] VQA 모달 열린 상태에서 배경 페이지 스크롤 불가 확인
- [ ] 브라우저 창을 822px 이하로 줄였을 때 수평 스크롤로 전체 콘텐츠 접근 가능 확인
- [ ] 모달 닫기 후 배경 스크롤 및 스크롤 위치 정상 복원 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)